### PR TITLE
track prover usage

### DIFF
--- a/certora_autosetup/autosetup/cli.py
+++ b/certora_autosetup/autosetup/cli.py
@@ -26,10 +26,15 @@ from certora_autosetup.utils.constants import (
     DIR_CERTORA_INTERNAL,
     FILE_AUTOSETUP_RESULT,
     FILE_LLM_USAGE,
+    FILE_PROVER_USAGE,
 )
 from certora_autosetup.utils.contract_utils import auto_detect_contracts, deduplicate_contract_handles, parse_contract_files, resolve_contract_handles
 from certora_autosetup.utils.enhanced_config_manager import ConfigManager
 from certora_autosetup.utils.llm_util import LlmUsageReport, ledger_reset
+from certora_autosetup.utils.prover_usage_ledger import (
+    reset as prover_usage_reset,
+    usage as prover_usage_rollup,
+)
 from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.scope import Scope
 
@@ -42,6 +47,9 @@ def main():
     # Start a clean per-process LLM usage ledger; every LLM response this process
     # makes is recorded into it (see llm_util).
     ledger_reset()
+    # Likewise a clean prover-usage ledger; every fresh (non-cached) prover run this
+    # process executes records its prover-reported runtime (see prover_usage_ledger).
+    prover_usage_reset()
 
     # Validate args
     if args.min_loop_iter < 1:
@@ -254,5 +262,12 @@ def main():
             bytes_mappings=result.bytes_mappings,
             llm_usage=ledger_rows,
         )
+
+    # Persist this run's prover-reported runtime (only the jobs actually executed;
+    # cache hits are excluded by the runner ledger) for composer to ingest. Mirrors
+    # llm_usage.json. Written last, after conf_runner's prover runs have completed.
+    (reports_dir / FILE_PROVER_USAGE).write_text(
+        json.dumps(prover_usage_rollup(), indent=2)
+    )
 
     sys.exit(0)

--- a/certora_autosetup/utils/cloud_runner.py
+++ b/certora_autosetup/utils/cloud_runner.py
@@ -827,10 +827,15 @@ class CloudProverRunner(ProverRunner):
 
             duration = time.time() - start_time
 
-            # Fresh run (cache hits short-circuit before this method) — record its
-            # prover-reported runtime. Skips the exception path below, which has no
-            # statsdata to read anyway.
-            self._record_fresh_prover_runtime(job_url)
+            # Fresh run (cache hits short-circuit before this method) — record the
+            # prover's server-reported runtime, computed from the job's start/finish
+            # timestamps (JobInfo.runtime). For a completed job this read is cheap
+            # (cache-served from polling). Best-effort; the exception path below has
+            # nothing to record anyway.
+            try:
+                self._record_prover_runtime_seconds(prover_api.get_job_info(job_url).runtime)
+            except Exception as e:
+                self.log(f"Could not record prover runtime for usage ledger: {e}", "DEBUG")
 
             if success:
                 # Job completed successfully, parse results

--- a/certora_autosetup/utils/cloud_runner.py
+++ b/certora_autosetup/utils/cloud_runner.py
@@ -827,6 +827,11 @@ class CloudProverRunner(ProverRunner):
 
             duration = time.time() - start_time
 
+            # Fresh run (cache hits short-circuit before this method) — record its
+            # prover-reported runtime. Skips the exception path below, which has no
+            # statsdata to read anyway.
+            self._record_fresh_prover_runtime(job_url)
+
             if success:
                 # Job completed successfully, parse results
                 job_handle.status = JobStatus.COMPLETED

--- a/certora_autosetup/utils/constants.py
+++ b/certora_autosetup/utils/constants.py
@@ -69,6 +69,7 @@ DIR_WORKTREE_LOGS = "worktree_logs"
 DIR_PREAUDIT_DEBUG = "preaudit_debug"
 FILE_AUTOSETUP_RESULT = "autosetup_result.json"
 FILE_LLM_USAGE = "llm_usage.json"
+FILE_PROVER_USAGE = "prover_usage.json"
 
 # Compiled-scene method inventory emitted under .certora_internal/
 FILE_ALL_METHODS_JSON = "all_methods.json"

--- a/certora_autosetup/utils/local_runner.py
+++ b/certora_autosetup/utils/local_runner.py
@@ -104,6 +104,11 @@ class LocalProverRunner(ProverRunner):
             )
             result = await self._execute_local_prover(job_spec, cache_key)
 
+            # Fresh run (cache hits returned above) — record its wall-clock runtime.
+            # Local runs are serialized (one prover at a time, no queueing), so
+            # wall-time is the run time.
+            self._record_prover_runtime_seconds(result.duration)
+
             # Step 3: Cache successful results (unless disabled)
             if result.success and not self.disable_cache:
                 await self._cache_result(cache_key, result)
@@ -189,9 +194,6 @@ class LocalProverRunner(ProverRunner):
                 job_handle.job_id = emv_folder_path
                 # Extract unresolved calls using ProverOutputUtility for consistency with cloud runner
                 output_data["unresolved_calls"] = self.extract_unresolved_calls(emv_folder_path)
-                # Fresh run (cache hits short-circuit before this method) — record its
-                # prover-reported runtime from the emv-* folder's statsdata.
-                self._record_fresh_prover_runtime(emv_folder_path)
 
             report_path = output_data.get("report_path")
 

--- a/certora_autosetup/utils/local_runner.py
+++ b/certora_autosetup/utils/local_runner.py
@@ -189,6 +189,9 @@ class LocalProverRunner(ProverRunner):
                 job_handle.job_id = emv_folder_path
                 # Extract unresolved calls using ProverOutputUtility for consistency with cloud runner
                 output_data["unresolved_calls"] = self.extract_unresolved_calls(emv_folder_path)
+                # Fresh run (cache hits short-circuit before this method) — record its
+                # prover-reported runtime from the emv-* folder's statsdata.
+                self._record_fresh_prover_runtime(emv_folder_path)
 
             report_path = output_data.get("report_path")
 

--- a/certora_autosetup/utils/paths.py
+++ b/certora_autosetup/utils/paths.py
@@ -26,6 +26,7 @@ from certora_autosetup.utils.constants import (
     FILE_COMPILATION_DUMMY_SPEC,
     FILE_ERC7201_SPEC,
     FILE_LLM_USAGE,
+    FILE_PROVER_USAGE,
     SUMMARIES_SUBDIR,
 )
 
@@ -97,17 +98,18 @@ def internal_difficult_retry_dir(project_root: Path) -> Path:
     return project_root / DIR_INTERNAL_DIFFICULT_RETRY
 
 
-def resolve_autosetup_llm_usage_file(project_root: Path) -> Path | None:
-    """Locate the ``llm_usage.json`` the most recent autosetup run wrote under ``project_root``.
+def _resolve_autosetup_reports_file(project_root: Path, filename: str) -> Path | None:
+    """Locate ``filename`` in the reports dir the most recent autosetup run wrote under
+    ``project_root``.
 
     Primary: read ``orchestration_timestamp`` from ``autosetup_result.json`` and build
-    ``<CERTORA_REPORTS_DIR>/<ts>/llm_usage.json`` — the deterministic inverse of how the CLI names
+    ``<CERTORA_REPORTS_DIR>/<ts>/<filename>`` — the deterministic inverse of how the CLI names
     that dir. Fallback (a ``--reports-dir`` override that kept the convention, or an older run): the
-    newest timestamped subdir holding a ``llm_usage.json``. Timestamps are ``%Y%m%d_%H%M%S``, so a
+    newest timestamped subdir holding ``<filename>``. Timestamps are ``%Y%m%d_%H%M%S``, so a
     plain lexicographic max picks the most recent. Returns ``None`` if nothing is found.
 
     This is the single source of truth for the on-disk usage-file layout; external consumers (e.g.
-    composer) should call it rather than re-deriving these paths.
+    composer) should call the typed wrappers below rather than re-deriving these paths.
     """
     reports_root = project_root / CERTORA_REPORTS_DIR
 
@@ -117,7 +119,7 @@ def resolve_autosetup_llm_usage_file(project_root: Path) -> Path | None:
     except (OSError, ValueError):
         timestamp = None
     if timestamp:
-        candidate = reports_root / timestamp / FILE_LLM_USAGE
+        candidate = reports_root / timestamp / filename
         if candidate.exists():
             return candidate
 
@@ -126,7 +128,19 @@ def resolve_autosetup_llm_usage_file(project_root: Path) -> Path | None:
     except OSError:
         return None
     for d in reversed(subdirs):
-        candidate = d / FILE_LLM_USAGE
+        candidate = d / filename
         if candidate.exists():
             return candidate
     return None
+
+
+def resolve_autosetup_llm_usage_file(project_root: Path) -> Path | None:
+    """Locate the ``llm_usage.json`` the most recent autosetup run wrote under ``project_root``
+    (``None`` if absent). See :func:`_resolve_autosetup_reports_file`."""
+    return _resolve_autosetup_reports_file(project_root, FILE_LLM_USAGE)
+
+
+def resolve_autosetup_prover_usage_file(project_root: Path) -> Path | None:
+    """Locate the ``prover_usage.json`` the most recent autosetup run wrote under ``project_root``
+    (``None`` if absent). See :func:`_resolve_autosetup_reports_file`."""
+    return _resolve_autosetup_reports_file(project_root, FILE_PROVER_USAGE)

--- a/certora_autosetup/utils/prover_runner.py
+++ b/certora_autosetup/utils/prover_runner.py
@@ -296,27 +296,17 @@ class ProverRunner(ABC):
         """Get cache key for job specification."""
         return job_spec.get_cache_key(self.config_manager)
 
-    def _record_fresh_prover_runtime(self, job_identifier: Optional[str]) -> None:
-        """Fold a freshly-executed prover run's prover-REPORTED runtime (statsdata
-        ``run_id.start_to_end_time``, in ms) into the process prover-usage ledger.
+    def _record_prover_runtime_seconds(self, seconds: Optional[float]) -> None:
+        """Fold a freshly-executed prover run's runtime (in seconds) into the process
+        prover-usage ledger. ``None`` or non-positive is a no-op.
 
-        ``job_identifier`` is whatever ``ProverOutputAPI`` resolves to statsdata for
-        this runner — the emv-* folder path (local) or the cloud job URL (cloud).
-        Called from each runner's leaf executor, on the fresh-run path only: cache
-        hits short-circuit before the executor runs, so cached jobs are excluded —
-        they consumed no prover compute this run. Best-effort: any failure to locate /
-        read statsdata is a silent no-op (a run that crashed before producing statsdata
-        simply isn't counted)."""
-        if not job_identifier:
-            return
-        try:
-            stats = self.prover_api.get_statsdata(job_identifier)
-            # statsdata records every metric as a list of samples; start_to_end_time
-            # always carries exactly one — the run's total.
-            runtime = stats["run_id"]["start_to_end_time"][0]
-            record_prover_runtime_ms(int(runtime))
-        except Exception as e:
-            self.log(f"Could not record prover runtime for usage ledger: {e}", "DEBUG")
+        Cloud passes the server-reported runtime (job start→finish); local passes its
+        wall-clock duration — local runs are serialized (one prover at a time, no
+        queueing), so wall-time is the run time. Callers are on the fresh-run path
+        only: cache hits short-circuit before the executor runs, so cached jobs are
+        excluded — they consumed no prover compute this run."""
+        if seconds and seconds > 0:
+            record_prover_runtime_ms(int(seconds * 1000))
 
     async def _check_cache(self, cache_key: str, job_spec: ProverJobSpec) -> Optional[ProverResult]:
         """Check if we have a cached result for this cache key."""

--- a/certora_autosetup/utils/prover_runner.py
+++ b/certora_autosetup/utils/prover_runner.py
@@ -33,6 +33,7 @@ from .enhanced_config_manager import ConfigManager, FileContent, ProverJobSpec
 from .file_utils import atomic_write_json_fsspec
 from .job_problem_fixes import MAX_JOB_PROBLEM_FIXES, on_job_problem
 from .logger import logger
+from .prover_usage_ledger import record_prover_runtime_ms
 from .runner_types import (
     JobHandle,
     NotificationType,
@@ -294,6 +295,28 @@ class ProverRunner(ABC):
     def _get_cache_key(self, job_spec: ProverJobSpec) -> str:
         """Get cache key for job specification."""
         return job_spec.get_cache_key(self.config_manager)
+
+    def _record_fresh_prover_runtime(self, job_identifier: Optional[str]) -> None:
+        """Fold a freshly-executed prover run's prover-REPORTED runtime (statsdata
+        ``run_id.start_to_end_time``, in ms) into the process prover-usage ledger.
+
+        ``job_identifier`` is whatever ``ProverOutputAPI`` resolves to statsdata for
+        this runner — the emv-* folder path (local) or the cloud job URL (cloud).
+        Called from each runner's leaf executor, on the fresh-run path only: cache
+        hits short-circuit before the executor runs, so cached jobs are excluded —
+        they consumed no prover compute this run. Best-effort: any failure to locate /
+        read statsdata is a silent no-op (a run that crashed before producing statsdata
+        simply isn't counted)."""
+        if not job_identifier:
+            return
+        try:
+            stats = self.prover_api.get_statsdata(job_identifier)
+            # statsdata records every metric as a list of samples; start_to_end_time
+            # always carries exactly one — the run's total.
+            runtime = stats["run_id"]["start_to_end_time"][0]
+            record_prover_runtime_ms(int(runtime))
+        except Exception as e:
+            self.log(f"Could not record prover runtime for usage ledger: {e}", "DEBUG")
 
     async def _check_cache(self, cache_key: str, job_spec: ProverJobSpec) -> Optional[ProverResult]:
         """Check if we have a cached result for this cache key."""

--- a/certora_autosetup/utils/prover_usage_ledger.py
+++ b/certora_autosetup/utils/prover_usage_ledger.py
@@ -1,0 +1,42 @@
+"""Process-wide ledger of prover-REPORTED runtime for the jobs this autosetup run
+actually executed.
+
+Cache hits are excluded: the runners short-circuit to a cached ``ProverResult`` before
+the fresh-run path that feeds this ledger, so a cached job (which consumed no prover
+compute this run) never lands here. Mirrors the LLM usage ledger in ``llm_util`` — a
+module-global accumulator reset at process start (``cli.main``) and harvested at the end
+into ``prover_usage.json``, which composer ingests.
+
+"Runtime" is the prover engine's own start-to-end wall time (``statsdata.json``
+``run_id.start_to_end_time``, in milliseconds) — matching what composer records for its
+own native prover runs, and NOT client-side wall-clock (which also covers cloud queue,
+polling, and result download).
+"""
+
+import threading
+
+_lock = threading.Lock()
+_total_ms: int = 0
+_runs: int = 0
+
+
+def reset() -> None:
+    """Start a clean ledger for this process."""
+    global _total_ms, _runs
+    with _lock:
+        _total_ms = 0
+        _runs = 0
+
+
+def record_prover_runtime_ms(ms: int) -> None:
+    """Add one freshly-executed prover run's prover-reported runtime (milliseconds)."""
+    global _total_ms, _runs
+    with _lock:
+        _total_ms += int(ms)
+        _runs += 1
+
+
+def usage() -> dict[str, int]:
+    """Serializable rollup written to ``prover_usage.json`` and ingested by composer."""
+    with _lock:
+        return {"ms": _total_ms, "runs": _runs}

--- a/certora_autosetup/utils/prover_usage_ledger.py
+++ b/certora_autosetup/utils/prover_usage_ledger.py
@@ -7,10 +7,11 @@ compute this run) never lands here. Mirrors the LLM usage ledger in ``llm_util``
 module-global accumulator reset at process start (``cli.main``) and harvested at the end
 into ``prover_usage.json``, which composer ingests.
 
-"Runtime" is the prover engine's own start-to-end wall time (``statsdata.json``
-``run_id.start_to_end_time``, in milliseconds) — matching what composer records for its
-own native prover runs, and NOT client-side wall-clock (which also covers cloud queue,
-polling, and result download).
+"Runtime" (milliseconds) is per-run how long the prover actually ran: for cloud jobs the
+server-reported job duration (start→finish from ``JobInfo``), for local jobs the wall-clock
+duration (local runs are serialized — one prover at a time, no queueing — so wall-time is
+the run time). It deliberately excludes the cloud queue / polling / download overhead that
+a client-side cloud wall-clock would include.
 """
 
 import threading

--- a/composer/diagnostics/timing.py
+++ b/composer/diagnostics/timing.py
@@ -83,20 +83,12 @@ class RunSummary:
     prover_total_s: float = 0.0
     prover_total_calls: int = 0
     _active_prover_by_task: dict[str, tuple[float, int]] = field(default_factory=dict, repr=False)
-    prover_reported_ms_total: int = 0
-    """Run-wide prover-REPORTED runtime (statsdata run_id.start_to_end_time, in ms), summed
-    over every prover run. Distinct from prover_total_s, which is composer's client-side
-    wall-clock (and so includes cloud queue / polling / result download)."""
-    _active_prover_reported_by_task: dict[str, int] = field(default_factory=dict, repr=False)
-    """Maps task_id -> prover-reported ms accumulated while the task is in flight."""
-    run_id: str = field(default_factory=lambda: uuid.uuid4().hex)
-    """Maps task_id -> (prover_s_accum, prover_calls) recorded while task is in flight."""
-    _latest_link_by_task: dict[str, str] = field(default_factory=dict, repr=False)
-    """Maps task_id -> link for the most recent prover run."""
-    token_usage_by_model: dict[str, TokenTotals] = field(default_factory=dict)
-    """Maps model_name -> accumulated raw token counts across the whole run."""
-    _active_tokens_by_task: dict[str, dict[str, TokenTotals]] = field(default_factory=dict, repr=False)
-    """Maps task_id -> {model_name -> token counts} accumulated while the task is in flight."""
+    prover_reported_ms_total: int = 0  # Run-wide prover-REPORTED runtime, summed over every prover run. Distinct from prover_total_s, which is composer's client-side wall-clock (and so includes cloud queue / polling / result download).
+    _active_prover_reported_by_task: dict[str, int] = field(default_factory=dict, repr=False)  # Maps task_id -> prover-reported ms accumulated while the task is in flight.
+    run_id: str = field(default_factory=lambda: uuid.uuid4().hex)  # Maps task_id -> (prover_s_accum, prover_calls) recorded while task is in flight.
+    _latest_link_by_task: dict[str, str] = field(default_factory=dict, repr=False)  # Maps task_id -> link for the most recent prover run.
+    token_usage_by_model: dict[str, TokenTotals] = field(default_factory=dict)  # Maps model_name -> accumulated raw token counts across the whole run.
+    _active_tokens_by_task: dict[str, dict[str, TokenTotals]] = field(default_factory=dict, repr=False)  # Maps task_id -> {model_name -> token counts} accumulated while the task is in flight.
 
     def record_phase(
         self,

--- a/composer/diagnostics/timing.py
+++ b/composer/diagnostics/timing.py
@@ -71,6 +71,7 @@ class PhaseRecord:
     error: str | None = None
     prover_s: float = 0.0
     prover_calls: int = 0
+    prover_reported_ms: int = 0  # prover-REPORTED runtime (statsdata run_id.start_to_end_time, ms) summed over this phase's runs
     final_link: str | None = None # URL (cloud) or local results directory (local) of the last prover run.
     token_usage_by_model: dict[str, TokenTotals] = field(default_factory=dict)
 
@@ -82,6 +83,12 @@ class RunSummary:
     prover_total_s: float = 0.0
     prover_total_calls: int = 0
     _active_prover_by_task: dict[str, tuple[float, int]] = field(default_factory=dict, repr=False)
+    prover_reported_ms_total: int = 0
+    """Run-wide prover-REPORTED runtime (statsdata run_id.start_to_end_time, in ms), summed
+    over every prover run. Distinct from prover_total_s, which is composer's client-side
+    wall-clock (and so includes cloud queue / polling / result download)."""
+    _active_prover_reported_by_task: dict[str, int] = field(default_factory=dict, repr=False)
+    """Maps task_id -> prover-reported ms accumulated while the task is in flight."""
     run_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     """Maps task_id -> (prover_s_accum, prover_calls) recorded while task is in flight."""
     _latest_link_by_task: dict[str, str] = field(default_factory=dict, repr=False)
@@ -102,6 +109,7 @@ class RunSummary:
         error: str | None = None,
     ) -> None:
         prover_s, prover_calls = self._active_prover_by_task.pop(task_id, (0.0, 0))
+        prover_reported_ms = self._active_prover_reported_by_task.pop(task_id, 0)
         link = self._latest_link_by_task.pop(task_id, None)
         tokens = self._active_tokens_by_task.pop(task_id, {})
         self.phases.append(PhaseRecord(
@@ -113,6 +121,7 @@ class RunSummary:
             error=error,
             prover_s=prover_s,
             prover_calls=prover_calls,
+            prover_reported_ms=prover_reported_ms,
             final_link=link,
             token_usage_by_model=tokens,
         ))
@@ -124,6 +133,20 @@ class RunSummary:
         if task_id is not None:
             prev_s, prev_n = self._active_prover_by_task.get(task_id, (0.0, 0))
             self._active_prover_by_task[task_id] = (prev_s + duration_s, prev_n + 1)
+
+    def record_prover_runtime(self, ms: int, *, task_id: str | None = None) -> None:
+        """Accumulate one prover run's prover-REPORTED runtime (statsdata.json
+        ``run_id.start_to_end_time``, in milliseconds — the prover engine's own
+        start-to-end wall time) into the run-wide total and, if a task is active,
+        into that task's in-flight bucket, later folded into its ``PhaseRecord`` by
+        ``record_phase``. Defaults attribution to the active task. Distinct from
+        ``add_prover_call``/``prover_total_s``, which records composer's client-side
+        wall-clock (and so also covers cloud queue, polling, and result download)."""
+        self.prover_reported_ms_total += ms
+        if (task_id := task_id or get_current_task_id()) is not None:
+            self._active_prover_reported_by_task[task_id] = (
+                self._active_prover_reported_by_task.get(task_id, 0) + ms
+            )
 
     def record_token_usage(self, usage: TokenUsageDict, *, task_id: str | None = None) -> None:
         """Accumulate one LLM call's token counts into the run-wide per-model totals
@@ -154,6 +177,21 @@ class RunSummary:
                 }
                 for p in self.phases
                 if p.token_usage_by_model
+            ],
+        }
+
+    def prover_usage_summary(self) -> dict[str, object]:
+        """Serializable run-total / per-phase prover-REPORTED runtime — the body of
+        ``prover_usage.json`` and of the ``prover_usage`` run tag. Runtime is the
+        prover's own start-to-end time (statsdata ``run_id.start_to_end_time``),
+        summed across every prover run (cloud and local alike), in milliseconds.
+        Minutes are trivially ``ms / 60_000`` and not stored."""
+        return {
+            "total_ms": self.prover_reported_ms_total,
+            "by_phase": [
+                {"task_id": p.task_id, "phase": p.phase, "ms": p.prover_reported_ms}
+                for p in self.phases
+                if p.prover_reported_ms
             ],
         }
 
@@ -262,6 +300,12 @@ def _format_summary(summary: RunSummary) -> str:
         f"Prover total: {_fmt_secs(summary.prover_total_s)} across "
         f"{summary.prover_total_calls} call(s)"
     )
+    if summary.prover_reported_ms_total:
+        out.append(
+            f"Prover runtime (reported): "
+            f"{summary.prover_reported_ms_total / 60_000:.1f} min "
+            f"({_fmt_secs(summary.prover_reported_ms_total / 1000)})"
+        )
     tot = summary.total_tokens()
     if tot:
         out.append(

--- a/composer/diagnostics/timing.py
+++ b/composer/diagnostics/timing.py
@@ -173,11 +173,10 @@ class RunSummary:
         }
 
     def prover_usage_summary(self) -> dict[str, object]:
-        """Serializable run-total / per-phase prover-REPORTED runtime — the body of
+        """Serializable run-total / per-phase prover-reported runtime — the body of
         ``prover_usage.json`` and of the ``prover_usage`` run tag. Runtime is the
         prover's own start-to-end time (statsdata ``run_id.start_to_end_time``),
-        summed across every prover run (cloud and local alike), in milliseconds.
-        Minutes are trivially ``ms / 60_000`` and not stored."""
+        summed across every prover run (cloud and local alike), in milliseconds."""
         return {
             "total_ms": self.prover_reported_ms_total,
             "by_phase": [

--- a/composer/prover/cloud.py
+++ b/composer/prover/cloud.py
@@ -11,6 +11,7 @@ import tarfile
 import tempfile
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import AsyncIterator, Awaitable, Callable
 from urllib.parse import urlparse, parse_qs
@@ -106,6 +107,23 @@ async def poll_job(
     """
     return await asyncio.wait_for(_poll_job_inner(job, interval=interval, on_status=on_status), timeout=timeout)
 
+def _job_runtime_ms(job_data: dict) -> int | None:
+    """Prover execution time (ms) from the cloud job's ``startTime``→``finishTime`` —
+    the post-dequeue run window.
+
+    EXCLUDES queue wait: the job is created at ``postTime``, sits in the queue, then
+    ``startTime`` marks when the prover actually began executing. Returns ``None``
+    if either timestamp is absent or unparseable, so usage capture never breaks a run.
+    """
+    start, finish = job_data.get("startTime"), job_data.get("finishTime")
+    if not start or not finish:
+        return None
+    try:
+        return int((datetime.fromisoformat(finish) - datetime.fromisoformat(start)).total_seconds() * 1000)
+    except (ValueError, TypeError):
+        return None
+
+
 def find_results_root(dest: Path) -> Path:
     """Navigate past the extra TarName/ top-level directory in the extracted archive."""
     children = [p for p in dest.iterdir() if p.is_dir()]
@@ -127,12 +145,14 @@ async def cloud_results(
     *,
     poll_timeout: float,
     poll_callback: Callable[[str, str], Awaitable[None]] | None = None,
-) -> AsyncIterator[Path]:
-    """Async context manager: poll cloud job, download results, yield path, clean up.
+) -> AsyncIterator[tuple[Path, int | None]]:
+    """Async context manager: poll cloud job, download results, yield (path, runtime_ms),
+    clean up.
 
-    Parses the cloud link, polls until completion, downloads and extracts the
-    results archive, then yields the path to the results root. The temporary
-    directory is cleaned up on exit.
+    Parses the cloud link, polls until completion, downloads and extracts the results
+    archive, then yields ``(results_root, runtime_ms)`` where ``runtime_ms`` is the prover's
+    queue-free execution time from the job's ``startTime``→``finishTime`` (``None`` if
+    unavailable). The temporary directory is cleaned up on exit.
     """
     cloud_job = parse_cloud_link(run_result_link)
 
@@ -148,6 +168,8 @@ async def cloud_results(
     status = job_data.get("jobStatus", "UNKNOWN")
     if status != "SUCCEEDED":
         raise RuntimeError(f"Cloud job finished with status {status} (expected DONE)")
+
+    runtime_ms = _job_runtime_ms(job_data)
 
     zip_url = job_data.get("zipOutputUrl")
     if not zip_url:
@@ -173,4 +195,4 @@ async def cloud_results(
         finally:
             tmp_path.unlink(missing_ok=True)
 
-        yield find_results_root(dest)
+        yield (find_results_root(dest), runtime_ms)

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -195,9 +195,9 @@ class ProverCallbacks:
     cloud runs ``link`` is the prover UI URL; for local runs it is a
     filesystem path to the results directory."""
     async def on_prover_runtime(self, ms: int) -> None: pass
-    """Fires once per run with the prover's self-reported runtime in milliseconds
-    (statsdata.json ``run_id.start_to_end_time``). Only fires when statsdata is
-    present and parseable — absent for an errored run that produced no results."""
+    """Fires once per run with the prover's queue-free run time in milliseconds — the
+    cloud job's ``startTime``->``finishTime`` execution window, or (local) the engine's
+    statsdata ``start_to_end_time``. Only fires when that value is available."""
     async def on_prover_result(self, results: dict[str, RuleResult]) -> None: pass
     async def on_analysis_start(self, rule: RuleResult) -> None: pass
     async def on_analysis_complete(self, rule: RuleResult, explanation: str) -> None: pass
@@ -316,9 +316,12 @@ DefaultCexHandler = TrivialFanoutCexHandler
 
 
 @asynccontextmanager
-async def _local_results(path: Path) -> AsyncIterator[Path]:
-    """Trivial context manager that yields a local results path unchanged."""
-    yield path
+async def _local_results(path: Path) -> AsyncIterator[tuple[Path, int | None]]:
+    """Trivial context manager yielding ``(local results path, None)``.
+
+    The ``None`` is the cloud-runtime slot (matching ``cloud_results``); local runs have no
+    cloud job, so their runtime is read from statsdata via ``read_prover_runtime_ms``."""
+    yield (path, None)
 
 
 async def _report_to_todo_list(
@@ -446,16 +449,19 @@ async def run_prover(
             return f"Prover did not produce local results.\nstdout:\n{stdout}"
         results_cm = _local_results(Path(run_result["link"]))
 
-    # 8. Parse results, read the prover's self-reported runtime, and run analysis.
+    # 8. Parse results, determine the prover's queue-free runtime, and run analysis.
     # All happen inside ``results_cm`` so the report directory (which contains
     # ``inputs/.certora_sources`` — the source files actually compiled into this
     # verification problem) stays alive for the analyzer to read. Cloud runs unzip
     # into a tmpdir whose lifetime is bound to ``cloud_results``; local runs hand
     # back a stable path. Either way the analyzer must complete before the
     # context manager exits.
-    async with results_cm as emv_path:
+    async with results_cm as (emv_path, cloud_runtime_ms):
         parsed = read_and_format_run_result(emv_path)
-        runtime_ms = read_prover_runtime_ms(emv_path)
+        # Queue-free run time: cloud uses the job's startTime->finishTime (execution
+        # window, excludes queue); local has no cloud job and isn't queued, so it reads
+        # the engine's own start_to_end from statsdata.
+        runtime_ms = cloud_runtime_ms if prover_opts.cloud else read_prover_runtime_ms(emv_path)
 
         if isinstance(parsed, str):
             return f"Failed to parse prover results: {parsed}"

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -43,7 +43,7 @@ from prover_output_utility import cloud_server_for_env
 from composer.prover.analysis import analyze_cex_raw
 from composer.prover.cloud import cloud_results
 from composer.prover.ptypes import RuleResult
-from composer.prover.results import read_and_format_run_result
+from composer.prover.results import read_and_format_run_result, read_prover_runtime_ms
 from composer.templates.loader import load_jinja_template
 from composer.prover.prover_protocol import ProverResult
 
@@ -194,6 +194,10 @@ class ProverCallbacks:
     """Fires once per run as soon as the prover emits its result link. For
     cloud runs ``link`` is the prover UI URL; for local runs it is a
     filesystem path to the results directory."""
+    async def on_prover_runtime(self, ms: int) -> None: pass
+    """Fires once per run with the prover's self-reported runtime in milliseconds
+    (statsdata.json ``run_id.start_to_end_time``). Only fires when statsdata is
+    present and parseable — absent for an errored run that produced no results."""
     async def on_prover_result(self, results: dict[str, RuleResult]) -> None: pass
     async def on_analysis_start(self, rule: RuleResult) -> None: pass
     async def on_analysis_complete(self, rule: RuleResult, explanation: str) -> None: pass
@@ -442,20 +446,23 @@ async def run_prover(
             return f"Prover did not produce local results.\nstdout:\n{stdout}"
         results_cm = _local_results(Path(run_result["link"]))
 
-    # 8. Parse results + run analysis. Both happen inside ``results_cm`` so
-    # the report directory (which contains ``inputs/.certora_sources`` —
-    # the source files actually compiled into this verification problem)
-    # stays alive for the analyzer to read. Cloud runs unzip into a tmpdir
-    # whose lifetime is bound to ``cloud_results``; local runs hand back
-    # a stable path. Either way the analyzer must complete before the
+    # 8. Parse results, read the prover's self-reported runtime, and run analysis.
+    # All happen inside ``results_cm`` so the report directory (which contains
+    # ``inputs/.certora_sources`` — the source files actually compiled into this
+    # verification problem) stays alive for the analyzer to read. Cloud runs unzip
+    # into a tmpdir whose lifetime is bound to ``cloud_results``; local runs hand
+    # back a stable path. Either way the analyzer must complete before the
     # context manager exits.
     async with results_cm as emv_path:
         parsed = read_and_format_run_result(emv_path)
+        runtime_ms = read_prover_runtime_ms(emv_path)
 
         if isinstance(parsed, str):
             return f"Failed to parse prover results: {parsed}"
 
-        # 9. Notify prover_result callback
+        # 9. Notify runtime + prover_result callbacks
+        if runtime_ms is not None:
+            await callbacks.on_prover_runtime(runtime_ms)
         await callbacks.on_prover_result(parsed)
 
         all_results = list(parsed.values())

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -23,6 +23,7 @@ CEX analysis flow:
 import asyncio
 import sys
 import tempfile
+import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -43,7 +44,7 @@ from prover_output_utility import cloud_server_for_env
 from composer.prover.analysis import analyze_cex_raw
 from composer.prover.cloud import cloud_results
 from composer.prover.ptypes import RuleResult
-from composer.prover.results import read_and_format_run_result, read_prover_runtime_ms
+from composer.prover.results import read_and_format_run_result
 from composer.templates.loader import load_jinja_template
 from composer.prover.prover_protocol import ProverResult
 
@@ -196,8 +197,8 @@ class ProverCallbacks:
     filesystem path to the results directory."""
     async def on_prover_runtime(self, ms: int) -> None: pass
     """Fires once per run with the prover's queue-free run time in milliseconds — the
-    cloud job's ``startTime``->``finishTime`` execution window, or (local) the engine's
-    statsdata ``start_to_end_time``. Only fires when that value is available."""
+    cloud job's ``startTime``->``finishTime`` execution window, or (local) the prover
+    subprocess wall-clock. Only fires when that value is available."""
     async def on_prover_result(self, results: dict[str, RuleResult]) -> None: pass
     async def on_analysis_start(self, rule: RuleResult) -> None: pass
     async def on_analysis_complete(self, rule: RuleResult, explanation: str) -> None: pass
@@ -316,12 +317,14 @@ DefaultCexHandler = TrivialFanoutCexHandler
 
 
 @asynccontextmanager
-async def _local_results(path: Path) -> AsyncIterator[tuple[Path, int | None]]:
-    """Trivial context manager yielding ``(local results path, None)``.
+async def _local_results(path: Path, runtime_ms: int) -> AsyncIterator[tuple[Path, int | None]]:
+    """Trivial context manager yielding ``(local results path, runtime_ms)``.
 
-    The ``None`` is the cloud-runtime slot (matching ``cloud_results``); local runs have no
-    cloud job, so their runtime is read from statsdata via ``read_prover_runtime_ms``."""
-    yield (path, None)
+    Mirrors ``cloud_results``' interface so ``run_prover`` consumes both uniformly. Where
+    ``cloud_results`` computes the runtime from the polled job, the local run already
+    happened in ``run_prover_inner``, so its wall-clock (queue-free — local isn't queued)
+    is measured there and handed in here."""
+    yield (path, runtime_ms)
 
 
 async def _report_to_todo_list(
@@ -416,12 +419,18 @@ async def run_prover(
 
     # 2. Notify callback
     await callbacks.on_prover_run(effective_args)
+    # Wall-clock of the prover subprocess. For LOCAL this IS the run time (certoraRun runs
+    # the prover and blocks until done; local runs aren't queued). For cloud the subprocess
+    # only submits and returns, so this isn't used — cloud runtime comes from the job's
+    # execution window (see cloud_results / _job_runtime_ms).
+    _t0 = time.perf_counter()
     run_result, stdout = await run_prover_inner(
         folder,
         effective_args,
         lambda ret_code, stdout, stderr: _logger.error("Process failed %d\nstdout:%s\nstderr:%s", ret_code, stdout, stderr),
         callbacks.on_stdout_line
     )
+    local_runtime_ms = int((time.perf_counter() - _t0) * 1000)
     if isinstance(run_result, str):
         return run_result
 
@@ -447,21 +456,17 @@ async def run_prover(
     else:
         if not run_result["is_local_link"]:
             return f"Prover did not produce local results.\nstdout:\n{stdout}"
-        results_cm = _local_results(Path(run_result["link"]))
+        results_cm = _local_results(Path(run_result["link"]), local_runtime_ms)
 
-    # 8. Parse results, determine the prover's queue-free runtime, and run analysis.
-    # All happen inside ``results_cm`` so the report directory (which contains
-    # ``inputs/.certora_sources`` — the source files actually compiled into this
-    # verification problem) stays alive for the analyzer to read. Cloud runs unzip
-    # into a tmpdir whose lifetime is bound to ``cloud_results``; local runs hand
-    # back a stable path. Either way the analyzer must complete before the
-    # context manager exits.
-    async with results_cm as (emv_path, cloud_runtime_ms):
+    # 8. Parse results and run analysis, both inside ``results_cm`` so the report
+    # directory (which contains ``inputs/.certora_sources`` — the source files actually
+    # compiled into this verification problem) stays alive for the analyzer to read.
+    # Cloud runs unzip into a tmpdir whose lifetime is bound to ``cloud_results``; local
+    # runs hand back a stable path. Either way the analyzer must complete before the
+    # context manager exits. ``runtime_ms`` is the prover's queue-free run time, sourced
+    # by each context manager (cloud job window / local subprocess wall-clock).
+    async with results_cm as (emv_path, runtime_ms):
         parsed = read_and_format_run_result(emv_path)
-        # Queue-free run time: cloud uses the job's startTime->finishTime (execution
-        # window, excludes queue); local has no cloud job and isn't queued, so it reads
-        # the engine's own start_to_end from statsdata.
-        runtime_ms = cloud_runtime_ms if prover_opts.cloud else read_prover_runtime_ms(emv_path)
 
         if isinstance(parsed, str):
             return f"Failed to parse prover results: {parsed}"

--- a/composer/prover/results.py
+++ b/composer/prover/results.py
@@ -3,13 +3,10 @@ from typing_extensions import Iterable
 from pathlib import Path
 import re
 import json
-import logging
 
 from pydantic import Field, BaseModel, ValidationError
 
 from composer.prover.ptypes import RuleResult, StatusCodes, RulePath
-
-_logger = logging.getLogger(__name__)
 
 T = TypeVar('T')
 R = TypeVar('R')
@@ -211,28 +208,6 @@ def read_and_format_run_result(s: Path) -> dict[str, RuleResult] | str:
     for r in _flat_yield(loaded_data.rules, lambda r: flatten_tree_view_root(tree_view_dir, r)):
         to_ret[r.name] = r
     return to_ret
-
-
-def read_prover_runtime_ms(results_root: Path) -> int | None:
-    """The prover engine's self-reported run time for this job, in milliseconds.
-
-    Read from ``<results_root>/Reports/statsdata.json`` (``run_id.start_to_end_time``) —
-    the engine's own start-to-end wall time, which is post-dequeue (queue-free). Used for
-    LOCAL runs; cloud runs instead derive runtime from the job's startTime->finishTime in
-    ``cloud_results`` (queue-free too, and no need to read the extracted archive). NOT
-    composer's client-side ``elapsed`` (which also covers cloud queue / polling / download).
-    The value is stored as a single-element list. Returns ``None`` on any failure (file
-    absent, malformed JSON, or the key missing) — usage capture must never break a run.
-    """
-    stats_path = results_root / "Reports" / "statsdata.json"
-    try:
-        # statsdata records every metric as a list of samples; start_to_end_time
-        # always carries exactly one — the run's total (IndexError below if empty).
-        runtime = json.loads(stats_path.read_text())["run_id"]["start_to_end_time"][0]
-        return int(runtime)
-    except (OSError, ValueError, KeyError, IndexError, TypeError) as e:
-        _logger.debug("Could not read prover runtime from %s: %s", stats_path, e)
-        return None
 
 def calltrace_to_xml(node: CallTraceModel) -> str:
     """

--- a/composer/prover/results.py
+++ b/composer/prover/results.py
@@ -214,14 +214,15 @@ def read_and_format_run_result(s: Path) -> dict[str, RuleResult] | str:
 
 
 def read_prover_runtime_ms(results_root: Path) -> int | None:
-    """The prover's self-reported run time for this job, in milliseconds.
+    """The prover engine's self-reported run time for this job, in milliseconds.
 
-    Read from ``<results_root>/Reports/statsdata.json`` (``run_id.start_to_end_time``)
-    — the prover engine's own start-to-end wall time, present and identical for cloud
-    (the extracted results archive) and local runs. This is NOT composer's client-side
-    ``elapsed`` (which also covers cloud queue / polling / result download). The value is
-    stored as a single-element list. Returns ``None`` on any failure (file absent,
-    malformed JSON, or the key missing) — usage capture must never break a prover run.
+    Read from ``<results_root>/Reports/statsdata.json`` (``run_id.start_to_end_time``) —
+    the engine's own start-to-end wall time, which is post-dequeue (queue-free). Used for
+    LOCAL runs; cloud runs instead derive runtime from the job's startTime->finishTime in
+    ``cloud_results`` (queue-free too, and no need to read the extracted archive). NOT
+    composer's client-side ``elapsed`` (which also covers cloud queue / polling / download).
+    The value is stored as a single-element list. Returns ``None`` on any failure (file
+    absent, malformed JSON, or the key missing) — usage capture must never break a run.
     """
     stats_path = results_root / "Reports" / "statsdata.json"
     try:

--- a/composer/prover/results.py
+++ b/composer/prover/results.py
@@ -3,10 +3,13 @@ from typing_extensions import Iterable
 from pathlib import Path
 import re
 import json
+import logging
 
 from pydantic import Field, BaseModel, ValidationError
 
 from composer.prover.ptypes import RuleResult, StatusCodes, RulePath
+
+_logger = logging.getLogger(__name__)
 
 T = TypeVar('T')
 R = TypeVar('R')
@@ -124,7 +127,7 @@ def flatten_tree_view(context: Path, r: RuleNodeModel, path: RulePath, parent_ty
                 cex_dump=None,
                 status=stat
             )]
-    
+
     if stat == "TIMEOUT":
         if len(r.children) == 0:
             return [RuleResult(path=effective_path, cex_dump=None,status=stat)]
@@ -208,6 +211,27 @@ def read_and_format_run_result(s: Path) -> dict[str, RuleResult] | str:
     for r in _flat_yield(loaded_data.rules, lambda r: flatten_tree_view_root(tree_view_dir, r)):
         to_ret[r.name] = r
     return to_ret
+
+
+def read_prover_runtime_ms(results_root: Path) -> int | None:
+    """The prover's self-reported run time for this job, in milliseconds.
+
+    Read from ``<results_root>/Reports/statsdata.json`` (``run_id.start_to_end_time``)
+    — the prover engine's own start-to-end wall time, present and identical for cloud
+    (the extracted results archive) and local runs. This is NOT composer's client-side
+    ``elapsed`` (which also covers cloud queue / polling / result download). The value is
+    stored as a single-element list. Returns ``None`` on any failure (file absent,
+    malformed JSON, or the key missing) — usage capture must never break a prover run.
+    """
+    stats_path = results_root / "Reports" / "statsdata.json"
+    try:
+        # statsdata records every metric as a list of samples; start_to_end_time
+        # always carries exactly one — the run's total (IndexError below if empty).
+        runtime = json.loads(stats_path.read_text())["run_id"]["start_to_end_time"][0]
+        return int(runtime)
+    except (OSError, ValueError, KeyError, IndexError, TypeError) as e:
+        _logger.debug("Could not read prover runtime from %s: %s", stats_path, e)
+        return None
 
 def calltrace_to_xml(node: CallTraceModel) -> str:
     """

--- a/composer/spec/artifacts.py
+++ b/composer/spec/artifacts.py
@@ -78,3 +78,15 @@ class ArtifactStore(ABC):
         (ensure_dir(self._internal_dir()) / "token_usage.json").write_text(
             json.dumps(payload, indent=2)
         )
+
+    def write_prover_usage(self, summary: RunSummary) -> None:
+        """The run's accumulated prover-reported runtime → ``{internal}/prover_usage.json``.
+
+        Prover-reported run time (statsdata.json ``run_id.start_to_end_time`` — the engine's
+        own start-to-end wall time, not composer's client-side ``elapsed``), in milliseconds
+        with a derived ``minutes`` ``total`` and a ``by_phase`` breakdown. Summed across every
+        prover run in the pipeline (cloud and local alike)."""
+        payload = {"run_id": summary.run_id, **summary.prover_usage_summary()}
+        (ensure_dir(self._internal_dir()) / "prover_usage.json").write_text(
+            json.dumps(payload, indent=2)
+        )

--- a/composer/spec/source/autoprove_common.py
+++ b/composer/spec/source/autoprove_common.py
@@ -236,16 +236,22 @@ async def autoprove_executor(args: AutoProveArgs, summary: RunSummary) -> AsyncI
         try:
             yield runner
         finally:
-            # Persist final token usage into RunMeta.tags at run close (totals
-            # known only once the pipeline is done). Mirrors token_usage.json.
+            # Persist final token + prover usage into the run's data_ns at run close
+            # (totals known only once the pipeline is done). Mirror the *_usage.json
+            # artifacts. prover_usage is the prover's self-reported runtime
+            # (statsdata run_id.start_to_end_time) summed over every prover run.
             await data_logger(
                 "token_usage", summary.token_usage_summary()
             )
-            # Dump final LLM token usage for the run (success or failure). Single
+            await data_logger(
+                "prover_usage", summary.prover_usage_summary()
+            )
+            # Dump final usage diagnostics for the run (success or failure). Single
             # choke point both console and TUI entry points pass through, with
             # system_doc in scope and the summary fully populated. Guarded so a
             # diagnostics-dump failure can never mask the pipeline's own outcome.
             try:
                 system_doc.artifact_store.write_token_usage(summary)
+                system_doc.artifact_store.write_prover_usage(summary)
             except Exception:
-                _logger.exception("failed to dump token usage")
+                _logger.exception("failed to dump usage diagnostics")

--- a/composer/spec/source/autosetup.py
+++ b/composer/spec/source/autosetup.py
@@ -273,5 +273,5 @@ def read_autosetup_prover_usage(project_root: Path) -> int | None:
     try:
         return int(json.loads(usage_file.read_text())["ms"])
     except (OSError, ValueError, KeyError, TypeError) as e:
-        _logger.debug(f"Could not read AutoSetup prover usage from {usage_file}: {e}")
+        _logger.warning(f"Could not read AutoSetup prover usage from {usage_file}: {e}")
         return None

--- a/composer/spec/source/autosetup.py
+++ b/composer/spec/source/autosetup.py
@@ -20,8 +20,11 @@ from composer.prover.core import ProverOptions
 
 from graphcore.utils import TokenUsageDict
 from composer.io.context import emit_custom_event
-# Locator for autosetup's on-disk llm_usage.json (certora_autosetup owns that layout).
-from certora_autosetup.utils.paths import resolve_autosetup_llm_usage_file
+# Locators for autosetup's on-disk usage files (certora_autosetup owns that layout).
+from certora_autosetup.utils.paths import (
+    resolve_autosetup_llm_usage_file,
+    resolve_autosetup_prover_usage_file,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -211,8 +214,8 @@ async def run_autosetup(
 # --- AutoSetup LLM token-usage ingestion -----------------------------------
 # AutoSetup runs as a separate process, so its LLM calls never pass through
 # composer's model factory and are invisible to the UsageCallback. Its only
-# trace is the llm_usage.json it writes to disk. certora_autosetup owns that
-# on-disk layout and exposes resolve_autosetup_llm_usage_file() to locate it.
+# trace is the llm_usage.json / prover_usage.json it writes to disk. certora_autosetup
+# owns that on-disk layout and exposes resolve_autosetup_{llm,prover}_usage_file() to locate them.
 
 
 def _to_token_usage(model: str, bucket: dict) -> TokenUsageDict:
@@ -248,3 +251,27 @@ def read_autosetup_usage(project_root: Path) -> list[TokenUsageDict]:
         return []
 
     return [_to_token_usage(model, bucket) for model, bucket in by_model.items()]
+
+
+def read_autosetup_prover_usage(project_root: Path) -> int | None:
+    """Prover-REPORTED runtime (milliseconds) AutoSetup's subprocess prover runs
+    consumed on this run — ready to fold into the run's prover usage via
+    ``RunSummary.record_prover_runtime``.
+
+    AutoSetup runs the prover in a separate process, so its runs never reach composer's
+    native ``run_prover`` capture; its only trace is the ``prover_usage.json`` it writes
+    (resolved from the same timestamped reports dir as ``read_autosetup_usage``). The
+    value already EXCLUDES cache hits — AutoSetup's ledger only counts freshly-executed
+    jobs, which is what "minutes each job ran" means.
+
+    Returns ``None`` on any failure (file absent — autosetup skipped, full cache hit,
+    crash, replayed snapshot, or an AutoSetup too old to emit it — or malformed JSON):
+    missing external usage must never break the phase."""
+    usage_file = resolve_autosetup_prover_usage_file(project_root)
+    if usage_file is None:
+        return None
+    try:
+        return int(json.loads(usage_file.read_text())["ms"])
+    except (OSError, ValueError, KeyError, TypeError) as e:
+        _logger.debug(f"Could not read AutoSetup prover usage from {usage_file}: {e}")
+        return None

--- a/composer/spec/source/autosetup.py
+++ b/composer/spec/source/autosetup.py
@@ -254,7 +254,7 @@ def read_autosetup_usage(project_root: Path) -> list[TokenUsageDict]:
 
 
 def read_autosetup_prover_usage(project_root: Path) -> int | None:
-    """Prover-REPORTED runtime (milliseconds) AutoSetup's subprocess prover runs
+    """Prover-reported runtime (milliseconds) AutoSetup's subprocess prover runs
     consumed on this run — ready to fold into the run's prover usage via
     ``RunSummary.record_prover_runtime``.
 

--- a/composer/spec/source/harness.py
+++ b/composer/spec/source/harness.py
@@ -33,7 +33,7 @@ from graphcore.tools.results import result_tool_generator
 
 from composer.diagnostics.timing import get_run_summary
 from composer.spec.graph_builder import run_to_completion, bind_standard
-from composer.spec.source.autosetup import run_autosetup, read_autosetup_usage, SetupFailure, SetupSuccess
+from composer.spec.source.autosetup import run_autosetup, read_autosetup_usage, read_autosetup_prover_usage, SetupFailure, SetupSuccess
 from composer.spec.service_host import ServiceHost
 from composer.spec.context import WorkflowContext, SourceCode, CacheKey
 from composer.spec.util import string_hash
@@ -601,6 +601,11 @@ async def run_autosetup_phase(
     summary = get_run_summary()
     for usage in read_autosetup_usage(Path(source.project_root)):
         summary.record_token_usage(usage)
+    # Likewise fold AutoSetup's subprocess prover runtime (prover-reported, cache hits
+    # excluded) into the run's prover_usage under the active AUTOSETUP_TASK_ID. None if
+    # absent — guarded so missing external usage can't break the phase.
+    if (autosetup_prover_ms := read_autosetup_prover_usage(Path(source.project_root))) is not None:
+        summary.record_prover_runtime(autosetup_prover_ms)
 
     await cache.cache_put(setup_result)
     return setup_result

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -137,6 +137,12 @@ class _SpecCallbacks(ProverEventCallbacks):
         })
 
     @override
+    async def on_prover_runtime(self, ms: int) -> None:
+        # Prover-reported runtime (statsdata run_id.start_to_end_time). Attributed to
+        # the active task; folded into the phase / run "prover_usage" totals.
+        self._summary.record_prover_runtime(ms)
+
+    @override
     async def on_prover_result(self, results: dict[str, RuleResult]) -> None:
         elapsed = (time.perf_counter() - self._started_mono) if self._started_mono else 0.0
         status_summary = { k: v.status for (k,v) in results.items() }

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -138,8 +138,8 @@ class _SpecCallbacks(ProverEventCallbacks):
 
     @override
     async def on_prover_runtime(self, ms: int) -> None:
-        # Prover-reported runtime (statsdata run_id.start_to_end_time). Attributed to
-        # the active task; folded into the phase / run "prover_usage" totals.
+        # Queue-free prover run time (cloud job startTime->finishTime, or local statsdata).
+        # Attributed to the active task; folded into the phase / run "prover_usage" totals.
         self._summary.record_prover_runtime(ms)
 
     @override

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -138,7 +138,7 @@ class _SpecCallbacks(ProverEventCallbacks):
 
     @override
     async def on_prover_runtime(self, ms: int) -> None:
-        # Queue-free prover run time (cloud job startTime->finishTime, or local statsdata).
+        # Queue-free prover run time (cloud job startTime->finishTime, or local subprocess wall-clock).
         # Attributed to the active task; folded into the phase / run "prover_usage" totals.
         self._summary.record_prover_runtime(ms)
 


### PR DESCRIPTION
Track prover usage in Autosetup, and in AutoProver.

Note this uses `prover_api.get_statsdata(job_identifier)["run_id"]["start_to_end_time"]` which has the actual runtime, without upload + queued time