### PR TITLE
Fix console-foundry startup crash: model-tier args were never registered

### DIFF
--- a/composer/foundry/entry.py
+++ b/composer/foundry/entry.py
@@ -29,7 +29,7 @@ from composer.core.user import user_data_ns
 from composer.diagnostics.logging_setup import setup_autoprove_logging
 from composer.diagnostics.timing import RunSummary, install_run_summary
 from composer.input.parsing import Arg, add_protocol_args
-from composer.input.types import DEFAULT_RECURSION_LIMIT, TieredModelOptions, RAGDBOptions
+from composer.input.types import DEFAULT_RECURSION_LIMIT, ExtendedModelOptions, RAGDBOptions
 from composer.io.multi_job import HandlerFactory
 from composer.io.thread_logging import thread_logger, default_logging_ns
 from composer.kb.knowledge_base import DefaultEmbedder
@@ -66,7 +66,7 @@ class FoundryRAGDBOptions(RAGDBOptions, Protocol):
     )]
 
 
-class FoundryArgs(TieredModelOptions, FoundryRAGDBOptions, Protocol):
+class FoundryArgs(ExtendedModelOptions, FoundryRAGDBOptions, Protocol):
     project_root: str
     main_contract: str
     system_doc: str | None
@@ -112,13 +112,12 @@ type FoundryRunner = Callable[
 ]
 
 
-@asynccontextmanager
-async def _entry_point(summary: RunSummary) -> AsyncIterator[FoundryRunner]:
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Foundry-test author for a property-extraction pipeline",
     )
     add_protocol_args(parser, FoundryRAGDBOptions)
-    add_protocol_args(parser, TieredModelOptions)
+    add_protocol_args(parser, ExtendedModelOptions)
     parser.add_argument(
         "--recursion-limit", type=int, default=DEFAULT_RECURSION_LIMIT,
         help=f"Max graph iterations (default: {DEFAULT_RECURSION_LIMIT})",
@@ -134,7 +133,12 @@ async def _entry_point(summary: RunSummary) -> AsyncIterator[FoundryRunner]:
     parser.add_argument("--max-bug-rounds", type=int, default=3, help="Max bug-extraction rounds per component (default: 3)")
     parser.add_argument("--forge-binary", default="forge", help="`forge` executable on PATH (default: forge)")
     parser.add_argument("--forge-timeout-s", type=int, default=600, help="Per-`forge test` invocation timeout in seconds (default: 600)")
+    return parser
 
+
+@asynccontextmanager
+async def _entry_point(summary: RunSummary) -> AsyncIterator[FoundryRunner]:
+    parser = _build_parser()
     args = cast(FoundryArgs, parser.parse_args())
 
     project_root = pathlib.Path(args.project_root).resolve()

--- a/tests/test_foundry_entry_args.py
+++ b/tests/test_foundry_entry_args.py
@@ -1,0 +1,26 @@
+"""Regression test for the console-foundry argument parser.
+
+The entry point consumes model-tier options (``heavy_model``, ``lite_model``,
+``tokens``, ...) from the parsed namespace. The parser used to register
+``TieredModelOptions`` — a read-only ``@property`` protocol that contributes no
+argparse options — so every console-foundry invocation crashed with
+``AttributeError: 'Namespace' object has no attribute 'heavy_model'`` before
+the pipeline started. The parser must register ``ExtendedModelOptions``, whose
+``Arg`` annotations actually produce the options.
+"""
+
+from composer.foundry.entry import _build_parser
+
+
+def test_foundry_parser_provides_model_tier_args() -> None:
+    args = _build_parser().parse_args(["proj", "src/C.sol:C", "doc.md"])
+    for attr in (
+        "heavy_model",
+        "lite_model",
+        "tokens",
+        "thinking_tokens",
+        "memory_tool",
+        "interleaved_thinking",
+        "rag_db",
+    ):
+        assert hasattr(args, attr), f"parser is missing --{attr.replace('_', '-')}"


### PR DESCRIPTION
## Problem

Every `console-foundry` invocation crashes at startup, before the pipeline runs:

```
File "composer/foundry/entry.py", line 198, in _entry_point
    heavy_model=args.heavy_model,
AttributeError: 'Namespace' object has no attribute 'heavy_model'
```

The entry point registers `TieredModelOptions` via `add_protocol_args`, but that protocol only declares read-only `@property` members, so it contributes **no** argparse options. The entry point then reads `args.heavy_model`, `args.lite_model`, and (via `llm_factory(args)`) `args.tokens` / `args.thinking_tokens` / etc. from the namespace. Regressed in AIComposer#139 (`console-autoprove` was switched to `ExtendedModelOptions`; the foundry entry got the read-only view instead).

## Fix

Register `ExtendedModelOptions` — the `Arg`-annotated protocol that actually produces `--heavy-model` / `--lite-model` / `--tokens` / `--thinking-tokens` / `--memory-tool` / `--interleaved-thinking` — mirroring `autoprove_common`. `FoundryArgs` updated accordingly.

Parser construction is extracted into `_build_parser()` so it's unit-testable; `tests/test_foundry_entry_args.py` asserts the parsed namespace carries every model-tier attribute the entry point consumes (this test fails on master with the AttributeError's root cause).

## Validation

- `console-foundry --help` now lists the model-tier flags.
- A real `console-foundry` run on a minimal foundry project gets past argument handling into the pipeline.
- Regression assertion run locally against the fixed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)