### PR TITLE
Fix Yul stack-too-deep detector to survive solc line-wrapping

### DIFF
--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -493,9 +493,16 @@ class CompilationWorkaroundManager:
         return None
 
     def _detect_yul_exception_stack_too_deep(self, output: str) -> bool:
-        """Detect YulException with stack too deep error."""
-        pattern = r"YulException:.*Stack too deep"
-        return bool(re.search(pattern, output, re.IGNORECASE))
+        """Detect YulException with stack too deep error.
+
+        solc hard-wraps its diagnostic text at a fixed width, so the phrase
+        "Stack too deep" is frequently split across a newline (e.g. the real
+        error reads "...Stack too\ndeep."). Match across arbitrary whitespace
+        (DOTALL + ``\\s+`` between words) so the wrap does not hide the error;
+        otherwise the via-ir / optimizer workarounds never trigger.
+        """
+        pattern = r"YulException:.*?Stack\s+too\s+deep"
+        return bool(re.search(pattern, output, re.IGNORECASE | re.DOTALL))
 
     def _detect_compiler_version_mismatch(
         self, output: str, contracts: List[ContractHandle]

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -1,0 +1,52 @@
+"""Unit tests for CompilationWorkaroundManager detectors."""
+
+from pathlib import Path
+
+import pytest
+
+from certora_autosetup.utils.compilation_workarounds import CompilationWorkaroundManager
+
+
+# Verbatim solc output captured from a real AutoProver run (tokemak-v2-core-fv):
+# solc hard-wraps its diagnostics, so "Stack too deep" is split across a newline
+# ("...Stack too\ndeep."). This is the case that must be detected so the via-ir /
+# optimizer workarounds fire.
+WRAPPED_YUL_STACK_TOO_DEEP = (
+    "Compiling certora/harnesses/LMPStrategyInstance1.sol...\n"
+    "solc8.17 had an error:\n"
+    "YulException: Variable param_0 is 2 slot(s) too deep inside the stack. Stack too\n"
+    "deep. Try compiling with `--via-ir` (cli) or the equivalent `viaIR: true` \n"
+    "(standard JSON) while enabling the optimizer. Otherwise, try removing local \n"
+    "variables.\n"
+)
+
+SINGLE_LINE_YUL_STACK_TOO_DEEP = (
+    "solc8.17 had an error:\n"
+    "YulException: Variable x is 2 slot(s) too deep. Stack too deep. Try --via-ir.\n"
+)
+
+UNRELATED_OUTPUT = (
+    "Compiling certora/harnesses/Foo.sol...\n"
+    "Warning: Unused local variable.\n"
+    "Compilation successful.\n"
+)
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> CompilationWorkaroundManager:
+    return CompilationWorkaroundManager(project_root=tmp_path)
+
+
+def test_detects_wrapped_yul_stack_too_deep(manager: CompilationWorkaroundManager) -> None:
+    # Regression: before the DOTALL/\s+ fix the wrapped phrase was missed, so
+    # yul_exception_add_optimizer never fired and the run died as "no applicable
+    # workaround".
+    assert manager._detect_yul_exception_stack_too_deep(WRAPPED_YUL_STACK_TOO_DEEP) is True
+
+
+def test_detects_single_line_yul_stack_too_deep(manager: CompilationWorkaroundManager) -> None:
+    assert manager._detect_yul_exception_stack_too_deep(SINGLE_LINE_YUL_STACK_TOO_DEEP) is True
+
+
+def test_ignores_unrelated_output(manager: CompilationWorkaroundManager) -> None:
+    assert manager._detect_yul_exception_stack_too_deep(UNRELATED_OUTPUT) is False


### PR DESCRIPTION
## Problem

An AutoProver run (`Certora/tokemak-v2-core-fv` @ `b0104fb9`) failed in the Autosetup **compilation-analysis** phase with `CompilationAnalysisError`, after only two workaround attempts:

1. `stack_too_deep_via_ir` fired (enabled `solc_via_ir_map[LMPStrategyInstance1]=true`) — recompile then failed with the **via-ir** form of the error, `YulException: … Stack too deep`.
2. The loop reported `⚠️ no specific workaround match — enabling use_relpaths_for_solc_json` (the catch-all), then `❌ no applicable workaround` → import-patch fallback → same error → give up.

The `yul_exception_add_optimizer` workaround (which would add `solc_optimize=200` alongside via-ir) **never fired**, so the optimizer was never tried.

## Root cause

`_detect_yul_exception_stack_too_deep` used:

```python
pattern = r"YulException:.*Stack too deep"
re.search(pattern, output, re.IGNORECASE)
```

solc hard-wraps its diagnostic text at a fixed width, so the real message splits the phrase across a newline:

```
YulException: Variable param_0 is 2 slot(s) too deep inside the stack. Stack too
deep. Try compiling with `--via-ir` ...
```

Without `re.DOTALL` (and with a literal space between `too` and `deep`), the pattern cannot match `Stack too\ndeep`, so the detector returned `False` and the optimizer workaround was skipped.

## Fix

Match across arbitrary whitespace (incl. newlines):

```python
pattern = r"YulException:.*?Stack\s+too\s+deep"
re.search(pattern, output, re.IGNORECASE | re.DOTALL)
```

Now `yul_exception_add_optimizer` triggers on the wrapped error, and its existing paired safety net (`yul_exception_stack_too_deep`, which removes via-ir + optimizer and disables autofinders if the error persists) still applies unchanged.

## Tests

`tests/test_compilation_workarounds.py` — asserts detection on the **verbatim wrapped** solc output from the failing run, on a single-line variant, and non-detection on unrelated output. The old pattern returns `False` on the wrapped fixture; the new one returns `True`.

## Validation still to do

- [ ] Build the AutoProver container from this branch and re-run on `tokemak-v2-core-fv` to confirm the optimizer path is attempted (note: it's still possible viaIR+optimizer won't fit `LMPStrategyInstance1` within stack limits — this fix ensures the intended path runs, not that the contract necessarily compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)