### PR TITLE
Add curated CVL summaries for Solady SafeTransferLib, CREATE3, LibClone

### DIFF
--- a/certora_autosetup/certora/specs/summaries/Solady/CREATE3.spec
+++ b/certora_autosetup/certora/specs/summaries/Solady/CREATE3.spec
@@ -22,10 +22,10 @@ methods {
     function CREATE3.predictDeterministicAddress(bytes32 salt, address deployer) internal returns (address) => NONDET;
 
     // deployDeterministic — older Solady order (initCode, salt).
-    function CREATE3.deployDeterministic(bytes initCode, bytes32 salt) internal returns (address) => NONDET;
-    function CREATE3.deployDeterministic(uint256 value, bytes initCode, bytes32 salt) internal returns (address) => NONDET;
+    function CREATE3.deployDeterministic(bytes memory initCode, bytes32 salt) internal returns (address) => NONDET;
+    function CREATE3.deployDeterministic(uint256 value, bytes memory initCode, bytes32 salt) internal returns (address) => NONDET;
 
     // deployDeterministic — newer Solady order (salt, initCode).
-    function CREATE3.deployDeterministic(bytes32 salt, bytes initCode) internal returns (address) => NONDET;
-    function CREATE3.deployDeterministic(uint256 value, bytes32 salt, bytes initCode) internal returns (address) => NONDET;
+    function CREATE3.deployDeterministic(bytes32 salt, bytes memory initCode) internal returns (address) => NONDET;
+    function CREATE3.deployDeterministic(uint256 value, bytes32 salt, bytes memory initCode) internal returns (address) => NONDET;
 }

--- a/certora_autosetup/certora/specs/summaries/Solady/CREATE3.spec
+++ b/certora_autosetup/certora/specs/summaries/Solady/CREATE3.spec
@@ -1,0 +1,31 @@
+// Summarization of Solady's CREATE3 deterministic-deployment library.
+//
+// CREATE3 deploys via raw create/create2 assembly the prover cannot reason about, so each
+// function is summarized as NONDET: it returns an arbitrary address and models no side
+// effects. This is the same over-approximation setups apply by hand to a factory's
+// Clones.cloneDeterministic / predictDeterministicAddress calls.
+//
+// Documented limitation (inherent to the summary, not a bug): properties about the exact
+// deterministic address, or about duplicate-salt reverts (guards of the form
+// `predictDeterministicAddress(salt).code.length > 0`), cannot be verified — the address
+// is havoc'd, so such guards fire nondeterministically.
+//
+// deployDeterministic's argument order changed across Solady versions ((initCode, salt) in
+// older releases, (salt, initCode) in newer ones); both orders are listed. A project only
+// has one of them: the summary_resolver prune pass keeps entries by (receiver, name, arity),
+// and the TypecheckerLoop backstop auto-disables whichever overload is not in the project's
+// actual code — so listing both is safe (the non-matching one becomes inert).
+
+methods {
+    // predictDeterministicAddress — signatures are stable across Solady versions.
+    function CREATE3.predictDeterministicAddress(bytes32 salt) internal returns (address) => NONDET;
+    function CREATE3.predictDeterministicAddress(bytes32 salt, address deployer) internal returns (address) => NONDET;
+
+    // deployDeterministic — older Solady order (initCode, salt).
+    function CREATE3.deployDeterministic(bytes initCode, bytes32 salt) internal returns (address) => NONDET;
+    function CREATE3.deployDeterministic(uint256 value, bytes initCode, bytes32 salt) internal returns (address) => NONDET;
+
+    // deployDeterministic — newer Solady order (salt, initCode).
+    function CREATE3.deployDeterministic(bytes32 salt, bytes initCode) internal returns (address) => NONDET;
+    function CREATE3.deployDeterministic(uint256 value, bytes32 salt, bytes initCode) internal returns (address) => NONDET;
+}

--- a/certora_autosetup/certora/specs/summaries/Solady/LibClone.spec
+++ b/certora_autosetup/certora/specs/summaries/Solady/LibClone.spec
@@ -1,0 +1,116 @@
+// Summarization of Solady's LibClone (minimal-proxy / ERC-1967 clone factory library).
+//
+// Every LibClone deploy/clone/create/predict function creates or derives an address via raw
+// create/create2/extcodecopy assembly the prover cannot reason about, so each is summarized
+// as NONDET: arbitrary return values (address / (bool,address) / bytes32 code hash) with no
+// modeled side effects. This is the over-approximation setups apply by hand to a proxy
+// factory's deployDeterministicERC1967 / predictDeterministicAddress calls.
+//
+// Scope: the address-returning families (clone*, deploy*/create*ERC1967*, predict*,
+// implementationOf, erc1967Bootstrap) and the bytes32 initCodeHash* family. Deliberately
+// EXCLUDED: the immutable-argument readers argsOnClone/argsOnERC1967*/argLoad and the
+// initCode* (bytes) builders. Those read a proxy's immutable args out of its bytecode and,
+// for meaningful rules, need per-project ghosts correlating each clone to its args (a NONDET
+// bytes blob would drop that correlation) — so they are left to hand-written summaries.
+//
+// Documented limitation: exact-address and duplicate-salt-revert properties cannot be
+// verified under NONDET (the address is havoc'd).
+//
+// Signatures were generated from a real Solady LibClone compilation. Overloads absent from a
+// given project's Solady version are dropped by the summary_resolver prune pass (name/arity)
+// or auto-disabled by the TypecheckerLoop backstop (type mismatch), so listing the full set
+// is safe.
+
+methods {
+    function LibClone.clone(address) internal returns (address) => NONDET;
+    function LibClone.clone(address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.clone(uint256, address) internal returns (address) => NONDET;
+    function LibClone.clone(uint256, address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.cloneDeterministic(address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.cloneDeterministic(address, bytes32) internal returns (address) => NONDET;
+    function LibClone.cloneDeterministic(uint256, address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.cloneDeterministic(uint256, address, bytes32) internal returns (address) => NONDET;
+    function LibClone.cloneDeterministic_PUSH0(address, bytes32) internal returns (address) => NONDET;
+    function LibClone.cloneDeterministic_PUSH0(uint256, address, bytes32) internal returns (address) => NONDET;
+    function LibClone.clone_PUSH0(address) internal returns (address) => NONDET;
+    function LibClone.clone_PUSH0(uint256, address) internal returns (address) => NONDET;
+    function LibClone.createDeterministicClone(address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicClone(uint256, address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967(address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967(address, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967(uint256, address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967(uint256, address, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967BeaconProxy(address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967BeaconProxy(address, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967BeaconProxy(uint256, address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967BeaconProxy(uint256, address, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967I(address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967I(address, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967I(uint256, address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967I(uint256, address, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967IBeaconProxy(address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967IBeaconProxy(address, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967IBeaconProxy(uint256, address, bytes memory, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.createDeterministicERC1967IBeaconProxy(uint256, address, bytes32) internal returns (bool, address) => NONDET;
+    function LibClone.deployDeterministicERC1967(address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967(address, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967(uint256, address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967(uint256, address, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967BeaconProxy(address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967BeaconProxy(address, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967BeaconProxy(uint256, address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967BeaconProxy(uint256, address, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967I(address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967I(address, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967I(uint256, address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967I(uint256, address, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967IBeaconProxy(address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967IBeaconProxy(address, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967IBeaconProxy(uint256, address, bytes memory, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployDeterministicERC1967IBeaconProxy(uint256, address, bytes32) internal returns (address) => NONDET;
+    function LibClone.deployERC1967(address) internal returns (address) => NONDET;
+    function LibClone.deployERC1967(address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.deployERC1967(uint256, address) internal returns (address) => NONDET;
+    function LibClone.deployERC1967(uint256, address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.deployERC1967BeaconProxy(address) internal returns (address) => NONDET;
+    function LibClone.deployERC1967BeaconProxy(address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.deployERC1967BeaconProxy(uint256, address) internal returns (address) => NONDET;
+    function LibClone.deployERC1967BeaconProxy(uint256, address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.deployERC1967I(address) internal returns (address) => NONDET;
+    function LibClone.deployERC1967I(address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.deployERC1967I(uint256, address) internal returns (address) => NONDET;
+    function LibClone.deployERC1967I(uint256, address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.deployERC1967IBeaconProxy(address) internal returns (address) => NONDET;
+    function LibClone.deployERC1967IBeaconProxy(address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.deployERC1967IBeaconProxy(uint256, address) internal returns (address) => NONDET;
+    function LibClone.deployERC1967IBeaconProxy(uint256, address, bytes memory) internal returns (address) => NONDET;
+    function LibClone.erc1967Bootstrap() internal returns (address) => NONDET;
+    function LibClone.erc1967Bootstrap(address) internal returns (address) => NONDET;
+    function LibClone.implementationOf(address) internal returns (address) => NONDET;
+    function LibClone.initCodeHash(address) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHash(address, bytes memory) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967(address) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967(address, bytes memory) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967BeaconProxy(address) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967BeaconProxy(address, bytes memory) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967Bootstrap(address) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967I(address) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967I(address, bytes memory) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967IBeaconProxy(address) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHashERC1967IBeaconProxy(address, bytes memory) internal returns (bytes32) => NONDET;
+    function LibClone.initCodeHash_PUSH0(address) internal returns (bytes32) => NONDET;
+    function LibClone.predictDeterministicAddress(address, bytes memory, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddress(address, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddress(bytes32, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967(address, bytes memory, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967(address, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967BeaconProxy(address, bytes memory, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967BeaconProxy(address, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967Bootstrap() internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967Bootstrap(address, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967I(address, bytes memory, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967I(address, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967IBeaconProxy(address, bytes memory, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddressERC1967IBeaconProxy(address, bytes32, address) internal returns (address) => NONDET;
+    function LibClone.predictDeterministicAddress_PUSH0(address, bytes32, address) internal returns (address) => NONDET;
+}

--- a/certora_autosetup/certora/specs/summaries/Solady/SafeTransferLib.spec
+++ b/certora_autosetup/certora/specs/summaries/Solady/SafeTransferLib.spec
@@ -1,0 +1,72 @@
+// Summarization of Solady's SafeTransferLib functions.
+// Mirrors OpenZeppelin/OZ_SafeERC20.spec: the library wraps a raw token call in
+// assembly (which breaks the prover's pointer analysis), so we reroute each safe
+// wrapper to a direct token call and `require` success to model revert-on-failure.
+//
+// Uses an explicit `SafeTransferLib.` receiver (not the wildcard `_.` OZ_SafeERC20
+// uses): Solady's safeTransfer(address,address,uint256) shares the same erased
+// signature as OZ SafeERC20's, so an explicit receiver avoids a double-declaration
+// conflict when a project imports both libraries, and makes each entry eligible for
+// the summary_resolver prune pass.
+//
+// Out of scope (left unsummarized): ETH helpers (safeTransferETH, forceSafeTransferETH,
+// trySafeTransferETH, safeTransferAllETH) — raw call{value:}, would need a BALANCE hook
+// to model ETH effects; the balance-derived variants (safeTransferAll/safeTransferAllFrom);
+// and the Permit2 helpers (safeTransferFrom2, permit2, permit2TransferFrom).
+
+methods {
+    function SafeTransferLib.safeTransfer(address token, address to, uint256 amount) internal =>
+        cvl_safeTransfer(executingContract, token, to, amount) expect void;
+
+    function SafeTransferLib.safeTransferFrom(address token, address from, address to, uint256 amount) internal =>
+        cvl_safeTransferFrom(executingContract, token, from, to, amount) expect void;
+
+    function SafeTransferLib.safeApprove(address token, address to, uint256 amount) internal =>
+        cvl_safeApprove(executingContract, token, to, amount) expect void;
+
+    // safeApproveWithRetry has the same success semantics as safeApprove; the retry path
+    // only matters when the first approve reverts, which our success-modeling elides.
+    function SafeTransferLib.safeApproveWithRetry(address token, address to, uint256 amount) internal =>
+        cvl_safeApprove(executingContract, token, to, amount) expect void;
+
+    function SafeTransferLib.balanceOf(address token, address account) internal returns (uint256) =>
+        cvl_balanceOf(token, account);
+}
+
+// Direct call to the token's transfer function. SafeTransferLib checks the return value
+// and reverts on failure, so we require success to model that behavior.
+function cvl_safeTransfer(address executing_contract, address token, address to, uint256 amount) {
+    env e;
+    require e.msg.sender == executing_contract, "The caller must be the contract executing the SafeTransferLib function";
+
+    bool success = token.transfer(e, to, amount);
+
+    require success, "SafeTransferLib would revert on failure, so we model this behavior";
+}
+
+// Direct call to the token's transferFrom function.
+function cvl_safeTransferFrom(address executing_contract, address token, address from, address to, uint256 amount) {
+    env e;
+    require e.msg.sender == executing_contract, "The caller must be the contract executing the SafeTransferLib function";
+
+    bool success = token.transferFrom(e, from, to, amount);
+
+    require success, "SafeTransferLib would revert on failure, so we model this behavior";
+}
+
+// Direct call to the token's approve function.
+function cvl_safeApprove(address executing_contract, address token, address to, uint256 amount) {
+    env e;
+    require e.msg.sender == executing_contract, "The caller must be the contract executing the SafeTransferLib function";
+
+    bool success = token.approve(e, to, amount);
+
+    require success, "SafeTransferLib would revert on failure, so we model this behavior";
+}
+
+// Direct call to the token's balanceOf. SafeTransferLib.balanceOf reverts if the call
+// fails; modeled here as a plain successful read.
+function cvl_balanceOf(address token, address account) returns uint256 {
+    env e;
+    return token.balanceOf(e, account);
+}

--- a/certora_autosetup/setup/function_summaries.json
+++ b/certora_autosetup/setup/function_summaries.json
@@ -183,5 +183,11 @@
     "library_names": ["CREATE3"],
     "summary_file": "specs/summaries/Solady/CREATE3.spec",
     "description": "Solady CREATE3.predictDeterministicAddress (NONDET address)"
+  },
+  "solady_libclone": {
+    "names": ["clone", "cloneDeterministic", "cloneDeterministic_PUSH0", "clone_PUSH0", "createDeterministicClone", "createDeterministicERC1967", "createDeterministicERC1967BeaconProxy", "createDeterministicERC1967I", "createDeterministicERC1967IBeaconProxy", "deployDeterministicERC1967", "deployDeterministicERC1967BeaconProxy", "deployDeterministicERC1967I", "deployDeterministicERC1967IBeaconProxy", "deployERC1967", "deployERC1967BeaconProxy", "deployERC1967I", "deployERC1967IBeaconProxy", "erc1967Bootstrap", "implementationOf", "initCodeHash", "initCodeHashERC1967", "initCodeHashERC1967BeaconProxy", "initCodeHashERC1967Bootstrap", "initCodeHashERC1967I", "initCodeHashERC1967IBeaconProxy", "initCodeHash_PUSH0", "predictDeterministicAddress", "predictDeterministicAddressERC1967", "predictDeterministicAddressERC1967BeaconProxy", "predictDeterministicAddressERC1967Bootstrap", "predictDeterministicAddressERC1967I", "predictDeterministicAddressERC1967IBeaconProxy", "predictDeterministicAddress_PUSH0"],
+    "library_names": ["LibClone"],
+    "summary_file": "specs/summaries/Solady/LibClone.spec",
+    "description": "Solady LibClone clone/deploy/predict/initCodeHash (NONDET)"
   }
 }

--- a/certora_autosetup/setup/function_summaries.json
+++ b/certora_autosetup/setup/function_summaries.json
@@ -171,5 +171,17 @@
     "library_names": ["SafeTransferLib"],
     "summary_file": "specs/summaries/Solady/SafeTransferLib.spec",
     "description": "Solady SafeTransferLib.balanceOf"
+  },
+  "solady_create3_deploy": {
+    "names": ["deployDeterministic"],
+    "library_names": ["CREATE3"],
+    "summary_file": "specs/summaries/Solady/CREATE3.spec",
+    "description": "Solady CREATE3.deployDeterministic (NONDET address)"
+  },
+  "solady_create3_predict": {
+    "names": ["predictDeterministicAddress"],
+    "library_names": ["CREATE3"],
+    "summary_file": "specs/summaries/Solady/CREATE3.spec",
+    "description": "Solady CREATE3.predictDeterministicAddress (NONDET address)"
   }
 }

--- a/certora_autosetup/setup/function_summaries.json
+++ b/certora_autosetup/setup/function_summaries.json
@@ -147,5 +147,29 @@
     "library_names": ["CTHelpers"],
     "summary_file": "specs/summaries/CTHelpers.spec",
     "description": "Gnosis Conditional Tokens CTHelpers.getCollectionId (bn128 collection-id derivation)"
+  },
+  "solady_safeTransfer": {
+    "names": ["safeTransfer"],
+    "library_names": ["SafeTransferLib"],
+    "summary_file": "specs/summaries/Solady/SafeTransferLib.spec",
+    "description": "Solady SafeTransferLib.safeTransfer"
+  },
+  "solady_safeTransferFrom": {
+    "names": ["safeTransferFrom"],
+    "library_names": ["SafeTransferLib"],
+    "summary_file": "specs/summaries/Solady/SafeTransferLib.spec",
+    "description": "Solady SafeTransferLib.safeTransferFrom"
+  },
+  "solady_safeApprove": {
+    "names": ["safeApprove", "safeApproveWithRetry"],
+    "library_names": ["SafeTransferLib"],
+    "summary_file": "specs/summaries/Solady/SafeTransferLib.spec",
+    "description": "Solady SafeTransferLib.safeApprove"
+  },
+  "solady_balanceOf": {
+    "names": ["balanceOf"],
+    "library_names": ["SafeTransferLib"],
+    "summary_file": "specs/summaries/Solady/SafeTransferLib.spec",
+    "description": "Solady SafeTransferLib.balanceOf"
   }
 }


### PR DESCRIPTION
Curated CVL summaries for three Solady libraries whose inline assembly breaks the prover:

- **SafeTransferLib** — reroute safe wrappers to direct token calls (mirrors the OZ SafeERC20 summary).
- **CREATE3** & **LibClone** — NONDET the deterministic deploy/clone/predict functions (opaque create2 assembly). Limitation: exact-address / duplicate-salt-revert properties become unverifiable.

Gated by library name in `function_summaries.json`. Version/overload variants are handled by the existing prune pass (name/arity) + TypecheckerLoop backstop, so overloads absent from a project go inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)