### PR TITLE
End to End Integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,6 +28,13 @@ jobs:
           cache-dependency-glob: "uv.lock"
           cache-suffix: integration
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'certora'
+
       - name: sync-deps
         run: |
           uv sync --group test --extra prover
@@ -53,6 +60,6 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           curl -sf -X POST -H 'Content-type: application/json' \
             --data "{
-              \"text\": \":red_circle: *Composer integration tests failed* in \`${{ github.repository }}\`\n<${RUN_URL}|View the failed run>\"
+              \"text\": \":red_circle: *AutoProver integration tests failed* in \`${{ github.repository }}\`\n<${RUN_URL}|View the failed run>\"
             }" \
             "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,9 +49,13 @@ jobs:
           uv run solc-select install 0.8.29
           uv run solc-select use 0.8.29
 
-      - name: run prover integration tests
+      - name: async runners
+        name: |
+          uv pip install pytest-xdist
+
+      - name: run autoprover integration tests
         run: |
-          uv run pytest -m 'expensive' tests -k test_autoprove_integration
+          uv run pytest -n 3 -m 'expensive' tests
         env:
           CERTORAKEY: ${{ secrets.CERTORAKEY }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   schedule:
-    - cron: '7 3 * * *'
+    - cron: '7 5 * * *'
   workflow_dispatch: {}   # adds a "Run workflow" button in the Actions tab
 
 # If a manual run and a scheduled run overlap, cancel the older one

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: run prover integration tests
         run: |
-          uv run pytest -m 'expensive' tests
+          uv run pytest -m 'expensive' tests -k test_autoprove_integration
         env:
           CERTORAKEY: ${{ secrets.CERTORAKEY }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '7 3 * * *'
   workflow_dispatch: {}   # adds a "Run workflow" button in the Actions tab
-
-on:
   push:
     branches: [ main, master ]
   pull_request:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,13 @@ on:
     - cron: '7 3 * * *'
   workflow_dispatch: {}   # adds a "Run workflow" button in the Actions tab
 
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+
 # If a manual run and a scheduled run overlap, cancel the older one
 # so you don't pay for the expensive job twice.
 concurrency:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
           uv run solc-select use 0.8.29
 
       - name: async runners
-        name: |
+        run: |
           uv pip install pytest-xdist
 
       - name: run autoprover integration tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'certora'
+          cache: 'maven'
 
       - name: sync-deps
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'maven'
 
       - name: sync-deps
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,8 +46,8 @@ jobs:
       - name: sync solc
         run: |
           uv pip install solc-select
-          uv run solc-select install 0.8.19
-          uv run solc-select use 0.8.19
+          uv run solc-select install 0.8.29
+          uv run solc-select use 0.8.29
 
       - name: run prover integration tests
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '7 3 * * *'
   workflow_dispatch: {}   # adds a "Run workflow" button in the Actions tab
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
-
 
 # If a manual run and a scheduled run overlap, cancel the older one
 # so you don't pay for the expensive job twice.
@@ -61,7 +56,7 @@ jobs:
 
       # Fires ONLY if a step above failed. The whole point of the file.
       - name: Notify Slack on failure
-        if: false
+        if: failure()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |

--- a/composer/input/files.py
+++ b/composer/input/files.py
@@ -233,22 +233,32 @@ class FileUploader:
     filename) so callers pass a single handle through the upload
     pipeline instead of threading ``(client, uploaded_files)`` pairs.
 
-    Construct via :meth:`fresh`; it creates an async client and seeds
-    the cache from the live Files API listing so duplicate uploads are
-    skipped on subsequent calls."""
+    Construct via :meth:`fresh`; the dedup cache is seeded lazily from the
+    live Files API listing on the first upload (see :meth:`_ensure_seeded`),
+    so a run that only inlines text documents never lists files."""
 
     client: anthropic.AsyncAnthropic
-    uploaded: dict[str, str] = field(default_factory=dict)
+    #: ``None`` until the first upload seeds it from the Files-API listing.
+    uploaded: dict[str, str] | None = None
+    #: Guards the one-time seed against concurrent first uploads.
+    _seed_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     @staticmethod
     async def fresh() -> "FileUploader":
-        """Build a fresh ``FileUploader`` with the cache seeded from the
-        account's existing Files-API uploads."""
-        client = anthropic.AsyncAnthropic()
-        uploaded: dict[str, str] = {}
-        async for f in await client.beta.files.list():
-            uploaded[f.filename] = f.id
-        return FileUploader(client=client, uploaded=uploaded)
+        """Build a fresh ``FileUploader``. Constructs the async client but makes
+        no network call — the existing-uploads cache is seeded on first upload."""
+        return FileUploader(client=anthropic.AsyncAnthropic())
+
+    async def _ensure_seeded(self) -> dict[str, str]:
+        """Seed the dedup cache from the account's existing Files-API uploads on
+        first use, then return it. Guarded so concurrent first uploads list once."""
+        async with self._seed_lock:
+            if self.uploaded is None:
+                seeded: dict[str, str] = {}
+                async for f in await self.client.beta.files.list():
+                    seeded[f.filename] = f.id
+                self.uploaded = seeded
+            return self.uploaded
 
     async def _upload_raw(
         self, file_path: str | pathlib.Path
@@ -268,14 +278,15 @@ class FileUploader:
         raw, crc_hex = await asyncio.to_thread(_read_and_crc)
         digest = _bytes_digest(raw)
         crc_basename = f"{crc_hex}_{basename}"
-        if crc_basename not in self.uploaded:
+        uploaded = await self._ensure_seeded()
+        if crc_basename not in uploaded:
             mime = await _upload_mime(file_path)
             uploaded_file = await self.client.beta.files.upload(
                 file=(crc_basename, open(file_path, "rb"), mime)
             )
-            self.uploaded[crc_basename] = uploaded_file.id
+            uploaded[crc_basename] = uploaded_file.id
             return uploaded_file.id, basename, raw, digest
-        return self.uploaded[crc_basename], basename, raw, digest
+        return uploaded[crc_basename], basename, raw, digest
 
     async def upload_file_if_needed(
         self, file_path: str | pathlib.Path

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -401,6 +401,11 @@ async def run_prover(
 
     # 1. Build effective args. extra_args is already fully resolved by make_prover_options.
     effective_args = args + prover_opts.extra_args
+    # On the cloud path we poll for results ourselves (step 7), so certoraRun must submit and return
+    # the link rather than block on the verdict. certoraRun force-enables wait_for_results when it
+    # detects GITHUB_ACTION in the environment, which would deadlock against that polling — pin it off.
+    if prover_opts.cloud and "--wait_for_results" not in effective_args:
+        effective_args = effective_args + ["--wait_for_results", "none"]
 
     # 2. Notify callback
     await callbacks.on_prover_run(effective_args)

--- a/composer/spec/source/autoprove_common.py
+++ b/composer/spec/source/autoprove_common.py
@@ -111,14 +111,24 @@ async def _entry_point(summary: RunSummary) -> AsyncIterator[Executor]:
     parser.add_argument("--max-bug-rounds", type=int, default=3, help="Maximum number of bug-extraction rounds run per component during property analysis (default: 3)")
 
     args = cast(AutoProveArgs, parser.parse_args())
+    async with autoprove_executor(args, summary) as runner:
+        yield runner
 
+
+@asynccontextmanager
+async def autoprove_executor(args: AutoProveArgs, summary: RunSummary) -> AsyncIterator[Executor]:
+    """Set up services from already-parsed args and yield the pipeline runner.
+
+    ``_entry_point`` parses argv into ``AutoProveArgs`` then delegates here; tests
+    construct ``AutoProveArgs`` directly.
+    """
     # Parse main_contract (path:ContractName)
     project_root = pathlib.Path(args.project_root).resolve()
     main_contract_path, contract_name = args.main_contract.split(":", 1)
 
     full_contract_path = pathlib.Path(main_contract_path).resolve()
     if not full_contract_path.is_relative_to(project_root):
-        parser.error(f"Invalid path: {full_contract_path} doesn't appear in project root {project_root}")
+        raise ValueError(f"Invalid path: {full_contract_path} doesn't appear in project root {project_root}")
 
     relative_path = str(full_contract_path.relative_to(project_root))
 
@@ -164,7 +174,7 @@ async def _entry_point(summary: RunSummary) -> AsyncIterator[Executor]:
         # Read input documents now that the uploader is available.
         content = await conns.uploader.get_document(sys_path)
         if content is None:
-            parser.error(f"cannot read {sys_path}")
+            raise ValueError(f"cannot read {sys_path}")
 
         system_doc = ProverSourceCode(
             content=content,

--- a/composer/spec/source/common_pipeline.py
+++ b/composer/spec/source/common_pipeline.py
@@ -28,6 +28,7 @@ from composer.spec.source.artifacts import ComponentSpec, InvariantSpec, ProverS
 from composer.spec.source.task_ids import (
     bug_analysis_task_id, cvl_gen_task_id, REPORT_TASK_ID,
 )
+from composer.spec.source.report import build as report_build
 from composer.spec.source.report.build import build_report
 from composer.spec.source.report.collect import ReportComponentInput
 from composer.spec.source.report_prover import make_prover_fetcher
@@ -258,6 +259,8 @@ async def generate_all_component_cvl(
         if report is not None:
             store.write_report(report)
     except Exception:
+        if report_build.RERAISE_REPORT_FAILURES:
+            raise
         _log.warning("autoprove report phase failed (continuing)", exc_info=True)
 
     failures: list[str] = []

--- a/composer/spec/source/report/build.py
+++ b/composer/spec/source/report/build.py
@@ -25,6 +25,15 @@ from composer.spec.source.report.schema import (
 
 _log = logging.getLogger(__name__)
 
+#: Test escape hatch. When True, a report-phase failure re-raises instead of being
+#: absorbed (the grouping fallback here, and the best-effort guard around the whole
+#: phase in common_pipeline). Production/manual-harness runs leave this False so a
+#: degraded grouping never fails the run; a harness test flips it on so a broken
+#: tape (missing/mis-keyed ``report`` lane) fails loudly instead of silently
+#: exercising the fallback path. Read as a live module attribute — set it via the
+#: module, not a by-value import.
+RERAISE_REPORT_FAILURES = False
+
 
 async def build_report[R: ReportableResult](
     *,
@@ -59,6 +68,8 @@ async def build_report[R: ReportableResult](
         if properties and not grouped:
             raise ValidationError("grouping produced no high-level properties")
     except Exception as e:  # noqa: BLE001 — any LLM/transport/validation error degrades
+        if RERAISE_REPORT_FAILURES:
+            raise
         fallback_reason = (
             f"validation rejected the grouping: {e}" if isinstance(e, ValidationError)
             else f"grouping failed: {e}"

--- a/composer/testing/harness_tape.py
+++ b/composer/testing/harness_tape.py
@@ -67,6 +67,8 @@ class HarnessFakeLLM(FakeMessagesListChatModel):
     # task_id -> next index. Mutated in place; each instance owns its own dict.
     lane_cursors: dict[str, int] = Field(default_factory=dict, exclude=True)
 
+    with_human_delay: bool = Field(default=True)
+
     @override
     def bind_tools(
         self,
@@ -87,7 +89,8 @@ class HarnessFakeLLM(FakeMessagesListChatModel):
         **kwargs: Any
     ) -> AIMessage:
         # Simulate LLM latency to keep the TUI from filling all at once to give some ability to judge the "feel" of the UI.
-        await asyncio.sleep(random.random() * 1.5 + 1.0)
+        if self.with_human_delay:
+            await asyncio.sleep(random.random() * 1.5 + 1.0)
 
         task_id = get_current_task_id()
         if task_id is None:

--- a/composer/testing/ui_harness_autoprove_Counter.py
+++ b/composer/testing/ui_harness_autoprove_Counter.py
@@ -55,6 +55,9 @@ so their responses live in the parent's lane.
     cvl-0-Increment  : batch_cvl_generation, component=<one>
                         (+ feedback ×1, CEX ×1 — surfaces the real
                         ``incrementOther`` implementation bug)
+    ── final, best-effort report phase ──
+    report           : build_report → call_grouping_llm (one structured-output
+                        call partitioning the formalized properties into groups)
 
     Per-component lanes are ``{bug,cvl}-{component index}-{slugified_name}``;
     here the Counter's sole component is "Increment".
@@ -66,7 +69,7 @@ import uuid
 from composer.testing.harness_tape import HarnessFakeLLM
 from composer.spec.source.task_ids import (
     SYSTEM_ANALYSIS_TASK_ID, HARNESS_TASK_ID, INVARIANTS_TASK_ID,
-    INVARIANT_CVL_TASK_ID, bug_analysis_task_id, cvl_gen_task_id,
+    INVARIANT_CVL_TASK_ID, REPORT_TASK_ID, bug_analysis_task_id, cvl_gen_task_id,
 )
 
 from langchain_core.messages import AIMessage, BaseMessage
@@ -236,6 +239,7 @@ _APP_RESULT = {
                 "The only contract in the system; owns the count and per-"
                 "caller tally state and the two increment entry points."
             ),
+            "solidity_identifier": "Counter",
             "components": [
                 {
                     "name": "Increment",
@@ -290,6 +294,7 @@ _CLASSIFIER_RESULT = {
             "name": "Counter",
             "link_fields": [],
             "num_instances": None,
+            "solidity_identifier": "Counter"
         }
     ],
     "erc20_contracts": [],
@@ -1153,78 +1158,6 @@ _BUG_TAPE: list[BaseMessage] = [
         ),
     ),
 
-    # ───────────────────────────────────────────────────────────────────
-    # P5b. Interactive refinement conversation (only when --interactive)
-    # ───────────────────────────────────────────────────────────────────
-    # ``run_bug_analysis`` enters ``refinement_loop`` once
-    # ``interactive=True``. The conversation graph has its own thread,
-    # its own tools (``env.source_tools`` + ``finalize_properties`` +
-    # ``update_requirements``), and is driven by stdin via
-    # ``RichConsoleConversationClient`` (see
-    # ``composer/ui/conversation_client.py``).
-    #
-    # The flow is interrupt-driven:
-    #   chat_node → interrupt(HumanPrompt)  →  outer loop reads stdin
-    #     →  resume with HumanMessage  →  llm_echo (TAPE ENTRY)
-    #     →  (optional) tools  →  llm_echo (TAPE ENTRY)
-    #     →  ... back to chat_node, repeat
-    #   until the LLM calls ``finalize_properties`` (Exit) which raises
-    #   ``interrupt(EndConversation())`` from inside the tools node.
-    #
-    # Every AI message below tags the expected human reply with
-    # ``[TAPE EXPECTATION: respond '...']``. The harness operator types
-    # that reply into the prompt-toolkit prompt to advance the tape. The
-    # tape entries below are popped one per ``llm_echo`` invocation.
-
-    # P5b.1 — first AI turn after the user's opening prompt. The expected
-    # opening from the user is a question about the property list. The AI
-    # answers conversationally with NO tool call, so control returns to
-    # ``chat_node`` for the next human turn.
-    _ai(
-        "Sure — property 1 and property 2 cover the obvious behavior of "
-        "``increment()``: it adds 1 to ``count`` and 1 to "
-        "``increments[msg.sender]``. Property 3 is about "
-        "``incrementOther(other)``: the function name suggests it credits "
-        "a different address, so the matching post-condition is "
-        "``increments[other]`` goes up by 1. I haven't tried to prove "
-        "any of these yet — they're just what the surface contract "
-        "promises."
-    ),
-
-    # P5b.2 — second AI turn: the user has asked for a rewording of
-    # property 3. The AI calls ``update_requirements`` with the full
-    # refined list. SetRequirements injects the new list into
-    # ``state["extra_data"]`` via a Command and the state-diff renderer
-    # fires.
-    _ai(
-        "Got it — I'll tighten property 3 to call out both the move and "
-        "the non-move, conditioned on ``other != msg.sender``. Updating "
-        "now.",
-        _tc(
-            "update_requirements",
-            new_requirements=_REFINED_BUG_ANALYSIS_PROPS,
-        ),
-    ),
-
-    # P5b.3 — after ``update_requirements`` returns, llm_echo fires again.
-    # The AI yields control back to the user (no tool calls) so they can
-    # approve.
-    _ai(
-        "Updated. Property 3 now reads: \"After calling "
-        "incrementOther(other) with other != msg.sender, "
-        "increments[other] must increase by exactly 1 and "
-        "increments[msg.sender] must be unchanged.\" The first two are "
-        "untouched."
-    ),
-
-    # P5b.4 — user has signaled finalization. The AI calls
-    # ``finalize_properties`` (Exit) which raises
-    # ``interrupt(EndConversation())`` from inside the tools node; the
-    # outer loop catches it and exits the refinement context.
-    _ai(
-        "Finalizing the refined property list.",
-        _tc("finalize_properties"),
-    ),
 
     # ───────────────────────────────────────────────────────────────────
     # P6. Component CVL generation (batch_cvl_generation, component=<one>)
@@ -1394,6 +1327,61 @@ _CVL_TAPE: list[BaseMessage] = [
 ]
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# P7. Report grouping (build_report → call_grouping_llm)
+# ───────────────────────────────────────────────────────────────────────────
+# The final, best-effort phase. ``call_grouping_llm`` makes ONE structured-output
+# call (``llm.with_structured_output(GroupingResult)``), so this lane has exactly
+# one entry: an AIMessage whose ``GroupingResult`` tool call (the tool name is the
+# pydantic model's class name) partitions every formalized property into groups.
+#
+# The five formalized properties this run produces (component, title):
+#   ("Increment", count_increments_by_one / sender_increments_by_one /
+#    other_increments_by_one)  +  ("Structural Invariants",
+#    increments_sum_is_count / zero_address_is_zero).
+# ``coverage.validate`` requires each appear in exactly one group, so the two
+# groups below must cover all five with no overlap or omission. Without this lane
+# the call raised ``no tape lane``, which ``build_report`` swallows into its
+# fallback single-bucket grouping — so the report path ran but the grouping step
+# was never actually exercised.
+
+_REPORT_TAPE: list[BaseMessage] = [
+    _ai(
+        "Partitioning the formalized properties into high-level claims.",
+        _tc(
+            "GroupingResult",
+            groups=[
+                {
+                    "slug": "increment-accounting",
+                    "title": "Increment entry points update counters by exactly one",
+                    "description": (
+                        "Each increment operation advances the global counter and the "
+                        "relevant per-address tally by exactly one."
+                    ),
+                    "members": [
+                        ["Increment", "count_increments_by_one"],
+                        ["Increment", "sender_increments_by_one"],
+                        ["Increment", "other_increments_by_one"],
+                    ],
+                },
+                {
+                    "slug": "counter-structural-invariants",
+                    "title": "Counter state respects its structural invariants",
+                    "description": (
+                        "The global counter stays consistent with the sum of the per-address "
+                        "tallies and the zero address is never credited."
+                    ),
+                    "members": [
+                        ["Structural Invariants", "increments_sum_is_count"],
+                        ["Structural Invariants", "zero_address_is_zero"],
+                    ],
+                },
+            ],
+        ),
+    ),
+]
+
+
 # The tape, as a per-phase lane map keyed by run_task task_id. HarnessFakeLLM
 # serves each LLM call from its lane's cursor, so the scripted responses stay
 # correct even though the pipeline runs phases concurrently. The Counter
@@ -1405,6 +1393,7 @@ _AUTOPROVE_TAPE: dict[str, list[BaseMessage]] = {
     INVARIANT_CVL_TASK_ID: _INVARIANT_CVL_TAPE,
     bug_analysis_task_id(0, "Increment"): _BUG_TAPE,
     cvl_gen_task_id(0, "Increment"): _CVL_TAPE,
+    REPORT_TASK_ID: _REPORT_TAPE,
 }
 
 
@@ -1418,16 +1407,16 @@ _AUTOPROVE_TAPE: dict[str, list[BaseMessage]] = {
 # ``run_task`` task_id, and within a lane responses are consumed in order.
 
 
-def get_autoprove_Counter_llm() -> HarnessFakeLLM:
+def get_autoprove_Counter_llm(with_delay: bool = True) -> HarnessFakeLLM:
     """Return a fresh fake LLM loaded with the autoprove counter tape.
 
     Each call returns an independent instance with its own per-lane cursors, so
     tests can run multiple scenarios without cross-contamination.
     """
-    return HarnessFakeLLM(lanes=_AUTOPROVE_TAPE)
+    return HarnessFakeLLM(lanes=_AUTOPROVE_TAPE, with_human_delay=with_delay)
 
 
-def install_harness_tape() -> HarnessFakeLLM:
+def install_harness_tape(with_delay: bool = True) -> HarnessFakeLLM:
     """Monkey-patch ``composer.workflow.services.create_llm`` and
     ``create_llm_base`` so the real autoprove pipeline receives the fake.
 
@@ -1441,7 +1430,7 @@ def install_harness_tape() -> HarnessFakeLLM:
     Returns the fake instance so the caller can inspect ``.i`` /
     ``.responses`` for debugging.
     """
-    fake = get_autoprove_Counter_llm()
+    fake = get_autoprove_Counter_llm(with_delay)
     import composer.spec.agent_index as a_ind
     a_ind._UNSAFE_DISABLE_CACHE = True
 

--- a/tests/test_autoprove_integration.py
+++ b/tests/test_autoprove_integration.py
@@ -61,8 +61,11 @@ _SUMMARIES_REL = "specs/summaries/Counter_base_summaries.spec"
 
 
 async def _fake_autosetup_phase(*_args, **_kwargs) -> SetupSuccess:
-    """Stand in for the AutoSetup subprocess, which makes its own un-tapeable LLM
-    calls. Writes out the (trivial, no-op) summaries spec the generated CVL imports
+    """Stand in for the AutoSetup subprocess, which makes its LLM
+    calls that we, in autoprover land, aren't going to start taping.
+    It is also not an intersting unit of test for this workflow, so just use the
+    trivial, precomputed setups.
+    Writes out the (trivial, no-op) summaries spec the generated CVL imports
     against, then returns the config AutoSetup would have produced for Counter."""
     summaries = _SCENARIO / "certora" / _SUMMARIES_REL
     summaries.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_autoprove_integration.py
+++ b/tests/test_autoprove_integration.py
@@ -52,7 +52,7 @@ _COUNTER_PROVER_CONFIG = {
     "parametric_contracts": "Counter",
     "prover_args": ["-quiet"],
     "run_source": "AUTO_PROVER",
-    "solc": "solc8.29",
+    "solc": "solc",
     "verify": "Counter:certora/specs/sanity-Counter.spec",
     "wait_for_results": "none",
 }

--- a/tests/test_autoprove_integration.py
+++ b/tests/test_autoprove_integration.py
@@ -1,0 +1,192 @@
+"""End-to-end integration test for the autoprove pipeline.
+
+The LLM is mocked — the hand-authored Counter tape, installed via
+``install_harness_tape`` (which also disables the agent-index cache) — and so is
+AutoSetup, which makes its own LLM calls inside a subprocess and so can't be
+taped; ``_fake_autosetup_phase`` returns a canned ``SetupSuccess`` for Counter.
+Everything else runs for real: Postgres (checkpoint / store / memory) in a
+testcontainer and the live Certora cloud prover. Given the deterministic tape +
+fixed spec/code, the prover is reasonably deterministic. Pass/fail is simply: the
+pipeline runs start to finish without raising.
+
+Marked ``expensive`` (live cloud prover + containers + the embedding model load)
+and skipped without testcontainers. Run with ``-m expensive``.
+"""
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast, TYPE_CHECKING
+
+import psycopg
+import pytest
+from psycopg.sql import SQL, Identifier, Literal
+
+import composer.workflow.services as services
+from composer.diagnostics.timing import RunSummary
+from composer.spec.source.autoprove_common import autoprove_executor, AutoProveArgs
+from composer.spec.source.autosetup import SetupSuccess
+from composer.ui.autoprove_console import AutoProveConsoleHandler
+from composer.testing.ui_harness_autoprove_Counter import install_harness_tape
+
+if TYPE_CHECKING:
+    from testcontainers.postgres import PostgresContainer
+
+
+from tests.conftest import needs_postgres, MockSentenceTransformer
+
+pytestmark = [pytest.mark.expensive, needs_postgres, pytest.mark.asyncio]
+
+_SCENARIO = Path(__file__).parent.parent / "test_scenarios" / "autoprove_counter"
+_RAG_DB = "rag_db"
+# DBs that hold pgvector embeddings and need the extension (the store role's DB
+# + the RAG DB); checkpoint/memory are plain.
+_VECTOR_DBS = ("langgraph_store_db", _RAG_DB)
+
+# The config AutoSetup produced for Counter on a local run (its outputs aren't
+# checked in). DummyERC20Impl is dropped — Counter is standalone and the mock
+# generated against it doesn't ship. ``verify`` is overlaid per-spec by
+# ``prover_config_overlay`` at run time, so it need not name a spec that exists.
+_COUNTER_PROVER_CONFIG = {
+    "assert_autofinder_success": True,
+    "files": ["src/Counter.sol"],
+    "global_timeout": "1200",
+    "parametric_contracts": "Counter",
+    "prover_args": ["-quiet"],
+    "run_source": "AUTO_PROVER",
+    "solc": "solc8.29",
+    "verify": "Counter:certora/specs/sanity-Counter.spec",
+    "wait_for_results": "none",
+}
+# AutoSetup's summaries spec, relative to certora/ (the SetupSuccess contract).
+_SUMMARIES_REL = "specs/summaries/Counter_base_summaries.spec"
+
+
+async def _fake_autosetup_phase(*_args, **_kwargs) -> SetupSuccess:
+    """Stand in for the AutoSetup subprocess, which makes its own un-tapeable LLM
+    calls. Writes out the (trivial, no-op) summaries spec the generated CVL imports
+    against, then returns the config AutoSetup would have produced for Counter."""
+    summaries = _SCENARIO / "certora" / _SUMMARIES_REL
+    summaries.parent.mkdir(parents=True, exist_ok=True)
+    summaries.write_text(
+        "// Auto-generated base summaries for Counter\n// No summaries needed for Counter\n"
+    )
+    return SetupSuccess(
+        prover_config=dict(_COUNTER_PROVER_CONFIG),
+        summaries_path=_SUMMARIES_REL,
+        user_types=[],
+    )
+
+# graphcore's Postgres memory backend doesn't self-create its schema; this mirrors
+# the memories_fs DDL in graphcore/tests/conftest.py (keep in sync if that moves).
+_MEMORIES_DDL = """
+CREATE TABLE IF NOT EXISTS memories_fs(
+    namespace TEXT NOT NULL,
+    entry_name TEXT NOT NULL,
+    full_path TEXT,
+    parent_path TEXT,
+    is_directory BOOL NOT NULL,
+    contents TEXT,
+    FOREIGN KEY(parent_path, namespace) REFERENCES memories_fs(full_path, namespace) ON DELETE CASCADE,
+    UNIQUE (namespace, full_path),
+    UNIQUE (namespace, parent_path, entry_name),
+    CHECK (parent_path is NOT NULL OR (full_path = '/memories' AND is_directory AND entry_name = 'memories')),
+    CHECK (parent_path is NULL OR (full_path = concat(parent_path, '/', entry_name))),
+    CHECK (contents IS NOT NULL != is_directory)
+);
+CREATE INDEX IF NOT EXISTS memories_namespace_path ON memories_fs(namespace, full_path text_pattern_ops);
+"""
+
+
+def _db_url(pg: "PostgresContainer", database: str) -> str:
+    return (
+        f"postgresql://{pg.username}:{pg.password}"
+        f"@{pg.get_container_host_ip()}:{pg.get_exposed_port(5432)}/{database}"
+    )
+
+
+def _make_args(rag_conn: str) -> AutoProveArgs:
+    """Hand-built ``AutoProveArgs`` (the CLI path builds this via argparse)."""
+    return cast(AutoProveArgs, SimpleNamespace(
+        project_root=str(_SCENARIO),
+        main_contract=f"{_SCENARIO / "src/Counter.sol"}:Counter",
+        system_doc=str(_SCENARIO / "system.md"),
+        max_concurrent=4,
+        cache_ns=None,
+        memory_ns=None,
+        cloud=True,
+        interactive=False,
+        threat_model=None,
+        recursion_limit=100,
+        max_bug_rounds=1,
+        rag_db=rag_conn,
+        # Model-config fields: only read through ``llm_factory(args)``, which the
+        # tape patches to ignore args, so the values are inert — present to satisfy
+        # the AutoProveArgs surface.
+        heavy_model="fake-heavy",
+        lite_model="fake-lite",
+        tokens=128_000,
+        thinking_tokens=2048,
+        memory_tool=False,
+        interleaved_thinking=False,
+    ))
+
+async def test_autoprove_counter_runs_end_to_end(pg_container: "PostgresContainer", monkeypatch):
+    assert _SCENARIO.is_dir(), _SCENARIO
+
+    # 1. Give the container the roles + databases the pipeline expects, matching
+    #    the hardcoded creds in services._DATABASE_CONFIGS (a login role owning its
+    #    own DB) — so the real connection-string path works unpatched.
+    admin_url = pg_container.get_connection_url(driver=None)
+    with psycopg.connect(admin_url, autocommit=True) as admin:
+        for cfg in services._DATABASE_CONFIGS.values():
+            admin.execute(SQL("CREATE ROLE {} LOGIN PASSWORD {}").format(
+                Identifier(cfg["user"]), Literal(cfg["password"])))
+            admin.execute(SQL("CREATE DATABASE {} OWNER {}").format(
+                Identifier(cfg["database"]), Identifier(cfg["user"])))
+        admin.execute(SQL("CREATE DATABASE {}").format(Identifier(_RAG_DB)))
+    # pgvector must be installed by a superuser, so do it on the admin connection.
+    for db in _VECTOR_DBS:
+        with psycopg.connect(_db_url(pg_container, db), autocommit=True) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    # The memory backend doesn't self-create its schema (the checkpointer/store do,
+    # via .setup()), so create memories_fs as the memory role (its DB owner).
+    mem = services._DATABASE_CONFIGS["memory"]
+    mem_url = (
+        f"postgresql://{mem['user']}:{mem['password']}"
+        f"@{pg_container.get_container_host_ip()}:{pg_container.get_exposed_port(5432)}/{mem['database']}"
+    )
+    with psycopg.connect(mem_url, autocommit=True) as conn:
+        conn.execute(_MEMORIES_DDL)
+
+    # 2. Only host/port need redirecting — the role creds already match the configs.
+    monkeypatch.setenv("CERTORA_AI_COMPOSER_PGHOST", pg_container.get_container_host_ip())
+    monkeypatch.setenv("CERTORA_AI_COMPOSER_PGPORT", str(pg_container.get_exposed_port(5432)))
+
+    # 3. Mock only the LLM (Counter tape) + disable the agent-index cache.
+    install_harness_tape(with_delay=False)
+    # autoprove_common imported `llm_factory` by name, so install_harness_tape's
+    # patch of services.llm_factory doesn't reach that binding — rebind it here.
+    monkeypatch.setattr("composer.spec.source.autoprove_common.llm_factory", services.llm_factory)
+    # Swap the real sentence-transformer for the deterministic mock: no model
+    # download, and nothing in this run depends on real embeddings (index cache
+    # disabled by the tape, RAG DB empty).
+    monkeypatch.setattr(
+        "composer.spec.source.autoprove_common.get_model", MockSentenceTransformer
+    )
+    # AutoSetup runs an LLM in a subprocess we can't tape — swap the phase for a
+    # canned Counter SetupSuccess. Patch the name the pipeline imported, not the
+    # definition in harness.py.
+    monkeypatch.setattr(
+        "composer.spec.source.pipeline.run_autosetup_phase", _fake_autosetup_phase
+    )
+    # The report phase is best-effort and absorbs failures (grouping degrades to a
+    # fallback bucket; the outer guard logs-and-continues). Flip both into re-raise
+    # so a broken report lane fails this test instead of passing silently.
+    monkeypatch.setattr(
+        "composer.spec.source.report.build.RERAISE_REPORT_FAILURES", True
+    )
+
+    # 4. Run the whole pipeline. Pass == it completes without raising.
+    summary = RunSummary()
+    async with autoprove_executor(_make_args(_db_url(pg_container, _RAG_DB)), summary) as run:
+        await run(AutoProveConsoleHandler().make_handler)


### PR DESCRIPTION
Adds an end-to-end integration test, based off an (updated) counter.py harness tape. The prover and database calls are real, the LLM calls are all mocked via the harness tape mechanism. The actual test simply asserts "nothing crashed"; no attempt is made (yet!) to ensure that files/reports ended up where they need to be. That's easy enough to add later, but it's worth getting this landed now. The setup required for getting the integration test env mocked out is unfortunate; (perhaps the memory backend should do its own DDL a la the RAG DB) and all the database provisioning is equally sadge, but for now, it works.

Because these tests are (relatively) long they run as a cron nightly at 3:07 UTC; they will send a message on slack to our dev channel to let us know (on top of sending whatever emails that may or may not be enabled).