### PR TITLE
autosetup: reset generated call-resolution spec on re-run (tentative)

### DIFF
--- a/certora_autosetup/autosetup/autosetup.py
+++ b/certora_autosetup/autosetup/autosetup.py
@@ -267,7 +267,10 @@ class Autosetup:
         # Step 5: Generate the user-facing sanity spec at certora/specs/sanity-{C}.spec.
         # It directly imports the summary aggregator, call resolution, and (when present) erc7201.
         # Must run after ERC-7201 detection (in setup_prover) so the erc7201 import is included.
-        self.rule_generator.generate_sanity_specs({main_contract_name: summary_spec_path})
+        self.rule_generator.generate_sanity_specs(
+            {main_contract_name: summary_spec_path},
+            reset_call_resolution_spec=not self.config.skip_call_resolution,
+        )
 
         # Step 6: Load bytes mappings
         self._load_bytes_mappings()

--- a/certora_autosetup/setup/sanity_rule_generator.py
+++ b/certora_autosetup/setup/sanity_rule_generator.py
@@ -24,13 +24,24 @@ class SanityRuleGenerator:
         self.certora_dir = certora_dir
         self.log = log_func if log_func else lambda msg, level="INFO": print(f"[{level}] {msg}")
 
-    def generate_sanity_specs(self, per_contract_summaries_specs: Dict[str, Path]) -> None:
+    def generate_sanity_specs(
+        self,
+        per_contract_summaries_specs: Dict[str, Path],
+        reset_call_resolution_spec: bool = False,
+    ) -> None:
         """Create per-contract sanity specs at certora/specs/sanity-{C}.spec.
 
         Each spec is the bundled sanity.spec body with three imports prepended:
         summary aggregator, call-resolution, and (when present) erc7201. Skip-if-exists
         so user edits survive re-runs. Also touches an empty call-resolution
         spec so the import resolves before call_resolution.py runs.
+
+        When ``reset_call_resolution_spec`` is set, the call-resolution spec is emptied
+        even if it already exists. It is a generated artifact that call_resolution.py
+        rewrites during warmup; a stale, populated one left over from a previous run
+        would be typechecked (via the sanity spec's import) against the freshly-trimmed
+        base config before call resolution regenerates it, failing with
+        "<contract> does not exist". Callers pass this whenever call resolution will run.
         """
         sanity_template = self.certora_dir / "sanity.spec"
         if not sanity_template.exists():
@@ -49,7 +60,7 @@ class SanityRuleGenerator:
 
             call_res_spec = user_call_resolution_spec_path(project_root, contract_name)
             call_res_spec.parent.mkdir(parents=True, exist_ok=True)
-            if not call_res_spec.exists():
+            if reset_call_resolution_spec or not call_res_spec.exists():
                 call_res_spec.write_text("")
 
             if target_spec.exists():


### PR DESCRIPTION
SG: we have an issue with contract selection/trimming due to call resolution and behavior is not idempotent. 
If we have call resolution and the autosetup run is cached, why do we need to run sanity which then fails.
If we have call resolution and the autosetup run is not cached, why do we not remove the call resolution spec files first?

--- 

**Tentative / draft — needs a maintainer sanity-check.** Clean first runs are *not* affected; this only fixes a re-run/idempotency case, and it's possible the intended design handles this differently.

## Symptom
Re-running `certora-autosetup` in a directory that already has a generated call-resolution spec (e.g. iterating with `--clear-cache`) aborts during cache warmup:

```
Error in spec file (<C>_call_resolution.spec:2:1): Tried to register <inst>
as <Contract> but <Contract> does not exist.
...
No fixable typechecker errors found -> Cache warmup failed - stopping orchestration
```

A clean first run in a pristine checkout succeeds.

## Root cause
`SanityRuleGenerator.generate_sanity_specs` only wrote an **empty** call-resolution spec when the file was **absent** (`if not call_res_spec.exists()`). The call-resolution spec is a generated artifact that `call_resolution.py` rewrites during warmup — but on a re-run a stale, *populated* spec from the previous run survives.

The warmup step (`autosetup.py:747-771`) trims the base config to `main + additional_contracts + libraries` and then typechecks the sanity spec (which imports the call-resolution spec) against that trimmed scene, **before** call resolution runs and re-adds the linked/dispatched contracts. The stale `using X as y` declarations reference contracts no longer in scene → hard typecheck error the fix-loop can't repair.

On a clean run the spec is empty at that point, the typecheck passes, and call resolution then repopulates the spec and re-adds the contracts.

## Fix
Reset the generated call-resolution spec to empty at the start of each run when call resolution will run (`reset_call_resolution_spec=not skip_call_resolution`). A re-run then behaves like a clean run. User-facing specs (the sanity spec) are still skip-if-exists; only the auto-generated call-resolution artifact is reset.

## Validation
Verified against a multi-contract Solidity project whose main contract links/dispatches to several sibling contracts.

| Scenario | master | this branch |
|---|---|---|
| Clean first run (default strip) | PASS (sanity) | unaffected |
| Re-run (`--clear-cache`, stale spec present) | FAIL — warmup typecheck aborts | PASS — autosetup completes |

## Open questions for reviewer
- Is resetting the generated spec each run the intended approach, or should the warmup trim instead retain the contracts the generated specs reference? (The trim is the deeper reason the stale spec can't typecheck.)
- Under `--skip-call-resolution` the spec is left as-is (not reset) — confirm that's desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
