### PR TITLE
autoprove/foundry: fail the run when every component fails to generate

### DIFF
--- a/composer/cli/console_autoprove.py
+++ b/composer/cli/console_autoprove.py
@@ -26,6 +26,9 @@ async def _main() -> int:
             for f in result.failures:
                 print(f"    - {f}")
         print(f"{'=' * 60}")
+        if result.all_failed:
+            print("  RUN FAILED: every component failed to generate or gave up.")
+            return 1
         return 0
 
 

--- a/composer/cli/console_foundry.py
+++ b/composer/cli/console_foundry.py
@@ -32,6 +32,9 @@ async def _main() -> int:
             for f in result.failures:
                 print(f"    - {f}")
         print(f"{'=' * 60}")
+        if result.all_failed:
+            print("  RUN FAILED: every component failed to generate or gave up.")
+            return 1
         return 0
 
 

--- a/composer/pipeline/ptypes.py
+++ b/composer/pipeline/ptypes.py
@@ -112,9 +112,8 @@ class CorePipelineResult[FormT: BackendResult]:
 
     @property
     def all_failed(self) -> bool:
-        """Every attempted component failed to generate or gave up — nothing was delivered.
-        The run is a total failure and its entry point returns a non-zero exit code. Guarded
-        on a non-empty outcome set so "all of nothing" is never reported as failure (the
+        """Every attempted component failed to generate or gave up - te run is a total failure.
+        Guarded on a non-empty outcome set so "all of nothing" is never reported as failure (the
         driver raises before returning in the no-outcomes case anyway)."""
         return bool(self.outcomes) and self.n_delivered == 0
 

--- a/composer/pipeline/ptypes.py
+++ b/composer/pipeline/ptypes.py
@@ -104,6 +104,20 @@ class CorePipelineResult[FormT: BackendResult]:
     outcomes: list[ComponentOutcome[FormT]]
     failures: list[str]
 
+    @property
+    def n_delivered(self) -> int:
+        """Components that produced a deliverable — a successful formalization. Everything
+        else (a ``GaveUp`` or a crash) is a component that failed to generate."""
+        return sum(1 for o in self.outcomes if isinstance(o.result, Delivered))
+
+    @property
+    def all_failed(self) -> bool:
+        """Every attempted component failed to generate or gave up — nothing was delivered.
+        The run is a total failure and its entry point returns a non-zero exit code. Guarded
+        on a non-empty outcome set so "all of nothing" is never reported as failure (the
+        driver raises before returning in the no-outcomes case anyway)."""
+        return bool(self.outcomes) and self.n_delivered == 0
+
 __all__ = [
     "CorePipelineResult",
     "ComponentOutcome",

--- a/tests/test_pipeline_result.py
+++ b/tests/test_pipeline_result.py
@@ -1,0 +1,69 @@
+"""Tests for the run-level success/failure verdict of the shared pipeline result.
+
+``CorePipelineResult.all_failed`` is the signal the autoprove/foundry entry points
+translate into a non-zero exit code: a run in which *every* attempted component failed
+to generate a deliverable — either it gave up (``GaveUp``) or it crashed
+(``BaseException``) — is a total failure. As long as one component delivered, the run
+succeeds regardless of how many others gave up.
+"""
+from pathlib import Path
+from typing import Any, cast
+
+from composer.pipeline.ptypes import (
+    ComponentOutcome, CorePipelineResult, Delivered, GaveUp,
+)
+from composer.spec.system_model import ContractComponentInstance
+
+
+def _delivered() -> Delivered:
+    # all_failed / n_delivered only branch on isinstance(result, Delivered); the wrapped
+    # BackendResult is never inspected, so a placeholder is enough.
+    return Delivered(result=cast(Any, None), deliverable=Path("composer_c.spec"))
+
+
+def _outcome(result: Delivered | GaveUp | BaseException) -> ComponentOutcome:
+    return ComponentOutcome(feat=cast(ContractComponentInstance, None), props=[], result=result)
+
+
+def _result(*results: Delivered | GaveUp | BaseException) -> CorePipelineResult:
+    outcomes = [_outcome(r) for r in results]
+    return CorePipelineResult(
+        n_components=len(outcomes), n_properties=0, outcomes=outcomes, failures=[],
+    )
+
+
+def test_all_delivered_is_not_a_failure():
+    r = _result(_delivered(), _delivered())
+    assert r.n_delivered == 2
+    assert r.all_failed is False
+
+
+def test_one_delivered_among_giveups_is_not_a_failure():
+    r = _result(_delivered(), GaveUp(reason="x"), Exception("boom"))
+    assert r.n_delivered == 1
+    assert r.all_failed is False
+
+
+def test_all_gave_up_is_a_failure():
+    r = _result(GaveUp(reason="a"), GaveUp(reason="b"))
+    assert r.n_delivered == 0
+    assert r.all_failed is True
+
+
+def test_all_crashed_is_a_failure():
+    r = _result(Exception("boom"), RuntimeError("bang"))
+    assert r.n_delivered == 0
+    assert r.all_failed is True
+
+
+def test_giveup_and_crash_mix_with_no_delivery_is_a_failure():
+    r = _result(GaveUp(reason="a"), Exception("boom"))
+    assert r.all_failed is True
+
+
+def test_empty_outcomes_is_not_reported_as_failure():
+    # The driver raises before returning an empty outcome set; the guard keeps
+    # "all of nothing" from being reported as a total failure regardless.
+    r = _result()
+    assert r.n_delivered == 0
+    assert r.all_failed is False


### PR DESCRIPTION
Add `CorePipelineResult.all_failed` (true when no component produced a deliverable — all gave up or crashed) and `n_delivered`. The console autoprove/foundry entry points now return a non-zero exit code in that case.