### PR TITLE
Set `--msg` on call resolution prover jobs; default it on every job spec

### DIFF
--- a/certora_autosetup/autosetup/autosetup.py
+++ b/certora_autosetup/autosetup/autosetup.py
@@ -215,10 +215,6 @@ class Autosetup:
         llm = set(setup._methods_per_contract.keys()) & self._library_names
         return curated | llm
 
-    def _build_job_msg(self, contract_name: str, conf_file: Path) -> str:
-        """Build the msg string for a prover job."""
-        return ProverJobSpec.build_job_msg(self.config.orchestration_timestamp, contract_name, conf_file)
-
     def run(self, main_contract_handle: ContractHandle, skip_warmup: bool = False) -> AutosetupResult:
         """Execute the full autosetup pipeline.
 
@@ -811,7 +807,6 @@ class Autosetup:
                     contract_name=contract_name,
                     phase=f"Sanity Test Run - {contract_name}",
                     extra_args=autosetup.config.extra_args,
-                    msg=autosetup._build_job_msg(contract_name, test_config.path),
                 ))
 
                 if skip_warmup:
@@ -831,7 +826,6 @@ class Autosetup:
                     contract_name=contract_name,
                     phase="Sanity Warmup - warmup",
                     extra_args=autosetup.config.extra_args,
-                    msg=autosetup._build_job_msg(contract_name, warmup_config.path),
                 )
 
             async def prepare_and_run_warmup():

--- a/certora_autosetup/conf_runner/callbacks.py
+++ b/certora_autosetup/conf_runner/callbacks.py
@@ -191,7 +191,6 @@ class JobCallbacks:
                     phase=f"{result.job_spec.phase}_{rule_name}_multi_assert",
                     extra_args=result.job_spec.extra_args,
                     context=result.job_spec.context,
-                    msg=ProverJobSpec.build_job_msg(self.orchestration_timestamp, contract_name, new_config_path),
                 )
                 new_jobs.append(new_job_spec)
 
@@ -294,7 +293,6 @@ class JobCallbacks:
                     phase=f"{result.job_spec.phase}_{rule_name}_difficult_retry",
                     extra_args=result.job_spec.extra_args,
                     context=result.job_spec.context,
-                    msg=ProverJobSpec.build_job_msg(self.orchestration_timestamp, contract_name, new_config_path),
                 )
                 new_jobs.append(new_job_spec)
 

--- a/certora_autosetup/conf_runner/conf_runner.py
+++ b/certora_autosetup/conf_runner/conf_runner.py
@@ -137,7 +137,6 @@ class ConfRunner:
                     contract_name=contract_name,
                     phase=f"{tool_name}-{config_name}",
                     extra_args=self.config.extra_args,
-                    msg=ProverJobSpec.build_job_msg(self.orchestration_timestamp, contract_name, config_file),
                 )
                 job_specs.append(job_spec)
                 self.log(

--- a/certora_autosetup/setup/call_resolution.py
+++ b/certora_autosetup/setup/call_resolution.py
@@ -473,6 +473,9 @@ class CallResolutionPhase:
             phase="call_resolution",
             config_file=config_content,
             extra_args=self.extra_args,
+            msg=ProverJobSpec.build_job_msg(
+                self.contract_name, self.config_file, suffix=f"(iteration {self.current_iteration})"
+            ),
         )
 
         prover_result = await self.prover_runner.check_with_prover(job_spec)

--- a/certora_autosetup/setup/sanity.py
+++ b/certora_autosetup/setup/sanity.py
@@ -364,14 +364,6 @@ class SanityPhase:
         """Directory for transient conf copies, kept out of the user-facing certora/confs/ tree."""
         return self.prover_runner.project_root / DIR_INTERNAL_CONFS
 
-    def _build_job_msg(self, conf_file: Path) -> Optional[str]:
-        """Build the msg string for a prover job.
-
-        Format: "ProverLite <timestamp> <ContractName>: <conf_name>"
-        Returns None if no orchestration_timestamp is set.
-        """
-        return ProverJobSpec.build_job_msg(self.orchestration_timestamp, self.contract_name, conf_file)
-
     def log(self, level: str, message: str):
         """Simple contract logging utility."""
         log_with_contract("Sanity", level, self.contract_name, message)
@@ -598,7 +590,6 @@ class SanityPhase:
                 phase=f"Sanity Coverage Rerun - {self.contract_name} - {method}",
                 config_file=coverage_config,
                 extra_args=self.extra_args,
-                msg=self._build_job_msg(coverage_config.path),
             ))
         return await self.prover_runner.submit_and_wait_for_jobs(job_specs, completion_callback=completion_callback)
 
@@ -728,7 +719,6 @@ class SanityPhase:
                 phase="hashing_bound_detection",
                 config_file=bound_detection_config,
                 extra_args=self.extra_args,
-                msg=self._build_job_msg(bound_detection_config.path),
             )
 
             result = await self.prover_runner.check_with_prover(job_spec)
@@ -904,7 +894,6 @@ class SanityPhase:
                 config_file=test_config,
                 extra_args=self.extra_args,
                 context=config,  # Store BoundConfiguration as context
-                msg=self._build_job_msg(test_config.path),
             )
             job_specs.append(job_spec)
 

--- a/certora_autosetup/utils/enhanced_config_manager.py
+++ b/certora_autosetup/utils/enhanced_config_manager.py
@@ -75,6 +75,11 @@ class ProverJobSpec(Generic[ContextT]):
     context: Optional[ContextT] = None
     msg: Optional[str] = None  # Message for --msg argument
 
+    def __post_init__(self) -> None:
+        # When no msg is given, default it to "<Contract>: <conf_name>".
+        if self.msg is None:
+            self.msg = self.build_job_msg(self.contract_name, self.config_file.path)
+
     def get_cache_key(self, config_manager: "ConfigManager") -> str:
         """
         Generate cache key from config + all referenced files + extra_args.
@@ -100,20 +105,24 @@ class ProverJobSpec(Generic[ContextT]):
         return cache_key
 
     @staticmethod
-    def build_job_msg(orchestration_timestamp: str, contract_name: str, conf_file: Path) -> str:
+    def build_job_msg(contract_name: str, conf_file: Path, suffix: Optional[str] = None) -> str:
         """Build the msg string for a prover job.
 
-        Format: "Certora <timestamp> <ContractName>: <conf_name>"
+        Format: "<ContractName>: <conf_name>" (with " <suffix>" appended if provided).
 
         Args:
-            orchestration_timestamp: Timestamp string from orchestration start
             contract_name: Name of the contract being verified
             conf_file: Path to the configuration file
+            suffix: Optional trailing text to disambiguate jobs that reuse the same
+                conf (e.g. an iteration marker); the caller decides its content
 
         Returns:
-            Formatted message string or None if no timestamp
+            Formatted message string
         """
-        return f"Certora {orchestration_timestamp} {contract_name}: {conf_file.stem}"
+        msg = f"{contract_name}: {conf_file.stem}"
+        if suffix:
+            msg += f" {suffix}"
+        return msg
 
 
 class ConfigManager:


### PR DESCRIPTION
Call-resolution prover jobs were submitted without `--msg`, so they showed up unlabeled in the prover dashboard. `ProverJobSpec` now defaults `msg` to `"<Contract>: <conf_name>"` in `__post_init__`, so every job is labeled automatically without each call site passing one. Call resolution adds an `(iteration N)` suffix to keep its repeated same-conf jobs distinguishable.

Also simplified the message format — dropped the redundant `"Certora "` prefix and the unused timestamp from `build_job_msg` — and removed the now-unused `_build_job_msg` wrappers.