### PR TITLE
De-couple composer from AutoSetup's on-disk contract

### DIFF
--- a/certora_autosetup/autosetup/autosetup.py
+++ b/certora_autosetup/autosetup/autosetup.py
@@ -35,7 +35,7 @@ from certora_autosetup.setup.solidity_utils import (
     find_libraries_used_by,
 )
 from certora_autosetup.cache.cache_fs import cache_path, get_fs
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.constants import (
     CERTORA_REPORTS_DIR,
     DIR_CERTORA_INTERNAL,

--- a/certora_autosetup/autosetup/cli.py
+++ b/certora_autosetup/autosetup/cli.py
@@ -21,7 +21,12 @@ from certora_autosetup.setup.sanity_rule_generator import SanityRuleGenerator
 from certora_autosetup.setup.setup_prover import SetupProver
 from certora_autosetup.setup.signature_manager import SignatureManager
 from certora_autosetup.utils.cloud_runner import CloudProverRunner
-from certora_autosetup.utils.constants import CERTORA_REPORTS_DIR, DIR_CERTORA_INTERNAL, FILE_AUTOSETUP_RESULT
+from certora_autosetup.utils.constants import (
+    CERTORA_REPORTS_DIR,
+    DIR_CERTORA_INTERNAL,
+    FILE_AUTOSETUP_RESULT,
+    FILE_LLM_USAGE,
+)
 from certora_autosetup.utils.contract_utils import auto_detect_contracts, deduplicate_contract_handles, parse_contract_files, resolve_contract_handles
 from certora_autosetup.utils.enhanced_config_manager import ConfigManager
 from certora_autosetup.utils.llm_util import LlmUsageReport, ledger_reset
@@ -205,7 +210,7 @@ def main():
     # reports dir, where aggregate_llm_usage merges the per-contract files.
     ledger_rows = result.llm_usage
     reports_dir.mkdir(parents=True, exist_ok=True)
-    (reports_dir / "llm_usage.json").write_text(
+    (reports_dir / FILE_LLM_USAGE).write_text(
         json.dumps(LlmUsageReport.from_rows(ledger_rows).to_dict(), indent=2)
     )
 

--- a/certora_autosetup/autosetup/cli.py
+++ b/certora_autosetup/autosetup/cli.py
@@ -30,7 +30,7 @@ from certora_autosetup.utils.constants import (
 from certora_autosetup.utils.contract_utils import auto_detect_contracts, deduplicate_contract_handles, parse_contract_files, resolve_contract_handles
 from certora_autosetup.utils.enhanced_config_manager import ConfigManager
 from certora_autosetup.utils.llm_util import LlmUsageReport, ledger_reset
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.scope import Scope
 
 

--- a/certora_autosetup/conf_runner/callbacks.py
+++ b/certora_autosetup/conf_runner/callbacks.py
@@ -18,7 +18,7 @@ from certora_autosetup.setup.setup_completeness_checker import SetupCompleteness
 from certora_autosetup.utils.enhanced_config_manager import FileContent, ProverJobSpec
 from certora_autosetup.utils.paths import internal_difficult_retry_dir, internal_multi_assert_dir
 from certora_autosetup.utils.runner_types import ProverResult
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 
 
 COMPONENT = "ConfRunner"

--- a/certora_autosetup/conf_runner/conf_runner.py
+++ b/certora_autosetup/conf_runner/conf_runner.py
@@ -17,7 +17,7 @@ from certora_autosetup.conf_runner.types import ConfRunnerConfig
 from certora_autosetup.reporting.reporter import Reporter
 from certora_autosetup.reporting.json_reporter import JsonReporter
 from certora_autosetup.setup.setup_completeness_checker import SetupCompletenessChecker, SetupCompletenessReport
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.enhanced_config_manager import ConfigManager, FileContent, ProverJobSpec
 from certora_autosetup.utils.prover_runner import ProverRunner
 from certora_autosetup.utils.runner_types import ProverResult

--- a/certora_autosetup/parallel_autosetup.py
+++ b/certora_autosetup/parallel_autosetup.py
@@ -26,6 +26,7 @@ from certora_autosetup.utils.constants import (
     CERTORA_REPORTS_DIR,
     DIR_CERTORA_INTERNAL,
     DIR_WORKTREE_LOGS,
+    FILE_LLM_USAGE,
 )
 from certora_autosetup.utils.llm_util import LlmUsageReport, UsageRow
 from certora_autosetup.utils.logger import logger
@@ -471,7 +472,7 @@ def aggregate_llm_usage(results: list[ContractRunResult], dest: Path) -> None:
         if not result.success:
             logger.warning(f"Skipping llm_usage for failed contract {result.contract_name}", COMPONENT)
             continue
-        usage_path = dest / result.contract_name / "llm_usage.json"
+        usage_path = dest / result.contract_name / FILE_LLM_USAGE
         if not usage_path.exists():
             logger.warning(f"No llm_usage.json for {result.contract_name} at {usage_path}", COMPONENT)
             continue

--- a/certora_autosetup/parsers/base.py
+++ b/certora_autosetup/parsers/base.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 from certora_autosetup.setup.solidity_utils import find_all_solidity_files
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.types import ContractHandle
 
 

--- a/certora_autosetup/parsers/cvl_summary_parser.py
+++ b/certora_autosetup/parsers/cvl_summary_parser.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List
 
 from certora_autosetup.parsers.spec_imports import parse_imports_from_spec
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 
 
 IV_PREFIX = "iv_"

--- a/certora_autosetup/parsers/foundry.py
+++ b/certora_autosetup/parsers/foundry.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional
 from certora_autosetup.build_systems.foundry import FoundryManager
 from certora_autosetup.parsers.base import ContractExtractor
 from certora_autosetup.setup.solidity_utils import find_all_library_files_and_names
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.types import ContractHandle
 
 

--- a/certora_autosetup/parsers/hardhat.py
+++ b/certora_autosetup/parsers/hardhat.py
@@ -14,7 +14,7 @@ from typing import List
 from certora_autosetup.build_systems.hardhat import HardhatManager
 from certora_autosetup.parsers.base import ContractExtractor
 from certora_autosetup.setup.solidity_utils import find_all_library_files_and_names
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.types import ContractHandle
 
 

--- a/certora_autosetup/parsers/spec_imports.py
+++ b/certora_autosetup/parsers/spec_imports.py
@@ -3,7 +3,7 @@ import re
 from collections import deque
 from pathlib import Path
 
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 
 
 def parse_imports_from_spec(spec_path: Path, recursive: bool = True) -> list[Path]:

--- a/certora_autosetup/parsers/type_analyzer.py
+++ b/certora_autosetup/parsers/type_analyzer.py
@@ -12,7 +12,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.types import TypeDescKind, parse_type_desc_kind
 
 

--- a/certora_autosetup/setup/proxy_detection.py
+++ b/certora_autosetup/setup/proxy_detection.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field
 from certora_autosetup.utils.llm_util import _load_anthropic_key, _get_cached_client, default_anthropic_model
 from certora_autosetup.utils.types import ContractHandle
 
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 
 import anthropic
 import anthropic.types

--- a/certora_autosetup/setup/setup_erc7201_patch.py
+++ b/certora_autosetup/setup/setup_erc7201_patch.py
@@ -18,7 +18,7 @@ from typing import Callable, List, Optional, Tuple
 from pydantic import BaseModel, Field
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.llm_util import call_llm_structured, ledger_component
 
 

--- a/certora_autosetup/setup/setup_summaries.py
+++ b/certora_autosetup/setup/setup_summaries.py
@@ -33,7 +33,7 @@ from pydantic import BaseModel, Field, ValidationError, Discriminator
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.contract_utils import split_contract_spec
 from certora_autosetup.cache.cache_fs import cache_path, get_fs
 from certora_autosetup.utils.constants import (

--- a/certora_autosetup/setup/solidity_import_patch.py
+++ b/certora_autosetup/setup/solidity_import_patch.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from shutil import copyfile
 from certora_autosetup.utils.progress_display import make_tqdm
 from certora_autosetup.setup.solidity_utils import DEPENDENCIES, find_all_solidity_files
-from certora_autosetup.utils import logger as _logger
+from certora_autosetup.utils.logger import logger as _logger
 
 PATCH_FILE = ".certora_internal/import_patch.json"
 KNOWN_IMPORT_ROOTS = ["contracts", "src"] + DEPENDENCIES

--- a/certora_autosetup/setup/solidity_utils.py
+++ b/certora_autosetup/setup/solidity_utils.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
-from certora_autosetup.utils import logger as _logger
+from certora_autosetup.utils.logger import logger as _logger
 from certora_autosetup.utils.types import ContractHandle
 
 DEPENDENCIES = [

--- a/certora_autosetup/typechecker_loop.py
+++ b/certora_autosetup/typechecker_loop.py
@@ -18,7 +18,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from certora_autosetup.parsers.prover_config_parser import get_spec_from_verify_field
 from certora_autosetup.parsers.spec_imports import parse_imports_from_spec
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.constants import SUMMARIES_SUBDIR
 from certora_autosetup.utils.paths import internal_round_summaries_dir, internal_typechecker_round_dir
 

--- a/certora_autosetup/utils/__init__.py
+++ b/certora_autosetup/utils/__init__.py
@@ -1,2 +1,1 @@
 # Utils package for PreAudit tools
-from .logger import logger

--- a/certora_autosetup/utils/constants.py
+++ b/certora_autosetup/utils/constants.py
@@ -68,6 +68,7 @@ DIR_SANITY_ANALYSIS = "sanity_analysis"
 DIR_WORKTREE_LOGS = "worktree_logs"
 DIR_PREAUDIT_DEBUG = "preaudit_debug"
 FILE_AUTOSETUP_RESULT = "autosetup_result.json"
+FILE_LLM_USAGE = "llm_usage.json"
 
 # Compiled-scene method inventory emitted under .certora_internal/
 FILE_ALL_METHODS_JSON = "all_methods.json"

--- a/certora_autosetup/utils/contract_utils.py
+++ b/certora_autosetup/utils/contract_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from certora_autosetup.parsers.build_system_detector import BuildSystem, BuildSystemDetector
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 from certora_autosetup.utils.types import ContractHandle
 from certora_autosetup.parsers.foundry import FoundryContractExtractor
 

--- a/certora_autosetup/utils/paths.py
+++ b/certora_autosetup/utils/paths.py
@@ -5,9 +5,12 @@ one well-known artifact. User-facing artifacts live under `certora/`;
 intermediate machinery lives under `.certora_internal/`.
 """
 
+import json
 from pathlib import Path
 
 from certora_autosetup.utils.constants import (
+    CERTORA_REPORTS_DIR,
+    DIR_CERTORA_INTERNAL,
     DIR_INTERNAL_CONFS,
     DIR_INTERNAL_DIFFICULT_RETRY,
     DIR_INTERNAL_MULTI_ASSERT,
@@ -18,9 +21,11 @@ from certora_autosetup.utils.constants import (
     DIR_USER_CONFS,
     DIR_USER_HARNESSES,
     DIR_USER_SPECS,
+    FILE_AUTOSETUP_RESULT,
     FILE_COMPILATION_CONF,
     FILE_COMPILATION_DUMMY_SPEC,
     FILE_ERC7201_SPEC,
+    FILE_LLM_USAGE,
     SUMMARIES_SUBDIR,
 )
 
@@ -90,3 +95,38 @@ def internal_multi_assert_dir(project_root: Path) -> Path:
 
 def internal_difficult_retry_dir(project_root: Path) -> Path:
     return project_root / DIR_INTERNAL_DIFFICULT_RETRY
+
+
+def resolve_autosetup_llm_usage_file(project_root: Path) -> Path | None:
+    """Locate the ``llm_usage.json`` the most recent autosetup run wrote under ``project_root``.
+
+    Primary: read ``orchestration_timestamp`` from ``autosetup_result.json`` and build
+    ``<CERTORA_REPORTS_DIR>/<ts>/llm_usage.json`` — the deterministic inverse of how the CLI names
+    that dir. Fallback (a ``--reports-dir`` override that kept the convention, or an older run): the
+    newest timestamped subdir holding a ``llm_usage.json``. Timestamps are ``%Y%m%d_%H%M%S``, so a
+    plain lexicographic max picks the most recent. Returns ``None`` if nothing is found.
+
+    This is the single source of truth for the on-disk usage-file layout; external consumers (e.g.
+    composer) should call it rather than re-deriving these paths.
+    """
+    reports_root = project_root / CERTORA_REPORTS_DIR
+
+    result_path = project_root / DIR_CERTORA_INTERNAL / FILE_AUTOSETUP_RESULT
+    try:
+        timestamp = json.loads(result_path.read_text()).get("orchestration_timestamp")
+    except (OSError, ValueError):
+        timestamp = None
+    if timestamp:
+        candidate = reports_root / timestamp / FILE_LLM_USAGE
+        if candidate.exists():
+            return candidate
+
+    try:
+        subdirs = sorted((d for d in reports_root.iterdir() if d.is_dir()), key=lambda d: d.name)
+    except OSError:
+        return None
+    for d in reversed(subdirs):
+        candidate = d / FILE_LLM_USAGE
+        if candidate.exists():
+            return candidate
+    return None

--- a/certora_autosetup/utils/signal_handler.py
+++ b/certora_autosetup/utils/signal_handler.py
@@ -11,7 +11,7 @@ import sys
 from typing import Callable
 
 from certora_autosetup.conf_runner import ConfRunner
-from certora_autosetup.utils import logger
+from certora_autosetup.utils.logger import logger
 
 
 COMPONENT = "SignalHandler"

--- a/composer/spec/source/autosetup.py
+++ b/composer/spec/source/autosetup.py
@@ -20,6 +20,8 @@ from composer.prover.core import ProverOptions
 
 from graphcore.utils import TokenUsageDict
 from composer.io.context import emit_custom_event
+# Locator for autosetup's on-disk llm_usage.json (certora_autosetup owns that layout).
+from certora_autosetup.utils.paths import resolve_autosetup_llm_usage_file
 
 _logger = logging.getLogger(__name__)
 
@@ -235,10 +237,6 @@ def read_autosetup_usage(project_root: Path) -> list[TokenUsageDict]:
     crash, replayed snapshot, or an AutoSetup too old to emit it — or malformed
     JSON): missing external usage must never break the phase.
     """
-    # Local import: importing certora_autosetup.utils at module load would instantiate its logger
-    # singleton (a RotatingFileHandler) as a side effect. This runs only at runtime, so import here.
-    from certora_autosetup.utils.paths import resolve_autosetup_llm_usage_file
-
     usage_file = resolve_autosetup_llm_usage_file(project_root)
     if usage_file is None:
         return []

--- a/composer/spec/source/autosetup.py
+++ b/composer/spec/source/autosetup.py
@@ -237,7 +237,6 @@ def read_autosetup_usage(project_root: Path) -> list[TokenUsageDict]:
     """
     # Local import: importing certora_autosetup.utils at module load would instantiate its logger
     # singleton (a RotatingFileHandler) as a side effect. This runs only at runtime, so import here.
-    # (Not a cycle — certora_autosetup never imports composer.)
     from certora_autosetup.utils.paths import resolve_autosetup_llm_usage_file
 
     usage_file = resolve_autosetup_llm_usage_file(project_root)

--- a/composer/spec/source/autosetup.py
+++ b/composer/spec/source/autosetup.py
@@ -209,49 +209,8 @@ async def run_autosetup(
 # --- AutoSetup LLM token-usage ingestion -----------------------------------
 # AutoSetup runs as a separate process, so its LLM calls never pass through
 # composer's model factory and are invisible to the UsageCallback. Its only
-# trace is the llm_usage.json it writes to disk. These names are AutoSetup's
-# on-disk contract (certora_autosetup constants + the autosetup_result.json it
-# drops in .certora_internal); we hard-code them rather than import
-# certora_autosetup, which composer must not depend on at import time.
-# TODO: improve this once the repos are merged.
-_CERTORA_INTERNAL = ".certora_internal"
-_AUTOSETUP_RESULT_FILE = "autosetup_result.json"
-_REPORTS_DIR = ".CertoraProverLiteReports"
-_LLM_USAGE_FILE = "llm_usage.json"
-
-
-def _resolve_autosetup_usage_file(project_root: Path) -> Path | None:
-    """Locate the ``llm_usage.json`` AutoSetup wrote for the most recent run.
-
-    Primary: read ``orchestration_timestamp`` from ``autosetup_result.json`` and
-    build ``.CertoraProverLiteReports/<ts>/llm_usage.json`` — the deterministic
-    inverse of how AutoSetup names that dir. Fallback (older AutoSetup, or a
-    ``--reports-dir`` override that kept the convention): the newest timestamped
-    subdir holding an ``llm_usage.json``. Timestamps are ``%Y%m%d_%H%M%S``, so a
-    plain lexicographic max picks the most recent. Returns ``None`` if nothing
-    is found.
-    """
-    reports_root = project_root / _REPORTS_DIR
-
-    result_path = project_root / _CERTORA_INTERNAL / _AUTOSETUP_RESULT_FILE
-    try:
-        timestamp = json.loads(result_path.read_text()).get("orchestration_timestamp")
-    except (OSError, ValueError):
-        timestamp = None
-    if timestamp:
-        candidate = reports_root / timestamp / _LLM_USAGE_FILE
-        if candidate.exists():
-            return candidate
-
-    try:
-        subdirs = sorted((d for d in reports_root.iterdir() if d.is_dir()), key=lambda d: d.name)
-    except OSError:
-        return None
-    for d in reversed(subdirs):
-        candidate = d / _LLM_USAGE_FILE
-        if candidate.exists():
-            return candidate
-    return None
+# trace is the llm_usage.json it writes to disk. certora_autosetup owns that
+# on-disk layout and exposes resolve_autosetup_llm_usage_file() to locate it.
 
 
 def _to_token_usage(model: str, bucket: dict) -> TokenUsageDict:
@@ -276,7 +235,12 @@ def read_autosetup_usage(project_root: Path) -> list[TokenUsageDict]:
     crash, replayed snapshot, or an AutoSetup too old to emit it — or malformed
     JSON): missing external usage must never break the phase.
     """
-    usage_file = _resolve_autosetup_usage_file(project_root)
+    # Local import: importing certora_autosetup.utils at module load would instantiate its logger
+    # singleton (a RotatingFileHandler) as a side effect. This runs only at runtime, so import here.
+    # (Not a cycle — certora_autosetup never imports composer.)
+    from certora_autosetup.utils.paths import resolve_autosetup_llm_usage_file
+
+    usage_file = resolve_autosetup_llm_usage_file(project_root)
     if usage_file is None:
         return []
     try:


### PR DESCRIPTION
Resolves the `composer/spec/source/autosetup.py` `TODO: improve this once the repos are merged`.

composer hard-coded AutoSetup's output layout (`.certora_internal`, `autosetup_result.json`, `.CertoraProverLiteReports`, `llm_usage.json`) and re-derived the usage-file path. Now that `certora_autosetup` lives in this repo, it becomes the single source of truth.
