### PR TITLE
Fix harness generation for file-level user-defined types

### DIFF
--- a/certora_autosetup/setup/setup_prover.py
+++ b/certora_autosetup/setup/setup_prover.py
@@ -1260,7 +1260,7 @@ class SetupProver:
                                 method.get("fullArgs", []), method.get("paramNames", [])
                             ):
                                 type_desc = arg.get("typeDesc", {})
-                                sol_type = parse_type_descriptor(type_desc, TypeParseMode.QUALIFIED)
+                                sol_type = parse_type_descriptor(type_desc, TypeParseMode.SOLIDITY)
                                 location = arg.get("location", "")
                                 if location in ("memory", "calldata", "storage"):
                                     sol_type = f"{sol_type} {location}"

--- a/certora_autosetup/utils/types.py
+++ b/certora_autosetup/utils/types.py
@@ -73,12 +73,17 @@ class TypeParseMode(Enum):
     QUALIFIED  - Qualifies user-defined types via canonicalId, preserves contract names.
                  Used for fullSignature in all_methods.json. Note - all_methods.json will
                  be deprecated at some point, and then this mode might become redundant.
+    SOLIDITY   - Emits a type reference that compiles in generated Solidity source (e.g.
+                 harnesses). Unlike QUALIFIED, a file-level user-defined type keeps its
+                 bare name (e.g. "ResolutionChain") rather than being prefixed with a
+                 contract that does not actually declare it. Used for harness generation.
     """
 
     CANONICAL = "canonical"
     INTERNAL = "internal"
     DISPATCHER = "dispatcher"
     QUALIFIED = "qualified"
+    SOLIDITY = "solidity"
 
 
 def _qualify_user_defined_type(type_desc: dict, contract_name: str) -> str:
@@ -99,6 +104,28 @@ def _qualify_user_defined_type(type_desc: dict, contract_name: str) -> str:
     if not name:
         raise ValueError(f"type descriptor {type_desc} has no canonical name")
     return f"{contract_name}.{name}"
+
+
+def _solidity_user_defined_type(type_desc: dict) -> str:
+    """Resolve a user-defined type to a reference that compiles in generated Solidity.
+
+    Unlike ``_qualify_user_defined_type``, this never prefixes a file-level type with a
+    consuming contract name. The canonicalId right side is already the correct source
+    reference: a contract-nested type keeps its "Contract.TypeName" form, while a
+    file-level type stays a bare "TypeName" (resolved via the harness' import of the
+    source file, which re-exports the file's own imports).
+    """
+    canonical_id = type_desc.get("canonicalId", "")
+    if "|" in canonical_id:
+        return canonical_id.split("|", 1)[1]
+    name = (
+        type_desc.get("name")
+        or type_desc.get("enumName")
+        or type_desc.get("structName")
+    )
+    if not name:
+        raise ValueError(f"type descriptor {type_desc} has no canonical name")
+    return name
 
 
 def parse_type_descriptor(type_desc: dict, mode: TypeParseMode, contract_name: str = "") -> str:
@@ -146,6 +173,8 @@ def parse_type_descriptor(type_desc: dict, mode: TypeParseMode, contract_name: s
                 return f"({','.join(members)})"
             elif mode == TypeParseMode.INTERNAL:
                 return type_desc.get("name", "unknown")
+            elif mode == TypeParseMode.SOLIDITY:
+                return _solidity_user_defined_type(type_desc)
             else:  # DISPATCHER or QUALIFIED
                 return _qualify_user_defined_type(type_desc, contract_name)
         case TypeDescKind.USER_DEFINED_VALUE_TYPE:
@@ -153,6 +182,8 @@ def parse_type_descriptor(type_desc: dict, mode: TypeParseMode, contract_name: s
                 return recurse(type_desc.get("underlying", {}))
             elif mode == TypeParseMode.INTERNAL:
                 return type_desc.get("name", "unknown")
+            elif mode == TypeParseMode.SOLIDITY:
+                return _solidity_user_defined_type(type_desc)
             else:  # DISPATCHER or QUALIFIED
                 return _qualify_user_defined_type(type_desc, contract_name)
         case TypeDescKind.USER_DEFINED_ENUM:
@@ -160,6 +191,8 @@ def parse_type_descriptor(type_desc: dict, mode: TypeParseMode, contract_name: s
                 return "uint8"
             elif mode == TypeParseMode.INTERNAL:
                 return type_desc.get("name", "unknown")
+            elif mode == TypeParseMode.SOLIDITY:
+                return _solidity_user_defined_type(type_desc)
             else:  # DISPATCHER or QUALIFIED
                 return _qualify_user_defined_type(type_desc, contract_name)
         case TypeDescKind.ARRAY:


### PR DESCRIPTION
`certora-autosetup` aborted during sanity optimization because every generated harness whose parent constructor takes a file-scope user-defined type failed to compile. For example, a contract whose constructor takes an `enum` declared at file scope (outside any contract) produces a harness that solc rejects:

    solc8.34 had an error:
    ParserError: Expected type name
     --> certora/harnesses/MyContract_1.sol:7:53:
    7 | constructor(address a0, .MyEnum a1) MyContract(a0, a1) {}
      |                         ^

All sanity/warmup jobs were rejected at submission (`0/3`, then `0/1`) and the run failed.

## Root cause

A file-level user-defined type has a build typeDesc of the form:

    {"canonicalId": "src/lib/Types.sol|MyEnum", "containingContract": null, ...}

Harness constructor-param extraction (`setup_prover.py`) parsed the type with `TypeParseMode.QUALIFIED`, which routes user-defined types through `_qualify_user_defined_type`. For a file-level type (canonicalId right-side has no `.`) that function unconditionally does `f"{contract_name}.{right_side}"`. The harness path passed no `contract_name`, yielding `".MyEnum"`. Passing the name would give `"MyContract.MyEnum"`, which also fails to compile — the enum isn't a member of that contract.

`QUALIFIED` itself is correct for its other callers, which build Certora `fullSignature` strings for CVL method/summary matching (where `MyContract.MyEnum` is the expected form), so the shared helper must not change.

## Fix

- Add `TypeParseMode.SOLIDITY`, which emits **compilable** Solidity type references: file-level type → bare name (`MyEnum`); contract-nested type → qualified (`Lib.MyStruct`).
- Use `SOLIDITY` only for harness constructor-param generation (`setup_prover.py`). Everything else is untouched.

The bare name resolves in the harness because it does a plain `import "../../src/MyContract.sol"`, which re-exports that file's own imports (including `MyEnum`).

## Verification

- Unit-checked all modes on the real typeDesc: `SOLIDITY` → `MyEnum`, `QUALIFIED` unchanged → `MyContract.MyEnum`, nested struct → `Lib.MyStruct`.
- Compiled the corrected harness with the same `solc` and the project's remappings — no errors (previously a `ParserError`).

## Scope / risk

Additive: a new enum value plus one call-site swap in the harness path. No change to `QUALIFIED`/`DISPATCHER`/`CANONICAL`/`INTERNAL` behavior, so CVL signature matching is unaffected.
