### PR TITLE
Add `CTHelpers.getCollectionId` curated summary

### DIFF
--- a/certora_autosetup/certora/specs/summaries/CTHelpers.spec
+++ b/certora_autosetup/certora/specs/summaries/CTHelpers.spec
@@ -1,0 +1,36 @@
+// Curated summary for the Gnosis Conditional Tokens helper library (CTHelpers).
+//
+// CTHelpers.getCollectionId derives a collection id as a compressed alt_bn128 curve point: it hashes
+// (conditionId, indexSet) to a curve point via a modular square root (the private CTHelpers.sqrt, a
+// large unrolled mulmod add-chain computing x^((P+1)/4) mod P) and, when parentCollectionId != 0,
+// EC-adds the parent point. The function is a deterministic function of its inputs, so a deterministic
+// ghost summary is a valid over-approximation. Summarizing it also keeps the modular-sqrt add-chain
+// out of the prover, which otherwise makes loop-summarization fold a huge nested mulmod/addmod
+// expression and exhaust memory.
+//
+// Over-approximation note: the ghost is an arbitrary deterministic function constrained only by the
+// injectivity axiom below. It does not model the homomorphic composition of nested collections (the
+// parentCollectionId point addition), so it cannot prove properties that assert how collections
+// compose under that composition; those must keep the real implementation. The injectivity axiom
+// states that distinct (parentCollectionId, conditionId, indexSet) inputs yield distinct ids, which
+// holds for the real collision-resistant derivation, so distinct collections remain distinct.
+//
+// Injectivity is encoded via left-inverse ghosts rather than a 6-variable forall: asserting that each
+// input component is recoverable from the id is equivalent to injectivity (equal ids force equal
+// inputs through the inverses) but only quantifies 3 variables and applies ghostCollectionId once, so
+// the solver instantiates it linearly instead of over every pair of ids.
+
+persistent ghost ghostCollectionIdInv1(bytes32) returns bytes32;
+persistent ghost ghostCollectionIdInv2(bytes32) returns bytes32;
+persistent ghost ghostCollectionIdInv3(bytes32) returns uint256;
+
+persistent ghost ghostCollectionId(bytes32, bytes32, uint256) returns bytes32 {
+    axiom forall bytes32 p1. forall bytes32 c1. forall uint256 i1.
+          ghostCollectionIdInv1(ghostCollectionId(p1, c1, i1)) == p1 &&
+          ghostCollectionIdInv2(ghostCollectionId(p1, c1, i1)) == c1 &&
+          ghostCollectionIdInv3(ghostCollectionId(p1, c1, i1)) == i1;
+}
+
+methods {
+    function CTHelpers.getCollectionId(bytes32 p, bytes32 c, uint256 i) internal returns (bytes32) => ghostCollectionId(p, c, i);
+}

--- a/certora_autosetup/setup/function_summaries.json
+++ b/certora_autosetup/setup/function_summaries.json
@@ -141,5 +141,11 @@
     "library_names": ["SafeERC20"],
     "summary_file": "specs/summaries/OpenZeppelin/OZ_SafeERC20.spec",
     "description": "OpenZeppelin SafeERC20.safeDecreaseAllowance"
+  },
+  "ctHelpers_getCollectionId": {
+    "names": ["getCollectionId"],
+    "library_names": ["CTHelpers"],
+    "summary_file": "specs/summaries/CTHelpers.spec",
+    "description": "Gnosis Conditional Tokens CTHelpers.getCollectionId (bn128 collection-id derivation)"
   }
 }


### PR DESCRIPTION
## Problem

`CTHelpers.getCollectionId` (Gnosis Conditional Tokens) derives a collection id as a compressed
alt_bn128 curve point: it hashes its inputs to a curve point via a modular square root — a large
unrolled `mulmod` add-chain computing `x^((P+1)/4) mod P`. Left in the verification scene, loop
summarization folds that add-chain into a huge nested `mulmod`/`addmod` expression and exhausts
memory, so any contract that reaches `getCollectionId` cannot be verified.

## Change

A curated summary for `getCollectionId`:

- A registry entry in `function_summaries.json` (`ctHelpers_getCollectionId`) matching the function
  on the `CTHelpers` library.
- `certora/specs/summaries/CTHelpers.spec`: a **deterministic ghost** summary. `getCollectionId` is a
  deterministic function of its inputs, so an arbitrary deterministic ghost is a sound
  over-approximation, and it keeps the modular-sqrt add-chain out of the prover.

Injectivity is encoded via **left-inverse ghosts** rather than a 6-variable `forall`: asserting each
input component is recoverable from the id is equivalent to injectivity but quantifies only 3
variables and applies the ghost once, so the solver instantiates it linearly. The spec documents the
over-approximation boundary: it does not model the homomorphic composition of nested collections
(the `parentCollectionId` point addition), so properties asserting how collections compose under
that composition must keep the real implementation.

## Dependency / ordering

This is most useful together with scene-timed summary emission: when `getCollectionId` is reached
only transitively (through a contract pulled into the scene by call resolution), curated matching
must run at the contract-add event to emit it. That lands in the summary-subsystem PR — merge that
first, then rebase this onto master (the two changes touch disjoint files, so no conflicts).

## Validation

The ghost and injectivity axiom typecheck and apply as a summary; verified end-to-end on a project
where `getCollectionId` is reached transitively — the modular-sqrt blowup no longer reaches the
prover and the run completes.
