### PR TITLE
Add parallel local-run smoke harness (moved from AIAutoProver)

### DIFF
--- a/tests/parallel-test.sh
+++ b/tests/parallel-test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." &>/dev/null && pwd)
+
+cd "$REPO_ROOT"
+
+compose_files=(
+    -f "$REPO_ROOT/scripts/docker-compose.yml"
+)
+
+DEST_DIR=$(mktemp -p "$REPO_ROOT/tests" -d --suffix '.autoprover-test')
+
+for i in 1 2 3 4 5; do
+    cp -r "$REPO_ROOT/tests/smoketest" "$DEST_DIR/$i"
+    echo "launching on $DEST_DIR/$i"
+    (
+        export HOST_WORK_DIR="$DEST_DIR/$i"
+        export HOST_UID=$(id -u) HOST_GID=$(id -g)
+
+        docker compose \
+            "${compose_files[@]}" \
+            --project-directory "$REPO_ROOT" \
+            --profile autoprove run --rm autoprove \
+            console-autoprove --cloud /work/ /work/src/Answer.sol:Answer /work/design.md \
+            |& tee "$DEST_DIR/$i/$(basename "$DEST_DIR/$i").log"
+    ) &
+    sleep 2
+done
+wait

--- a/tests/smoketest/design.md
+++ b/tests/smoketest/design.md
@@ -1,0 +1,43 @@
+# Answer — smoke test
+
+This is a deliberately trivial smoke test. The whole point is to exercise the
+autoprove pipeline end-to-end with the smallest possible input, **not** to
+demonstrate creative specification work.
+
+## Contract
+
+`src/Answer.sol` defines one contract, `Answer`, with one function:
+
+```solidity
+function theAnswer() external pure returns (uint256) {
+    return 42;
+}
+```
+
+That's the entire contract. There is nothing else.
+
+## Property to verify
+
+There is exactly **one** property:
+
+- `theAnswer()` always returns `42`.
+
+## Instructions for the autoprove pipeline
+
+Do not extract additional properties. Do not consider edge cases (there
+are none). Do not propose invariants beyond the literal "this function
+returns 42" property. Do not look for security implications, gas
+considerations, or composability concerns — none of those apply here.
+
+The expected output is a CVL spec containing one rule along the lines
+of:
+
+```cvl
+rule theAnswerIs42 {
+    env e;
+    assert theAnswer(e) == 42;
+}
+```
+
+If you find yourself thinking hard about this, you've already gone too
+far.

--- a/tests/smoketest/foundry.toml
+++ b/tests/smoketest/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.21"

--- a/tests/smoketest/src/Answer.sol
+++ b/tests/smoketest/src/Answer.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Answer {
+    function theAnswer() external pure returns (uint256) {
+        return 42;
+    }
+}


### PR DESCRIPTION
## What

Moves the parallel local-run smoke harness — `tests/parallel-test.sh` + `tests/smoketest/`

## Changes

- `tests/parallel-test.sh` — launches 5 concurrent `console-autoprove --cloud` runs against copies of `tests/smoketest/`, retargeted to this repo's single `scripts/docker-compose.yml` (no dev overlays).
- `tests/smoketest/` — the trivial `Answer` sample project (`design.md`, `foundry.toml`, `src/Answer.sol`).

## Notes

Manual harness (requires cloud credentials + a built image); not wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)