### PR TITLE
Scene-time curated summary emission + add CTHelpers curated summary

### DIFF
--- a/certora_autosetup/certora/specs/summaries/CTHelpers.spec
+++ b/certora_autosetup/certora/specs/summaries/CTHelpers.spec
@@ -1,0 +1,36 @@
+// Curated summary for the Gnosis Conditional Tokens helper library (CTHelpers).
+//
+// CTHelpers.getCollectionId derives a collection id as a compressed alt_bn128 curve point: it hashes
+// (conditionId, indexSet) to a curve point via a modular square root (the private CTHelpers.sqrt, a
+// large unrolled mulmod add-chain computing x^((P+1)/4) mod P) and, when parentCollectionId != 0,
+// EC-adds the parent point. The function is a deterministic function of its inputs, so a deterministic
+// ghost summary is a valid over-approximation. Summarizing it also keeps the modular-sqrt add-chain
+// out of the prover, which otherwise makes loop-summarization fold a huge nested mulmod/addmod
+// expression and exhaust memory.
+//
+// Over-approximation note: the ghost is an arbitrary deterministic function constrained only by the
+// injectivity axiom below. It does not model the homomorphic composition of nested collections (the
+// parentCollectionId point addition), so it cannot prove properties that assert how collections
+// compose under that composition; those must keep the real implementation. The injectivity axiom
+// states that distinct (parentCollectionId, conditionId, indexSet) inputs yield distinct ids, which
+// holds for the real collision-resistant derivation, so distinct collections remain distinct.
+//
+// Injectivity is encoded via left-inverse ghosts rather than a 6-variable forall: asserting that each
+// input component is recoverable from the id is equivalent to injectivity (equal ids force equal
+// inputs through the inverses) but only quantifies 3 variables and applies ghostCollectionId once, so
+// the solver instantiates it linearly instead of over every pair of ids.
+
+persistent ghost ghostCollectionIdInv1(bytes32) returns bytes32;
+persistent ghost ghostCollectionIdInv2(bytes32) returns bytes32;
+persistent ghost ghostCollectionIdInv3(bytes32) returns uint256;
+
+persistent ghost ghostCollectionId(bytes32, bytes32, uint256) returns bytes32 {
+    axiom forall bytes32 p1. forall bytes32 c1. forall uint256 i1.
+          ghostCollectionIdInv1(ghostCollectionId(p1, c1, i1)) == p1 &&
+          ghostCollectionIdInv2(ghostCollectionId(p1, c1, i1)) == c1 &&
+          ghostCollectionIdInv3(ghostCollectionId(p1, c1, i1)) == i1;
+}
+
+methods {
+    function CTHelpers.getCollectionId(bytes32 p, bytes32 c, uint256 i) internal returns (bytes32) => ghostCollectionId(p, c, i);
+}

--- a/certora_autosetup/setup/call_resolution.py
+++ b/certora_autosetup/setup/call_resolution.py
@@ -263,11 +263,6 @@ class CallResolutionPhase:
         # 2. LLM analysis per new contract. Sequential so ``SummarySetup``'s shared
         # accumulators (``_emitted_methods``, ``_methods_per_contract``,
         # ``_cvl_functions``) aren't touched concurrently.
-        # TODO: only LLM analysis runs for contracts pulled in during call resolution — the curated
-        # library-summary matcher (SummarySetup.match_summaries_from_all_methods against
-        # function_summaries.json) is applied only to the main contract and the initial
-        # additional_contracts, not here. Run curated matching on ``names`` here too to
-        # close that gap.
         contract_files = self.summary_setup.solidity_files_no_dependencies
         for name in names:
             try:
@@ -277,6 +272,29 @@ class CallResolutionPhase:
                     f"LLM analysis failed for {name}; continuing without summaries: {e}"
                 )
 
+        # 2b. Curated library summaries for the new contracts, scene-timed rather than matched once
+        # against the main contract. A curated summary is emitted only after its contract/library is in
+        # the conf — step 1 added the libraries these contracts use — so its receiver resolves instead
+        # of failing "contract not found" and being commented out by the typechecker loop.
+        try:
+            curated_keys: Set[str] = set()
+            for name in names:
+                matched, _ = self.summary_setup.match_summaries_from_all_methods(name)
+                curated_keys |= matched
+            if curated_keys:
+                # Publish so prune_emitted_specs (run before the next submission) ranks these as
+                # curated for dedup precedence over LLM specs.
+                self.summary_setup.matched_functions |= curated_keys
+                self.summary_setup.copy_summaries_folder(curated_keys)
+                registered = self.aggregator.register_curated(
+                    self.summary_setup.curated_summary_import_path(key, self.contract_name)
+                    for key in curated_keys
+                )
+                if registered:
+                    logger.info(f"Summary aggregator: registered curated specs {registered}")
+        except Exception as e:
+            logger.warning(f"Curated summary matching failed for {names}: {e}")
+
         # 3. Append imports for any specs that landed on disk.
         try:
             added = self.aggregator.register(names)
@@ -284,6 +302,21 @@ class CallResolutionPhase:
                 logger.info(f"Summary aggregator: registered LLM specs for {added}")
         except Exception as e:
             logger.warning(f"Summary aggregator register failed for {names}: {e}")
+
+        # 4. Prune entries that don't resolve in the scene across all emitted specs (curated + LLM,
+        # this and prior iterations) — the same global pass the initial setup runs, re-run here because
+        # this is the contract-add event. Cleans lazily-added union-template/curated specs before the
+        # next submission instead of letting them hard-fail it.
+        # TODO(perf): this re-checks every emitted spec on each contract-add. all_methods.json is built
+        # once and never regenerated, so an entry that resolved before stays resolvable — only the
+        # newly-added specs need the existence check. The exception is cross-spec dedup precedence (a
+        # newly-added curated spec can supersede a (receiver,name,params) an existing LLM spec kept),
+        # which needs the global view. Consider pruning only new specs for existence + handling dedup
+        # incrementally.
+        try:
+            self.summary_setup.prune_emitted_specs(self.contract_name)
+        except Exception as e:
+            logger.warning(f"Summary spec prune failed after adding {names}: {e}")
 
     async def execute(
         self,

--- a/certora_autosetup/setup/function_summaries.json
+++ b/certora_autosetup/setup/function_summaries.json
@@ -141,5 +141,11 @@
     "library_names": ["SafeERC20"],
     "summary_file": "specs/summaries/OpenZeppelin/OZ_SafeERC20.spec",
     "description": "OpenZeppelin SafeERC20.safeDecreaseAllowance"
+  },
+  "ctHelpers_getCollectionId": {
+    "names": ["getCollectionId"],
+    "library_names": ["CTHelpers"],
+    "summary_file": "specs/summaries/CTHelpers.spec",
+    "description": "Gnosis Conditional Tokens CTHelpers.getCollectionId (bn128 collection-id derivation)"
   }
 }

--- a/certora_autosetup/setup/setup_summaries.py
+++ b/certora_autosetup/setup/setup_summaries.py
@@ -61,6 +61,27 @@ from certora_autosetup.setup.summary_resolver import resolve_summary_specs
 from certora_autosetup.setup.signature_types import InheritanceGraph
 
 
+# CVL grammar keyword terminals (EVMVerifier CVL lexer, com.certora.certoraprover.cvl). A Solidity
+# parameter whose name equals one of these is lexed as that keyword inside a methods{} entry, which is
+# a syntax error; such names are suffixed with "_" before emission (see _cvl_safe_param_name).
+CVL_RESERVED_WORDS = frozenset({
+    "ALL", "ALWAYS", "ASSERT_FALSE", "AUTO", "CONSTANT", "Create", "DELETE", "DISPATCH", "DISPATCHER",
+    "HAVOC_ALL", "HAVOC_ECF", "NONDET", "PER_CALLEE_CONSTANT", "STORAGE", "Sload", "Sstore", "Tload",
+    "Tstore", "UNRESOLVED", "as", "assert", "assuming", "at", "axiom", "builtin", "default",
+    "definition", "description", "else", "event", "exists", "expect", "fallback", "false", "filtered",
+    "forall", "function", "ghost", "good_description", "havoc", "hook", "if", "import", "in", "indexed",
+    "invariant", "lastReverted", "lastStorage", "links", "mapping", "methods", "new", "norevert", "old",
+    "onTransactionBoundary", "override", "persistent", "preserved", "require", "requireInvariant",
+    "reset_storage", "return", "returns", "revert", "rule", "satisfy", "sig", "sort", "strong", "sum",
+    "true", "unresolved", "use", "using", "usum", "void", "weak", "with", "withrevert", "xor",
+})
+
+
+def _cvl_safe_param_name(name: str) -> str:
+    """The parameter name with a trailing "_" if it equals a CVL reserved word, otherwise unchanged."""
+    return f"{name}_" if name in CVL_RESERVED_WORDS else name
+
+
 try:
     from dotenv import load_dotenv
 
@@ -195,8 +216,8 @@ class DecimalSummary(BaseModel):
 
     @property
     def summary_line(self) -> str:
-        params = ", ".join([ f"{_pprint_type(p.ty)} {p.name}" for p in self.param_list ])
-        return f"function _.{self.method_name}({params}) internal => {self.cvl_function_name}({self.amount_parameter}) expect {self.return_type.ty_name};"
+        params = ", ".join([ f"{_pprint_type(p.ty)} {_cvl_safe_param_name(p.name)}" for p in self.param_list ])
+        return f"function _.{self.method_name}({params}) internal => {self.cvl_function_name}({_cvl_safe_param_name(self.amount_parameter)}) expect {self.return_type.ty_name};"
 
     @property
     def cvl_function(self) -> str:
@@ -238,7 +259,7 @@ class NondetSummary(BaseModel):
 
     @property
     def summary_line(self) -> str:
-        params = ", ".join([f"{_pprint_type(p.ty)} {p.name}" for p in self.param_list])
+        params = ", ".join([f"{_pprint_type(p.ty)} {_cvl_safe_param_name(p.name)}" for p in self.param_list])
         if self.return_type is not None:
             return_types = ", ".join([
                 _pprint_type(ty) for ty in self.return_type
@@ -351,6 +372,16 @@ class SummarySetup:
 
         # Initialize TypeAnalyzer for resolving user-defined types in function declarations
         self.type_analyzer: TypeAnalyzer = self._init_type_analyzer()
+
+    @functools.cached_property
+    def methods_parser(self) -> MethodParser:
+        """Parsed ``all_methods.json``, loaded once and reused.
+
+        ``all_methods.json`` is written once by the build (``generate_all_methods_json``) and is
+        immutable afterward, so the parse is cached rather than repeated per match/recipe call.
+        Access only after confirming the file exists.
+        """
+        return MethodParser(str(PATH_ALL_METHODS_JSON))
 
     def _init_type_analyzer(self) -> TypeAnalyzer:
         """Initialize TypeAnalyzer. Fatal error if initialization fails."""
@@ -857,6 +888,16 @@ class SummarySetup:
 
         return str(SUMMARIES_SUBDIR / versioned_rel_under)
 
+    def curated_summary_import_path(self, func_name: str, main_contract: str) -> str:
+        """Aggregator-relative import path for a matched curated-summary key.
+
+        A ``.template.spec`` entry is materialized into its ``{base}-{main_contract}.spec`` form first.
+        """
+        import_path: str = self.function_summaries[func_name]["summary_file"]
+        if import_path.endswith(".template.spec"):
+            import_path = self._materialize_template(import_path, main_contract)
+        return os.path.relpath(self.certora_dir / import_path, self.user_summaries_dir)
+
     def generate_base_aggregator(
         self,
         main_contract: str,
@@ -899,14 +940,7 @@ class SummarySetup:
         # the versioned ``{base}-{main}.spec`` directly into the user's dir) and import
         # that versioned name.
         for func_name in verified_functions:
-            func_info = self.function_summaries[func_name]
-            import_path: str = func_info["summary_file"]
-
-            if import_path.endswith(".template.spec"):
-                import_path = self._materialize_template(import_path, main_contract)
-
-            rel_to_aggregator = os.path.relpath(self.certora_dir / import_path, self.user_summaries_dir)
-            unique_imports.add(rel_to_aggregator)
+            unique_imports.add(self.curated_summary_import_path(func_name, main_contract))
 
         # Per-contract LLM specs for the initial scope.
         for c_name in in_scene_contracts:
@@ -931,6 +965,42 @@ class SummarySetup:
             "SUCCESS" if unique_imports else "INFO",
         )
         return aggregator_path
+
+    def prune_emitted_specs(self, main_contract: str) -> None:
+        """Comment out methods{} entries that don't resolve in the compiled scene, across ALL emitted
+        summary specs. Curated/dedicated library specs (in function_summaries.json key order) take
+        precedence over LLM-generated ones for duplicate (receiver, name, param_types) ownership.
+
+        Global by design — it needs every spec at once for that precedence — so it runs after summary
+        emission and before a prover submission, not inline per contract. Union templates and curated
+        specs added lazily during call resolution otherwise leave entries that fail CVL typechecking.
+
+        Each spec path is passed to the resolver at most once: several function_summaries keys can
+        share one summary_file (e.g. the SafeERC20 keys), and resolving the same file twice makes the
+        second pass treat the file's own kept entries as duplicates owned by the first and drop them.
+        """
+        if not PATH_ALL_METHODS_JSON.exists():
+            return
+        ordered_specs: List[Path] = []
+        seen: Set[Path] = set()
+
+        def _add(p: Path) -> None:
+            if p not in seen:
+                seen.add(p)
+                ordered_specs.append(p)
+
+        for key in self.function_summaries:  # function_summaries.json key order = curated precedence
+            if key not in self.matched_functions:
+                continue
+            rel_under = Path(self.function_summaries[key]["summary_file"]).relative_to(SUMMARIES_SUBDIR)
+            if str(rel_under).endswith(".template.spec"):
+                base_stem = rel_under.stem[: -len(".template")]
+                rel_under = rel_under.parent / f"{base_stem}-{main_contract}.spec"
+            _add(self.user_summaries_dir / rel_under)
+        # Then any other emitted spec (LLM per-contract, call resolution) — lower dedup precedence.
+        for spec in walk_files_by_suffix(self.user_summaries_dir, ".spec"):
+            _add(spec)
+        resolve_summary_specs(ordered_specs, PATH_ALL_METHODS_JSON, log=self.log)
 
     def should_process_file(self, file_path: str) -> bool:
         """Check if a file should be processed (not a dependency or internal file).
@@ -1197,6 +1267,7 @@ If the function cannot be summarized (e.g., struct parameters), return an Invali
         params = []
         for i, param_type in enumerate(param_types):
             param_name = param_names[i] if i < len(param_names) and param_names[i] else f""
+            param_name = _cvl_safe_param_name(param_name)
             location = locations[i] if i < len(locations) else ""
 
             cvl_type, classification = classify_solidity_type(param_type)
@@ -1633,7 +1704,7 @@ Method signature: {method_signature}
             )
             return []
 
-        mp = MethodParser(str(methods_file))
+        mp = self.methods_parser
 
         # Filter methods by properties and originatingContract
         all_methods = mp.get_all_methods()
@@ -2022,6 +2093,12 @@ Method signature: {method_signature}
             header.extend(['import "./_helpers.spec";', ""])
         return "\n".join(header + body)
 
+    def _returns_reference_type(self, method: Dict[str, Any]) -> bool:
+        """Whether any of the method's returns is a reference type (string/bytes/array/struct/mapping),
+        determined from the per-return data location recorded in the build JSON.
+        """
+        return any(loc in ("memory", "calldata", "storage") for loc in method.get("returnLocations", []))
+
     def _append_method_summary(
         self,
         content: List[str],
@@ -2059,7 +2136,12 @@ Method signature: {method_signature}
         content.append("     */")
 
         if summary_type.upper() == "NONDET":
-            if method["stateMutability"] in ["view", "pure"]:
+            if self._returns_reference_type(method):
+                sig = self._get_function_signature(method, is_wildcard=False)
+                content.append(
+                    f"    // AUTO-DISABLED (NONDET unsound for reference types): {sig}"
+                )
+            elif method["stateMutability"] in ["view", "pure"]:
                 if has_ellipsis and (nondet_summary := self._generate_nondet_summary(
                     method, udt_context
                 )) is not None:
@@ -2273,7 +2355,7 @@ Method signature: {method_signature}
             self.log("all_methods.json not found", "ERROR")
             return set(), set()
 
-        mp = MethodParser(str(methods_file))
+        mp = self.methods_parser
 
         self.log(f"Matching summaries for {main_contract}...")
         # Filter to only methods that originate from this contract (compilation unit)
@@ -2437,30 +2519,10 @@ Method signature: {method_signature}
         in_scene = [main_contract] + additional_names
         self.generate_base_aggregator(main_contract, in_scene, matched_functions)
 
-        # Step 5b: Prune summary methods{} entries that don't resolve in the compiled
-        # scene. Union templates (e.g. FixedPointMathLib.spec carries both solmate and
-        # solady naming) otherwise leave entries whose method doesn't exist at the
-        # declared receiver, which fail CVL typechecking before any checker runs.
-        # Curated/dedicated library specs take precedence over LLM-generated ones for
-        # duplicate (receiver, name, param_types) ownership, so resolve them first.
-        if PATH_ALL_METHODS_JSON.exists():
-            ordered_specs: List[Path] = []
-            for key in self.function_summaries:  # function_summaries.json key order
-                if key not in matched_functions:
-                    continue
-                rel_under = Path(self.function_summaries[key]["summary_file"]).relative_to(SUMMARIES_SUBDIR)
-                if str(rel_under).endswith(".template.spec"):
-                    base_stem = rel_under.stem[: -len(".template")]
-                    rel_under = rel_under.parent / f"{base_stem}-{main_contract}.spec"
-                ordered_specs.append(self.user_summaries_dir / rel_under)
-            curated = set(ordered_specs)
-            # Then any other emitted summary spec (LLM per-contract, aggregator, call
-            # resolution) — lower precedence for dedup, but still pruned for nonexistent
-            # entries.
-            for spec in walk_files_by_suffix(self.user_summaries_dir, ".spec"):
-                if spec not in curated:
-                    ordered_specs.append(spec)
-            resolve_summary_specs(ordered_specs, PATH_ALL_METHODS_JSON, log=self.log)
+        # Step 5b: Prune summary methods{} entries that don't resolve in the compiled scene
+        # (e.g. union-template specs naming functions the library doesn't have). Same pass is
+        # re-run before each call-resolution submission as lazily-added specs arrive.
+        self.prune_emitted_specs(main_contract)
 
         if not matched_functions and not any(
             (self.user_summaries_dir / f"{c}_summaries.spec").exists()

--- a/certora_autosetup/setup/summary_aggregator.py
+++ b/certora_autosetup/setup/summary_aggregator.py
@@ -4,7 +4,7 @@ The base summary aggregator at ``certora/specs/summaries/{main}_base_summaries.s
 written once by ``SummarySetup.generate_base_aggregator`` with curated bundled
 imports + per-contract LLM imports for the initial scene (main + additional
 contracts). After that, only ``BaseSummariesAggregator.register`` may mutate it,
-appending an ``import "./{C}_summaries.spec";`` line per newly summarized contract
+appending an ``import "{C}_summaries.spec";`` line per newly summarized contract
 brought into scene by call resolution. All mutations are idempotent so the same
 contract can be registered repeatedly across iterations.
 """
@@ -26,7 +26,7 @@ class BaseSummariesAggregator:
         self.aggregator_path = summaries_dir / f"{main_contract}_base_summaries.spec"
 
     def register(self, contract_names: Iterable[str]) -> List[str]:
-        """Append one ``import "./{C}_summaries.spec";`` line per contract whose
+        """Append one ``import "{C}_summaries.spec";`` line per contract whose
         per-contract spec exists on disk and isn't already imported.
 
         Returns:
@@ -45,7 +45,9 @@ class BaseSummariesAggregator:
             spec_path = self.summaries_dir / f"{name}_summaries.spec"
             if not spec_path.exists():
                 continue
-            import_line = f'import "./{name}_summaries.spec";'
+            # No "./" prefix: must match the form written at initial generation
+            # (setup_summaries.generate_base_aggregator) and by register_curated, or dedup misses it.
+            import_line = f'import "{name}_summaries.spec";'
             if import_line in existing or import_line in new_lines:
                 continue
             new_lines.append(import_line)
@@ -57,6 +59,40 @@ class BaseSummariesAggregator:
         with self.aggregator_path.open("a") as f:
             # Ensure the appended block starts on a new line even if the file
             # didn't end with one.
+            if existing and not existing.endswith("\n"):
+                f.write("\n")
+            for line in new_lines:
+                f.write(f"{line}\n")
+        return added
+
+    def register_curated(self, import_paths: Iterable[str]) -> List[str]:
+        """Append one ``import "<path>";`` line per curated summary spec not already imported.
+
+        ``import_paths`` are aggregator-relative paths (e.g. ``"CTHelpers.spec"`` or
+        ``"OpenZeppelin/OZ_Math.spec"``), matching the format written at initial generation.
+
+        Returns:
+            The import paths that had a line added (for logging). Empty if all were already
+            imported or the aggregator file doesn't exist yet.
+        """
+        if not self.aggregator_path.exists():
+            return []
+
+        existing = self.aggregator_path.read_text()
+        new_lines: List[str] = []
+        added: List[str] = []
+
+        for path in import_paths:
+            import_line = f'import "{path}";'
+            if import_line in existing or import_line in new_lines:
+                continue
+            new_lines.append(import_line)
+            added.append(path)
+
+        if not new_lines:
+            return []
+
+        with self.aggregator_path.open("a") as f:
             if existing and not existing.endswith("\n"):
                 f.write("\n")
             for line in new_lines:


### PR DESCRIPTION
## Problem

Curated library summaries were matched/emitted and pruned only **upfront** (main + additional
contracts). A library reached only *transitively* — via a contract pulled in later by call
resolution — was either missed, or its summary referenced a contract not yet in the conf scene and
got permanently commented out by the typechecker loop. Several CVL-generation issues also made
summaries fail typechecking: reserved words used as parameter names, NONDET on reference-return
functions, and a duplicate-spec-path bug that gutted curated specs shared by multiple registry keys.

## Change

- **Scene-timed emission:** curated matching + copy + register + prune now run at every contract-add
  — initial setup and each `_on_contracts_added` during call resolution. The prune-pass
  (`prune_emitted_specs`) is the same global pass run at both points, so lazily-added specs are
  cleaned before the next submission instead of aborting it.
- **Generation robustness:** escape CVL reserved words in parameter names (declaration + dispatch);
  skip NONDET for reference-return functions with an AUTO-DISABLED breadcrumb.
- **Correctness / perf:** dedup the prune spec list (multiple registry keys can share one file);
  cache the `all_methods.json` parse; align the aggregator import format so per-contract dedup works.
- **New curated summary:** `CTHelpers.getCollectionId` (Gnosis Conditional Tokens) as a deterministic
  ghost with left-inverse injectivity.

## Validation

Ran autosetup end-to-end on a real multi-module project: curated summaries (incl. the new CTHelpers
one) register via the call-resolution hook, union-template specs are pruned to only the functions
present in scene, no "contract not found" / "does not appear in code" aborts, no duplicate imports,
and each contract is LLM-analyzed exactly once.
