### PR TITLE
Add token usage to foundry flow

### DIFF
--- a/composer/foundry/entry.py
+++ b/composer/foundry/entry.py
@@ -16,22 +16,29 @@ from the non-source spec modules).
 """
 
 import argparse
+import logging
 import uuid
 from contextlib import asynccontextmanager
 from typing import Annotated, AsyncIterator, Awaitable, Callable, Protocol, cast
 
+from composer.core.user import get_uid
 from composer.diagnostics.timing import RunSummary
 from composer.input.parsing import Arg, add_protocol_args
 from composer.input.types import DEFAULT_RECURSION_LIMIT, RAGDBOptions, ExtendedModelOptions
 from composer.io.multi_job import HandlerFactory
+from composer.io.thread_logging import RunDataLogger
 from composer.rag.db import FOUNDRY_DEFAULT_CONNECTION, PostgreSQLRAGDatabase
+from composer.spec.context import SourceFields
 from composer.spec.util import FS_FORBIDDEN_READ
 
+from composer.foundry.artifacts import FoundryArtifactStore
 from composer.foundry.env import build_foundry_env
 from composer.foundry.pipeline import (
     FoundryPhase, FoundryPipelineResult, backend
 )
-from composer.pipeline.cli import cli_pipeline, user_ns
+from composer.pipeline.cli import cli_pipeline, user_ns, AtExit
+
+_log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +86,29 @@ type FoundryRunner = Callable[
 ]
 
 
+def _usage_exit_logger(summary: RunSummary) -> AtExit:
+    """The ``cli_pipeline`` teardown hook that persists this run's LLM usage — the
+    foundry counterpart to the autoprove flow's ``exit_logger``.
+
+    Logs the ``token_usage`` summary into the run's data_ns and always dumps the
+    ``job_info.json`` run manifest (identity + token usage) next to the foundry
+    ``report.json`` (``certora/foundry/reports/``) — on success or crash — so a foundry
+    job's cost is on disk even when the pipeline never produced a report. Each step is
+    guarded so a teardown failure can't mask the pipeline's own outcome."""
+    async def exit_logger(run: SourceFields, logger: RunDataLogger) -> None:
+        try:
+            await logger("token_usage", summary.token_usage_summary())
+        except Exception:
+            _log.exception("failed to log foundry usage to run data")
+        try:
+            FoundryArtifactStore(run.project_root).write_job_info(
+                summary, user_id=get_uid()
+            )
+        except Exception:
+            _log.exception("failed to dump foundry job info")
+    return exit_logger
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Foundry-test author for a property-extraction pipeline",
@@ -120,7 +150,7 @@ async def _entry_point(summary: RunSummary) -> AsyncIterator[FoundryRunner]:
                   summary=summary,
                   task_handler=fact,
                   design_doc_phase=cast(FoundryPhase, FoundryPhase.DISCOVER_DESIGN_DOC),
-                  at_exit=None,
+                  at_exit=_usage_exit_logger(summary),
                   workflow="foundry"
             ) as (staged, cont),
             PostgreSQLRAGDatabase.rag_context(staged.embed_model, args.rag_db) as foundry_rag_db,

--- a/composer/spec/artifacts.py
+++ b/composer/spec/artifacts.py
@@ -11,6 +11,7 @@ domain objects into ``stem``s and call these primitives.
 """
 
 import json
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TypedDict, Unpack
@@ -21,6 +22,8 @@ from composer.spec.types import PropertyFormulation
 from composer.spec.util import ensure_dir
 from .types import ArtifactIdentifier, FormalResult
 from composer.spec.source.report.schema import AutoProverReport
+
+_log = logging.getLogger(__name__)
 
 
 class StoreConfiguration(TypedDict):
@@ -120,3 +123,22 @@ class ArtifactStore[I: ArtifactIdentifier, FormT: FormalResult](ABC):
         (ensure_dir(self._internal_dir()) / "token_usage.json").write_text(
             json.dumps(payload, indent=2)
         )
+
+    def _job_info_payload(self, summary: RunSummary, *, user_id: str) -> dict[str, object]:
+        """The manifest body shared by every workflow: the tenant ``user_id``, the run's
+        ``run_id``, and the accumulated LLM ``token_usage``. Subclasses extend it with
+        any backend-specific usage they track."""
+        return {
+            "user_id": user_id,
+            "run_id": summary.run_id,
+            "token_usage": summary.token_usage_summary(),
+        }
+
+    def write_job_info(self, summary: RunSummary, *, user_id: str) -> None:
+        """The run's identity + usage manifest → ``{report}/job_info.json``, next to
+        ``report.json``. ``user_id`` is passed in so this stays a pure serializer of run
+        state; the body is :meth:`_job_info_payload`, which subclasses extend."""
+        payload = self._job_info_payload(summary, user_id=user_id)
+        out = self._report_dir() / "job_info.json"
+        out.write_text(json.dumps(payload, indent=2) + "\n")
+        _log.info("job info: wrote %s", out)

--- a/composer/spec/source/artifacts.py
+++ b/composer/spec/source/artifacts.py
@@ -121,16 +121,12 @@ class ProverArtifactStore(ArtifactStore[SpecIdentity, GeneratedCVL]):
         out_dir = ensure_dir(self._internal_dir())
         (out_dir / "components_to_prover_runs.json").write_text(json.dumps(runs, indent=2))
 
-    def write_job_info(self, summary: RunSummary, *, user_id: str) -> None:
-        """The run's identity + usage manifest — ``user_id``, ``run_id``, and the
-        ``token_usage`` / ``prover_usage`` summaries — to ``certora/ap_report/job_info.json``.
-        ``user_id`` is passed in so this stays a pure serializer of run state."""
-        payload = {
-            "user_id": user_id,
-            "run_id": summary.run_id,
-            "token_usage": summary.token_usage_summary(),
+    @override
+    def _job_info_payload(self, summary: RunSummary, *, user_id: str) -> dict[str, object]:
+        """Extends the shared manifest body with the prover-reported runtime: the
+        autoprove ``job_info.json`` also records ``prover_usage`` (summed prover
+        start-to-end time), alongside the base identity + ``token_usage``."""
+        return {
+            **super()._job_info_payload(summary, user_id=user_id),
             "prover_usage": summary.prover_usage_summary(),
         }
-        out = self._report_dir() / "job_info.json"
-        out.write_text(json.dumps(payload, indent=2) + "\n")
-        _log.info("autoprove job info: wrote %s", out)

--- a/composer/spec/source/autoprove_common.py
+++ b/composer/spec/source/autoprove_common.py
@@ -124,7 +124,7 @@ async def autoprove_executor(args: AutoProveArgs, summary: RunSummary) -> AsyncI
                 task_handler=handler,
                 at_exit=exit_logger,
 
-                worfklow="autoprove"
+                workflow="autoprove"
             ) as (staged, cont),
             PostgreSQLRAGDatabase.rag_context(staged.embed_model, args.rag_db) as rag_db
 


### PR DESCRIPTION
Extract the token usage logging from `ProverArtifactStore` into `ArtifactStore` and use it also in the foundry flow.