### PR TITLE
Summarizer: reject view-class summaries on payable methods

### DIFF
--- a/composer/cvl/summary_audit.py
+++ b/composer/cvl/summary_audit.py
@@ -1,0 +1,120 @@
+"""
+Audit for view-class summaries on payable methods.
+
+A view-class summary (``NONDET``, ``CONSTANT``, ``PER_CALLEE_CONSTANT``,
+``ALWAYS``) replaces the callee with an approximation that has no state
+effects. On a payable method that erases the callee's ETH accounting, so a
+caller that compensates after the call (e.g. checks its balance decreased by
+the sent value) reverts on every path and all of its rules pass vacuously.
+
+The audit walks the typed CVL AST — never the surface text — and checks the
+summarized methods' mutability against the method inventory the AutoSetup
+build already wrote (``.certora_internal/all_methods.json``). If the inventory
+is missing the audit is a no-op: the prompt-level rule still applies, and a
+missing artifact must not block spec generation.
+"""
+import json
+import logging
+from pathlib import Path
+from typing import Mapping
+
+from composer.cvl.schema import (
+    AlwaysSummary,
+    CallSummary,
+    CatchAllSummary,
+    CVLFile,
+    HavocingSummary,
+    ImportedFunction,
+    KeywordSummary,
+    MethodsBlock,
+)
+
+_logger = logging.getLogger(__name__)
+
+# Domain aliases: method inventories key methods by (contract, method).
+type ContractName = str
+type MethodName = str
+
+# Written by AutoSetup's compilation analysis, relative to the project root.
+_ALL_METHODS_JSON = Path(".certora_internal/all_methods.json")
+
+_PAYABLE = "payable"
+
+
+def load_payable_methods(project_root: Path) -> Mapping[ContractName, frozenset[MethodName]] | None:
+    """Payable external/public methods per contract, or None when the
+    inventory artifact is absent or unreadable (audit then degrades to no-op)."""
+    path = project_root / _ALL_METHODS_JSON
+    try:
+        entries = json.loads(path.read_text())
+    except (OSError, ValueError):
+        _logger.warning("Method inventory %s unavailable; payable-summary audit skipped", path)
+        return None
+    payable: dict[ContractName, set[MethodName]] = {}
+    for entry in entries:
+        if entry.get("stateMutability") == _PAYABLE and entry.get("visibility") in ("external", "public"):
+            payable.setdefault(entry.get("contractName", ""), set()).add(entry.get("name", ""))
+    return {contract: frozenset(names) for contract, names in payable.items()}
+
+
+def _is_view_class(summary: CallSummary) -> bool:
+    match summary:
+        case HavocingSummary(havoc_keyword="nondet"):
+            return True
+        case KeywordSummary() | AlwaysSummary():
+            return True
+        case _:
+            # Other havoc keywords stay conservative about state/ETH effects;
+            # expression summaries model effects explicitly; dispatchers inline
+            # real implementations. None of these erase ETH accounting.
+            return False
+
+
+def _payable_matches(
+    payable: Mapping[ContractName, frozenset[MethodName]],
+    contract: ContractName | None,
+    method: MethodName,
+    current_contract: ContractName,
+) -> list[str]:
+    """Qualified names of payable methods a summary on contract.method covers.
+    ``contract`` follows MethodReference: None = current contract, "_" = wildcard."""
+    if contract == "_":
+        return [f"{c}.{method}" for c, names in payable.items() if method in names]
+    host = current_contract if contract is None else contract
+    return [f"{host}.{method}"] if method in payable.get(host, frozenset()) else []
+
+
+def view_summary_violations(
+    cvl: CVLFile,
+    payable: Mapping[ContractName, frozenset[MethodName]],
+    current_contract: ContractName,
+) -> list[str]:
+    """One message per view-class summary that covers a payable method."""
+    violations: list[str] = []
+    for block in cvl.blocks:
+        if not isinstance(block, MethodsBlock):
+            continue
+        for entry in block.method_entries:
+            match entry:
+                case ImportedFunction(summary=summary, signature=sig) if summary is not None and _is_view_class(summary):
+                    hits = _payable_matches(
+                        payable, sig.method_ref.contract, sig.method_ref.method_name, current_contract
+                    )
+                    violations.extend(
+                        f"View-class summary on payable method {hit}: it erases the callee's ETH "
+                        "effects, so callers that account for the transferred value revert on every "
+                        "path and their rules pass vacuously. Use an expression summary over ghost "
+                        "state, or a havoc summary."
+                        for hit in hits
+                    )
+                case CatchAllSummary(contract_name=contract, summary=summary) if _is_view_class(summary):
+                    covered = sorted(payable.get(contract, frozenset()))
+                    if covered:
+                        violations.append(
+                            f"Catch-all view-class summary on {contract}._ also covers its payable "
+                            f"method(s) {', '.join(covered)}; summarize those separately with an "
+                            "expression or havoc summary."
+                        )
+                case _:
+                    pass
+    return violations

--- a/composer/spec/source/summarizer.py
+++ b/composer/spec/source/summarizer.py
@@ -22,7 +22,10 @@ from graphcore.graph import FlowInput, MessagesState, tool_state_update
 from graphcore.tools.schemas import WithImplementation, WithInjectedState, WithInjectedId
 
 from composer.spec.graph_builder import bind_standard, run_to_completion
-from composer.cvl.tools import get_cvl, put_cvl, put_cvl_raw, edit_cvl
+from composer.cvl.pretty_print import pretty_print
+from composer.cvl.schema import CVLFile
+from composer.cvl.summary_audit import load_payable_methods, view_summary_violations
+from composer.cvl.tools import DEFAULT_READ_KEY, DEFAULT_SPEC_KEY, get_cvl, maybe_update_cvl
 from composer.spec.gen_types import CVLResource, SUMMARIES_DIR, under_project
 from composer.spec.context import WorkflowContext, SourceCode, CacheKey
 from composer.spec.util import temp_certora_file, string_hash, ensure_dir
@@ -30,7 +33,7 @@ from composer.spec.service_host import ServiceHost
 from composer.spec.source.harness import ContractSetup, ExternalInterface, HarnessDef
 from composer.spec.system_model import HarnessedApplication, ExternalActor
 from composer.spec.gen_types import TypedTemplate
-from composer.ui.tool_display import tool_display
+from composer.ui.tool_display import suppress_ack, tool_display
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +147,41 @@ class _TypeChecker(
                 else:
                     return f"Typechecking failed:\nstdout:\n{res.stdout}\n{res.stderr}"
 
+@tool_display(lambda p: "Writing summaries spec", suppress_ack("Put result", ("Accepted",)))
+class _PutSummaries(WithInjectedId, WithImplementation[Command | str]):
+    """
+    Put the summaries CVL file using the structured AST representation.
+
+    The file is pretty printed and run through the official CVL parser; a parse
+    failure rejects the update with the reported errors. Additionally, view-class
+    summaries (NONDET / CONSTANT / PER_CALLEE_CONSTANT / ALWAYS) on payable
+    methods are rejected: they erase the callee's ETH effects and make every
+    compensating caller vacuously revert.
+    """
+    cvl_file: dict = Field(description="The CVL AST to put in the VFS")
+
+    @override
+    def run(self) -> Command | str:
+        source = get_runtime(SummaryContext).context.source
+        try:
+            parsed = CVLFile.model_validate(self.cvl_file)
+            pp = pretty_print(parsed)
+        except Exception:
+            return "Failed to pretty print the AST"
+        payable = load_payable_methods(pathlib.Path(source.project_root))
+        if payable is not None:
+            violations = view_summary_violations(parsed, payable, source.contract_name)
+            if violations:
+                return "Update rejected:\n" + "\n".join(f"- {v}" for v in violations)
+        return maybe_update_cvl(
+            tool_call_id=self.tool_call_id,
+            pp=pp,
+            ast_json=self.cvl_file,
+            reset_read=DEFAULT_READ_KEY,
+            spec_key=DEFAULT_SPEC_KEY,
+        )
+
+
 @tool_display("Writing Plan", None)
 class _PlanWrite(WithInjectedId, WithImplementation[Command]):
     """
@@ -205,11 +243,12 @@ async def _setup_summaries_impl(
             return "Spec has not been typechecked"
         return None
 
+    # Summaries specs are small, so every write goes through the structured
+    # put_cvl (here _PutSummaries) — that is what lets the payable audit see a
+    # typed AST instead of surface text. No raw/edit escape hatches.
     tools = [
         get_cvl(ST),
-        edit_cvl(ST),
-        put_cvl_raw,
-        put_cvl,
+        _PutSummaries.as_tool("put_cvl"),
         _PlanReader.as_tool("read_plan"),
         _PlanWrite.as_tool("plan_write"),
         _TypeChecker.as_tool("typechecker")

--- a/composer/templates/cvl_setup_summarization_prompt.j2
+++ b/composer/templates/cvl_setup_summarization_prompt.j2
@@ -165,5 +165,11 @@ Signal the completion of your work by calling the "result" tool.
     DO NOT, under any circumstances, use "assert" in any of the summaries you write. If you need to "exceptionally abort"
     a summary, use the "revert" statement.
   </hard_requirement>
+  <hard_requirement>
+    Do *NOT* apply a view-class summary (NONDET, CONSTANT, PER_CALLEE_CONSTANT, ALWAYS) to a *payable* method.
+    Such a summary erases the callee's ETH effects, so a caller that accounts for the transferred value
+    (e.g. checks its balance after the call) reverts on every path and all of its rules pass vacuously.
+    Model payable methods with an expression summary over ghost state, or leave them havocing.
+  </hard_requirement>
 </guidance>
 </task>

--- a/tests/test_summary_audit.py
+++ b/tests/test_summary_audit.py
@@ -1,0 +1,112 @@
+"""Tests for the payable view-summary audit over the typed CVL AST."""
+import json
+
+from composer.cvl.schema import (
+    AlwaysSummary,
+    BoolLiteral,
+    CatchAllSummary,
+    CVLFile,
+    DispatcherSummary,
+    ExpressionSummary,
+    HavocingSummary,
+    ImportedFunction,
+    KeywordSummary,
+    MethodReference,
+    MethodSignature,
+    MethodsBlock,
+    NumberLiteral,
+)
+from composer.cvl.summary_audit import load_payable_methods, view_summary_violations
+
+
+def _entry(method: str, contract: str | None, summary) -> ImportedFunction:
+    return ImportedFunction(
+        type="imported_function",
+        signature=MethodSignature(
+            method_ref=MethodReference(contract=contract, method_name=method),
+            parameters=[],
+            return_types=[],
+            visibility="external",
+            post_flags=[],
+        ),
+        summary=summary,
+    )
+
+
+def _spec(*entries) -> CVLFile:
+    return CVLFile(
+        import_specs=[],
+        import_contract=[],
+        blocks=[MethodsBlock(type="methods_block", method_entries=list(entries))],
+    )
+
+
+_NONDET = HavocingSummary(type="havocing", havoc_keyword="nondet")
+_PAYABLE = {"Vault": frozenset({"deposit"}), "Router": frozenset({"swap"})}
+
+
+class TestViewSummaryViolations:
+    def test_nondet_on_payable_wildcard(self):
+        spec = _spec(_entry("deposit", "_", _NONDET))
+        violations = view_summary_violations(spec, _PAYABLE, "Main")
+        assert len(violations) == 1 and "Vault.deposit" in violations[0]
+
+    def test_nondet_on_payable_named_contract(self):
+        spec = _spec(_entry("swap", "Router", _NONDET))
+        assert len(view_summary_violations(spec, _PAYABLE, "Main")) == 1
+
+    def test_current_contract_reference(self):
+        spec = _spec(_entry("deposit", None, _NONDET))
+        assert view_summary_violations(spec, _PAYABLE, "Vault")
+        assert not view_summary_violations(spec, _PAYABLE, "Main")
+
+    def test_view_method_allowed(self):
+        spec = _spec(_entry("balanceOf", "_", _NONDET))
+        assert not view_summary_violations(spec, _PAYABLE, "Main")
+
+    def test_constant_and_always_flagged(self):
+        constant = KeywordSummary(type="keyword", summary_keyword="constant")
+        always = AlwaysSummary(type="always", expression=BoolLiteral(type="bool_literal", value=True))
+        spec = _spec(_entry("deposit", "Vault", constant), _entry("swap", "Router", always))
+        assert len(view_summary_violations(spec, _PAYABLE, "Main")) == 2
+
+    def test_expression_dispatcher_and_havoc_allowed(self):
+        expression = ExpressionSummary(type="expression", expression=NumberLiteral(type="number_literal", value="0"))
+        dispatcher = DispatcherSummary(type="dispatcher", optimistic=True, use_fallback=True)
+        havoc = HavocingSummary(type="havocing", havoc_keyword="havoc_ecf")
+        spec = _spec(
+            _entry("deposit", "Vault", expression),
+            _entry("swap", "Router", dispatcher),
+            _entry("deposit", "_", havoc),
+        )
+        assert not view_summary_violations(spec, _PAYABLE, "Main")
+
+    def test_catch_all_over_payable_contract(self):
+        spec = _spec(CatchAllSummary(type="catch_all", contract_name="Vault", summary=_NONDET))
+        violations = view_summary_violations(spec, _PAYABLE, "Main")
+        assert len(violations) == 1 and "deposit" in violations[0]
+
+    def test_catch_all_over_view_only_contract(self):
+        spec = _spec(CatchAllSummary(type="catch_all", contract_name="Oracle", summary=_NONDET))
+        assert not view_summary_violations(spec, _PAYABLE, "Main")
+
+    def test_unsummarized_entry_ignored(self):
+        spec = _spec(_entry("deposit", "Vault", None))
+        assert not view_summary_violations(spec, _PAYABLE, "Main")
+
+
+class TestLoadPayableMethods:
+    def test_loads_external_and_public_payable(self, tmp_path):
+        inventory = [
+            {"contractName": "Vault", "name": "deposit", "stateMutability": "payable", "visibility": "external"},
+            {"contractName": "Vault", "name": "sweep", "stateMutability": "payable", "visibility": "public"},
+            {"contractName": "Vault", "name": "peek", "stateMutability": "view", "visibility": "external"},
+            {"contractName": "Vault", "name": "stash", "stateMutability": "payable", "visibility": "internal"},
+        ]
+        path = tmp_path / ".certora_internal" / "all_methods.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(inventory))
+        assert load_payable_methods(tmp_path) == {"Vault": frozenset({"deposit", "sweep"})}
+
+    def test_missing_inventory_returns_none(self, tmp_path):
+        assert load_payable_methods(tmp_path) is None


### PR DESCRIPTION
The interface summarizer's LLM freely wrote `=> NONDET` for payable methods. That erases the callee's ETH effects; a caller that accounts for the transferred value (e.g. a post-call balance check) then reverts on every path, and its rules pass vacuously.

- `composer/cvl/summary_audit.py`: walks the typed CVL AST (no text matching), flags NONDET/CONSTANT/PER_CALLEE_CONSTANT/ALWAYS on payable methods, incl. wildcard and catch-all entries. Payability comes from the build's `all_methods.json`; missing inventory degrades to no-op.
- Summarizer's put tool runs the audit and rejects violations; raw/edit escape hatches removed from this flow so every write is auditable.
- One hard rule added to the summarization prompt.

Tests: 11 new; full suite 114 passed; pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)