### PR TITLE
Handle cloud prover job failures gracefully instead of crashing the run

### DIFF
--- a/composer/prover/cloud.py
+++ b/composer/prover/cloud.py
@@ -16,11 +16,34 @@ from typing import AsyncIterator, Awaitable, Callable
 from urllib.parse import urlparse, parse_qs
 
 import aiohttp
+from prover_output_utility.models import JobStatus, convert_job_status
 
 logger = logging.getLogger("composer.spec")
 
-# Terminal job statuses — anything not in this set means "still running"
-_TERMINAL_STATUSES = frozenset({"FAILED", "ERROR", "CANCELLED", "TIMEOUT", "SUCCEEDED"})
+
+class CloudJobError(RuntimeError):
+    """Raised when a cloud prover job reaches a terminal status other than
+    SUCCEEDED, does not reach a terminal status within the poll timeout, or
+    finishes without an output archive. Carries the ``status`` and prover
+    ``link``.
+    """
+
+    def __init__(self, status: JobStatus, link: str) -> None:
+        super().__init__(f"Cloud job ended with status {status.value}")
+        self.status = status
+        self.link = link
+
+
+# Terminal cloud job statuses (the job is no longer running). A status outside
+# this set means the job is still in progress.
+_TERMINAL_STATUSES = frozenset({
+    JobStatus.SUCCEEDED,
+    JobStatus.FAILED,
+    JobStatus.CANCELED,
+    JobStatus.HALTED,
+    JobStatus.SERVICE_UNAVAILABLE,
+    JobStatus.UPLOAD_FAILED,
+})
 
 # Avoid requesting Brotli — aiohttp's brotli support is often broken/missing.
 _NO_BROTLI_HEADERS = {"Accept-Encoding": "gzip, deflate"}
@@ -87,7 +110,7 @@ async def _poll_job_inner(
             if on_status is not None:
                 await on_status(status)
 
-            if status in _TERMINAL_STATUSES:
+            if convert_job_status(status) in _TERMINAL_STATUSES:
                 return data
 
             await asyncio.sleep(interval)
@@ -143,15 +166,18 @@ async def cloud_results(
         if poll_callback:
             await poll_callback(status, f"Cloud job {cloud_job.job_id[:8]}: {status}")
 
-    job_data = await poll_job(cloud_job, timeout=poll_timeout, on_status=on_status)
+    try:
+        job_data = await poll_job(cloud_job, timeout=poll_timeout, on_status=on_status)
+    except TimeoutError as exc:
+        raise CloudJobError(JobStatus.UNKNOWN, run_result_link) from exc
 
-    status = job_data.get("jobStatus", "UNKNOWN")
-    if status != "SUCCEEDED":
-        raise RuntimeError(f"Cloud job finished with status {status} (expected DONE)")
+    status = convert_job_status(job_data.get("jobStatus", "UNKNOWN"))
+    if status is not JobStatus.SUCCEEDED:
+        raise CloudJobError(status, run_result_link)
 
     zip_url = job_data.get("zipOutputUrl")
     if not zip_url:
-        raise RuntimeError("Cloud job completed but no zipOutputUrl in response")
+        raise CloudJobError(status, run_result_link)
 
     separator = "&" if "?" in zip_url else "?"
     full_url = f"{zip_url}{separator}anonymousKey={cloud_job.anonymous_key}"

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -479,7 +479,7 @@ async def run_prover(
                     diagnoses=[],
                 )
     except CloudJobError as exc:
-        return f"Prover cloud job did not produce results (status {exc.status.value}). Prover link: {exc.link}"
+        return f"Prover cloud job did not produce results (status {exc.status.value})."
 
     prover_report: dict[str, bool] = {}
     for i in parsed.values():

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -41,7 +41,7 @@ from graphcore.graph import LLM
 from prover_output_utility import cloud_server_for_env
 
 from composer.prover.analysis import analyze_cex_raw
-from composer.prover.cloud import cloud_results
+from composer.prover.cloud import CloudJobError, cloud_results
 from composer.prover.ptypes import RuleResult
 from composer.prover.results import read_and_format_run_result
 from composer.templates.loader import load_jinja_template
@@ -444,34 +444,37 @@ async def run_prover(
     # whose lifetime is bound to ``cloud_results``; local runs hand back
     # a stable path. Either way the analyzer must complete before the
     # context manager exits.
-    async with results_cm as emv_path:
-        parsed = read_and_format_run_result(emv_path)
+    try:
+        async with results_cm as emv_path:
+            parsed = read_and_format_run_result(emv_path)
 
-        if isinstance(parsed, str):
-            return f"Failed to parse prover results: {parsed}"
+            if isinstance(parsed, str):
+                return f"Failed to parse prover results: {parsed}"
 
-        # 9. Notify prover_result callback
-        await callbacks.on_prover_result(parsed)
+            # 9. Notify prover_result callback
+            await callbacks.on_prover_result(parsed)
 
-        all_results = list(parsed.values())
+            all_results = list(parsed.values())
 
-        # 10. Hand off to the handler when anything failed. It owns the
-        # analysis approach, per-rule UI events, rendering, summarization
-        # (if any), and storage of any keyed records (e.g. report_keys
-        # for ``cex_remediation`` lookup). We get back the final report
-        # string. ``emv_path`` is the prover's report directory;
-        # implementations that read source narrow further to
-        # ``emv_path / "inputs" / ".certora_sources"``.
-        if any(r.status == "VIOLATED" for r in all_results):
-            result_str = await cex.analyze(
-                all_results, tool_call_id, callbacks, emv_path
-            )
-        else:
-            result_str = load_jinja_template(
-                "rule_feedback.j2",
-                rule_entries=[(r, None) for r in all_results],
-                diagnoses=[],
-            )
+            # 10. Hand off to the handler when anything failed. It owns the
+            # analysis approach, per-rule UI events, rendering, summarization
+            # (if any), and storage of any keyed records (e.g. report_keys
+            # for ``cex_remediation`` lookup). We get back the final report
+            # string. ``emv_path`` is the prover's report directory;
+            # implementations that read source narrow further to
+            # ``emv_path / "inputs" / ".certora_sources"``.
+            if any(r.status == "VIOLATED" for r in all_results):
+                result_str = await cex.analyze(
+                    all_results, tool_call_id, callbacks, emv_path
+                )
+            else:
+                result_str = load_jinja_template(
+                    "rule_feedback.j2",
+                    rule_entries=[(r, None) for r in all_results],
+                    diagnoses=[],
+                )
+    except CloudJobError as exc:
+        return f"Prover cloud job did not produce results (status {exc.status.value}). Prover link: {exc.link}"
 
     prover_report: dict[str, bool] = {}
     for i in parsed.values():


### PR DESCRIPTION
## What
A failed cloud prover job (FAILED/CANCELED/HALTED) currently
raises an uncaught `RuntimeError` in `cloud_results`, which propagates through
`run_prover` → `verify_spec` and aborts the entire AutoProver pipeline — producing no final report.

## Changes
- `cloud.py`: add `CloudJobError`; `cloud_results` raises it (not bare
  `RuntimeError`) on a non-SUCCEEDED terminal status, poll timeout, or missing
  output archive.
- `core.py`: `run_prover` catches `CloudJobError` and returns a message — like
  its other prover-failure paths — so the agent gets feedback and can continue (without crashing the whole pipeline).
- Source terminal-status detection from POU's `JobStatus` enum
  (`convert_job_status`) instead of a hand-maintained string set, fixing drift
  (misspelled `CANCELLED`, missing `HALTED`/`SERVICE_UNAVAILABLE`/`UPLOAD_FAILED`,
  bogus `ERROR`/`TIMEOUT`).

## Why
Two real autoprover runs died this way during invariant-CVL
generation when a generated spec's prover job returned `FAILED`.