### PR TITLE
make the prover global_timeout overridable via AUTOPROVER_GLOBAL_PROVER_TIMEOUT

### DIFF
--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -76,15 +76,15 @@ GLOBAL_PROVER_TIMEOUT_ENV = "AUTOPROVER_GLOBAL_PROVER_TIMEOUT"
 
 
 def _resolved_global_prover_timeout() -> int:
-    """Global prover timeout in seconds: ``DEFAULT_GLOBAL_TIMEOUT``, or the value of
-    ``AUTOPROVER_GLOBAL_PROVER_TIMEOUT`` when that env var is set, clamped to
-    ``[1, DEFAULT_GLOBAL_TIMEOUT]``. A non-integer env value is ignored with a warning."""
+    """Global prover timeout in seconds: ``DEFAULT_GLOBAL_TIMEOUT``, or the integer value of
+    ``AUTOPROVER_GLOBAL_PROVER_TIMEOUT`` when that env var is set. A non-integer env value is
+    ignored with a warning."""
     default = int(DEFAULT_GLOBAL_TIMEOUT)
     raw = os.environ.get(GLOBAL_PROVER_TIMEOUT_ENV)
     if raw is None:
         return default
     try:
-        return max(1, min(int(raw), default))
+        return int(raw)
     except ValueError:
         _logger.warning("Ignoring non-integer %s=%r", GLOBAL_PROVER_TIMEOUT_ENV, raw)
         return default

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -31,6 +31,7 @@ from typing import AsyncIterator, Callable, Protocol, cast, override, Awaitable
 from abc import ABC, abstractmethod
 import json
 import logging
+import os
 
 
 from langchain_core.messages import AnyMessage, HumanMessage
@@ -71,13 +72,31 @@ class ProverOptions:
         return float(self.extra_args[idx + 1])
 
 
+GLOBAL_PROVER_TIMEOUT_ENV = "AUTOPROVER_GLOBAL_PROVER_TIMEOUT"
+
+
+def _resolved_global_prover_timeout() -> int:
+    """Global prover timeout in seconds: ``DEFAULT_GLOBAL_TIMEOUT``, or the value of
+    ``AUTOPROVER_GLOBAL_PROVER_TIMEOUT`` when that env var is set, clamped to
+    ``[1, DEFAULT_GLOBAL_TIMEOUT]``. A non-integer env value is ignored with a warning."""
+    default = int(DEFAULT_GLOBAL_TIMEOUT)
+    raw = os.environ.get(GLOBAL_PROVER_TIMEOUT_ENV)
+    if raw is None:
+        return default
+    try:
+        return max(1, min(int(raw), default))
+    except ValueError:
+        _logger.warning("Ignoring non-integer %s=%r", GLOBAL_PROVER_TIMEOUT_ENV, raw)
+        return default
+
+
 def make_prover_options(*, cloud: bool) -> ProverOptions:
-    """Build prover options. Cloud runs get a default global timeout and the
+    """Build prover options. Cloud runs get a global prover timeout and the
     certoraRun ``--server`` resolved from the deployment env."""
     extras: list[str] = []
     if cloud:
         extras = [
-            "--global_timeout", str(int(DEFAULT_GLOBAL_TIMEOUT)),
+            "--global_timeout", str(_resolved_global_prover_timeout()),
             "--server", cloud_server_for_env()
         ]
     return ProverOptions(extra_args=extras)

--- a/tests/test_prover_options.py
+++ b/tests/test_prover_options.py
@@ -1,0 +1,25 @@
+"""Unit tests for the global-prover-timeout override."""
+
+from __future__ import annotations
+
+from composer.prover.core import (
+    DEFAULT_GLOBAL_TIMEOUT,
+    GLOBAL_PROVER_TIMEOUT_ENV,
+    _resolved_global_prover_timeout,
+)
+
+DEFAULT = int(DEFAULT_GLOBAL_TIMEOUT)
+
+
+class TestResolvedGlobalProverTimeout:
+    def test_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv(GLOBAL_PROVER_TIMEOUT_ENV, raising=False)
+        assert _resolved_global_prover_timeout() == DEFAULT
+
+    def test_integer_env_value_used(self, monkeypatch):
+        monkeypatch.setenv(GLOBAL_PROVER_TIMEOUT_ENV, "600")
+        assert _resolved_global_prover_timeout() == 600
+
+    def test_non_integer_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(GLOBAL_PROVER_TIMEOUT_ENV, "not-a-number")
+        assert _resolved_global_prover_timeout() == DEFAULT


### PR DESCRIPTION
`make_prover_options` now reads an optional `AUTOPROVER_GLOBAL_PROVER_TIMEOUT` env var for the cloud `--global_timeout` value (falling back to the 7200s default).