### PR TITLE
Never pin the scene to hardhat's implicit default solc

### DIFF
--- a/certora_autosetup/build_systems/hardhat.py
+++ b/certora_autosetup/build_systems/hardhat.py
@@ -229,6 +229,21 @@ class HardhatManager(BuildSystemManager):
                 )
             return str(path_obj)
 
+    @staticmethod
+    def _describe_solidity_version(solidity: Any) -> str:
+        """Best-effort human-readable version from a resolved `solidity` block (for logging)."""
+        if isinstance(solidity, str):
+            return solidity
+        if isinstance(solidity, dict):
+            compilers = solidity.get("compilers")
+            if isinstance(compilers, list) and compilers:
+                versions = {str(c["version"]) for c in compilers if isinstance(c, dict) and c.get("version")}
+                if versions:
+                    return ", ".join(sorted(versions))
+            if solidity.get("version"):
+                return str(solidity["version"])
+        return "unknown"
+
     def _extract_config_from_json(self, config_data: Dict[str, Any], config_type: str) -> HardhatConfig:
         """
         Extract HardhatConfig from Hardhat's JSON config output.
@@ -242,6 +257,20 @@ class HardhatManager(BuildSystemManager):
         """
         # Extract solidity settings
         solidity = config_data.get("solidity", {})
+
+        # When the user config has no `solidity` entry, the resolved config
+        # carries hardhat's own built-in default compiler (0.7.3) — a statement
+        # about hardhat, not about the project (e.g. brownie-generated stub
+        # configs). Ignore it: solc_version=None lets the compilation phase
+        # fall back to DEFAULT_SOLC_VERSION + per-contract pragma resolution.
+        if config_data.get("solidityImplicitDefault"):
+            self.log(
+                "Hardhat config has no `solidity` entry — ignoring hardhat's "
+                f"built-in default compiler ({self._describe_solidity_version(solidity)}); "
+                "solc will be resolved from source pragmas",
+                "WARNING",
+            )
+            solidity = {}
 
         # Solidity can be a string (version) or object (settings)
         if isinstance(solidity, str):

--- a/certora_autosetup/build_systems/hardhat_config_extractor.js
+++ b/certora_autosetup/build_systems/hardhat_config_extractor.js
@@ -52,7 +52,12 @@ try {
     // Extract relevant settings
     const output = {
         solidity: config.solidity || {},
-        paths: config.paths || {}
+        paths: config.paths || {},
+        // hre.config is the *resolved* config: when the user config has no
+        // `solidity` entry, hardhat fills in its own built-in default compiler
+        // (0.7.3), which says nothing about what the project's sources need.
+        // Flag that case so the caller can ignore the resolved version.
+        solidityImplicitDefault: hre.userConfig.solidity === undefined
     };
 
     // Output as JSON

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -316,7 +316,12 @@ class CompilationWorkaroundManager:
                 name="compiler_version_mismatch",
                 detect_fn=lambda output: self._detect_compiler_version_mismatch(output, contracts),
                 apply_fn=self._apply_compiler_version_workaround_to_config,
-                enabled=not solc_already_set,
+                # Enabled even when a global solc is configured: the detector
+                # only fires when that compiler provably cannot parse a file
+                # (hard ParserError), and _seed_compile_maps has already
+                # promoted the scalar into compiler_map, so overriding one
+                # contract's entry from its pragma is always safe.
+                enabled=True,
             ),
             CompilationWorkaround(
                 name="stack_too_deep_via_ir",
@@ -692,58 +697,69 @@ class CompilationWorkaroundManager:
     def _detect_compiler_version_mismatch(
         self, output: str, contracts: List[ContractHandle]
     ) -> Optional[Tuple[str, str]]:
-        """Detect compiler version mismatch error and extract contract name and required version."""
+        """Detect compiler version mismatch error and extract contract name and required version.
+
+        solc hard-wraps its diagnostic text at a fixed width, so the marker
+        phrase is frequently split across newlines (e.g. "ParserError: Source
+        \\nfile requires different compiler version"). Match it with ``\\s+``
+        between words over the whole output, then map each match back to its
+        line index for the path/pragma context extraction.
+        """
         lines = output.split("\n")
 
-        for i in range(len(lines)):
-            line = lines[i]
+        marker = re.compile(
+            r"ParserError:\s+Source\s+file\s+requires\s+different\s+compiler\s+version"
+        )
+        for match in marker.finditer(output):
+            # Line index of the match start; the error may span several lines,
+            # so context searches below start from where the marker begins.
+            i = output.count("\n", 0, match.start())
 
-            if "ParserError: Source file requires different compiler version" in line:
-                # Try to find file_path from preceding "Compiling ..." line
-                file_path = _find_compiling_path_before(lines, i, max_lookback=15)
+            # Try to find file_path from preceding "Compiling ..." line
+            file_path = _find_compiling_path_before(lines, i, max_lookback=15)
 
-                # Fallback: Extract file_path from arrow line if not found above
-                if not file_path:
-                    for j in range(i + 1, min(i + 10, len(lines))):
-                        if "-->" in lines[j]:
-                            path_parts = []
-                            arrow_line = lines[j].split("-->", 1)
-                            if len(arrow_line) > 1:
-                                path_parts.append(arrow_line[1].strip())
+            # Fallback: Extract file_path from arrow line if not found above
+            if not file_path:
+                for j in range(i + 1, min(i + 10, len(lines))):
+                    if "-->" in lines[j]:
+                        path_parts = []
+                        arrow_line = lines[j].split("-->", 1)
+                        if len(arrow_line) > 1:
+                            path_parts.append(arrow_line[1].strip())
 
-                            for k in range(j + 1, min(j + 5, len(lines))):
-                                stripped = lines[k].strip()
-                                if not stripped or stripped == "|":
-                                    break
-                                path_parts.append(stripped)
-                                if re.search(r":\d+:\d+:\s*$", stripped):
-                                    break
-
-                            full_path = "".join(path_parts)
-                            path_match = re.search(r"^(.+?):\d+:\d+:\s*$", full_path)
-                            if path_match:
-                                file_path = path_match.group(1).strip()
+                        for k in range(j + 1, min(j + 5, len(lines))):
+                            stripped = lines[k].strip()
+                            if not stripped or stripped == "|":
+                                break
+                            path_parts.append(stripped)
+                            if re.search(r":\d+:\d+:\s*$", stripped):
                                 break
 
-                if not file_path:
-                    continue
+                        full_path = "".join(path_parts)
+                        path_match = re.search(r"^(.+?):\d+:\d+:\s*$", full_path)
+                        if path_match:
+                            file_path = path_match.group(1).strip()
+                            break
 
-                # Extract pragma specification from subsequent lines
-                for k in range(i + 1, min(i + 10, len(lines))):
-                    pragma_spec = extract_pragma_spec(lines[k])
-                    if pragma_spec:
-                        version = resolve_pragma_to_version(pragma_spec)
-                        if not version:
-                            self.log(f"Could not resolve pragma '{pragma_spec}' to concrete version", "WARNING")
-                            return None
+            if not file_path:
+                continue
 
-                        contract_name = self._get_contract_name_from_path(file_path, contracts)
-                        if contract_name:
-                            self.log(f"Detected compiler version mismatch for {contract_name}: requires {version}")
-                            return (contract_name, version)
-                        else:
-                            self.log(f"Warning: Could not map path '{file_path}' to contract name", "WARNING")
-                            return None
+            # Extract pragma specification from subsequent lines
+            for k in range(i + 1, min(i + 10, len(lines))):
+                pragma_spec = extract_pragma_spec(lines[k])
+                if pragma_spec:
+                    version = resolve_pragma_to_version(pragma_spec)
+                    if not version:
+                        self.log(f"Could not resolve pragma '{pragma_spec}' to concrete version", "WARNING")
+                        return None
+
+                    contract_name = self._get_contract_name_from_path(file_path, contracts)
+                    if contract_name:
+                        self.log(f"Detected compiler version mismatch for {contract_name}: requires {version}")
+                        return (contract_name, version)
+                    else:
+                        self.log(f"Warning: Could not map path '{file_path}' to contract name", "WARNING")
+                        return None
 
         return None
 

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -432,3 +432,91 @@ def test_detects_single_line_source_not_found(manager: CompilationWorkaroundMana
 
 def test_ignores_unrelated_source_not_found(manager: CompilationWorkaroundManager) -> None:
     assert manager._has_source_not_found(UNRELATED_OUTPUT) is False
+
+
+# =============================================================================
+# compiler_version_mismatch: wrap-tolerant detection + enabled with global solc
+# =============================================================================
+
+# Verbatim certoraRun output from a real mass-test run: the whole
+# scene was pinned to solc7.3 while every source is ^0.8.0, and solc wrapped the
+# marker phrase ("ParserError: Source \nfile requires different compiler version"),
+# defeating the old single-line substring check.
+WRAPPED_COMPILER_VERSION_MISMATCH = (
+    "Compiling certora/mocks/DummyERC20Impl.sol...\n"
+    "\n"
+    "solc7.3 had an error:\n"
+    "/workspace/project/certora/mocks/DummyERC20Impl.sol:2:1: ParserError: Source \n"
+    "file requires different compiler version (current compiler is \n"
+    "0.7.3+commit.9bfce1f6.Linux.g++) - note that nightly builds are considered to be\n"
+    "strictly less than the released version\n"
+    "pragma solidity ^0.8.0;\n"
+    "^---------------------^\n"
+)
+
+SINGLE_LINE_COMPILER_VERSION_MISMATCH = (
+    "Compiling certora/mocks/DummyERC20Impl.sol...\n"
+    "solc7.3 had an error:\n"
+    "certora/mocks/DummyERC20Impl.sol:2:1: ParserError: Source file requires different compiler version (current compiler is 0.7.3+commit.9bfce1f6.Linux.g++)\n"
+    "pragma solidity ^0.8.0;\n"
+)
+
+MISMATCH_CONTRACTS = [
+    ContractHandle(contract_name="DummyERC20Impl", source_file="certora/mocks/DummyERC20Impl.sol"),
+    ContractHandle(contract_name="Vault", source_file="contracts/Vault.sol"),
+]
+
+
+@pytest.fixture
+def resolve_pragma_offline(monkeypatch):
+    """resolve_pragma_to_version fetches soliditylang.org; pin it for tests."""
+    monkeypatch.setattr(
+        "certora_autosetup.utils.compilation_workarounds.resolve_pragma_to_version",
+        lambda spec, **kwargs: "0.8.30",
+    )
+
+
+def test_detects_wrapped_compiler_version_mismatch(
+    manager: CompilationWorkaroundManager, resolve_pragma_offline
+) -> None:
+    # Regression: the wrapped marker phrase was missed, so the scene-wide wrong
+    # compiler pin was never repaired and the run died in compilation analysis.
+    result = manager._detect_compiler_version_mismatch(
+        WRAPPED_COMPILER_VERSION_MISMATCH, MISMATCH_CONTRACTS
+    )
+    assert result == ("DummyERC20Impl", "0.8.30")
+
+
+def test_detects_single_line_compiler_version_mismatch(
+    manager: CompilationWorkaroundManager, resolve_pragma_offline
+) -> None:
+    result = manager._detect_compiler_version_mismatch(
+        SINGLE_LINE_COMPILER_VERSION_MISMATCH, MISMATCH_CONTRACTS
+    )
+    assert result == ("DummyERC20Impl", "0.8.30")
+
+
+def test_ignores_unrelated_compiler_version_mismatch(
+    manager: CompilationWorkaroundManager,
+) -> None:
+    assert manager._detect_compiler_version_mismatch(UNRELATED_OUTPUT, MISMATCH_CONTRACTS) is None
+
+
+def test_compiler_mismatch_workaround_fires_with_global_solc(
+    manager, monkeypatch, tmp_path, resolve_pragma_offline
+) -> None:
+    # Regression: `enabled=not solc_already_set` disabled the only recovery path
+    # exactly when a build system pinned a wrong global solc. The workaround must
+    # override the seeded compiler_map entry from the pragma.
+    success, updated, compilation_config, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [WRAPPED_COMPILER_VERSION_MISMATCH],
+        MISMATCH_CONTRACTS,
+        extra_config={"solc": "solc7.3"},
+    )
+    assert success is True
+    assert fake_run.calls == 2  # failing compile + one recompile after the fix
+    assert compilation_config["compiler_map"]["DummyERC20Impl"] == "solc8.30"
+    assert compilation_config["compiler_map"]["Vault"] == "solc7.3"

--- a/tests/test_hardhat_config.py
+++ b/tests/test_hardhat_config.py
@@ -1,0 +1,57 @@
+"""Unit tests for HardhatManager config extraction."""
+
+from pathlib import Path
+
+import pytest
+
+from certora_autosetup.build_systems.hardhat import HardhatManager
+
+
+class _AllInScope:
+    def is_file_in_scope(self, file_path):
+        return True
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> HardhatManager:
+    return HardhatManager(tmp_path, _AllInScope())
+
+
+# Resolved-config JSON as emitted by hardhat_config_extractor.js for a config
+# with no `solidity` entry (e.g. a brownie-generated network-only stub): hardhat
+# fills in its own built-in default compiler, and the extractor flags it.
+IMPLICIT_DEFAULT_CONFIG = {
+    "solidity": {"compilers": [{"version": "0.7.3", "settings": {"optimizer": {"enabled": False, "runs": 200}}}]},
+    "paths": {},
+    "solidityImplicitDefault": True,
+}
+
+EXPLICIT_CONFIG = {
+    "solidity": {"compilers": [{"version": "0.8.20", "settings": {"optimizer": {"enabled": True, "runs": 800}}}]},
+    "paths": {},
+    "solidityImplicitDefault": False,
+}
+
+
+def test_implicit_default_solc_is_ignored(manager: HardhatManager) -> None:
+    # Regression (real brownie-stub project): hardhat's built-in default 0.7.3 was
+    # taken as the project's compiler and the whole ^0.8.0 scene was pinned to it,
+    # failing compilation analysis before any workaround could help.
+    config = manager._extract_config_from_json(IMPLICIT_DEFAULT_CONFIG, "javascript")
+    assert config.solc_version is None
+
+
+def test_explicit_solc_is_kept(manager: HardhatManager) -> None:
+    config = manager._extract_config_from_json(EXPLICIT_CONFIG, "javascript")
+    assert config.solc_version == "0.8.20"
+    assert config.optimizer is True
+    assert config.optimizer_runs == 800
+
+
+def test_missing_flag_keeps_reported_solc(manager: HardhatManager) -> None:
+    # Extractor output without the flag (e.g. the `{}` error fallback merged with
+    # defaults elsewhere) must behave as before: trust what is reported.
+    config = manager._extract_config_from_json(
+        {"solidity": "0.8.19", "paths": {}}, "javascript"
+    )
+    assert config.solc_version == "0.8.19"


### PR DESCRIPTION
## Problem

On a hardhat project whose `hardhat.config.js` has **no `solidity` entry** (e.g. a brownie-generated network-only stub), `npx hardhat config --json` reports hardhat's built-in default compiler (0.7.3). `HardhatManager` took that as the project's compiler and pinned the entire scene to `solc7.3` via `compiler_map` — on an all-`^0.8.0` codebase every file (including our own injected `DummyERC20Impl`) fails with `ParserError: Source file requires different compiler version`, and compilation analysis dies before any workaround can help.

Two additional defects kept the existing recovery path from firing:
1. `_detect_compiler_version_mismatch` matched the ParserError phrase within a single line, but solc hard-wraps its diagnostics (same class as the Yul stack-too-deep wrap bug fixed earlier).
2. The `compiler_version_mismatch` workaround was registered with `enabled=not solc_already_set`, i.e. disabled exactly when a build system pinned a wrong global solc.

## Fix

- `hardhat_config_extractor.js` additionally emits `solidityImplicitDefault: hre.userConfig.solidity === undefined`. When set, `HardhatManager` ignores the resolved compiler (logging why) and leaves `solc_version=None`, so compilation falls back to `DEFAULT_SOLC_VERSION` + per-contract pragma resolution.
- The mismatch detector matches the marker phrase across wrapped lines (`\s+` between words), then maps the match back to a line index for the existing path/pragma context extraction.
- The workaround is enabled even when a global solc is configured: the detector only fires when that compiler provably cannot parse a file, and `_seed_compile_maps` promotes the scalar into `compiler_map` up front, so a per-contract override is always safe.

## Validation

- 7 new unit tests (wrapped + single-line detection with a verbatim captured output, loop behavior with a wrong global solc, hardhat config extraction with implicit/explicit/legacy shapes); full suite passes (234).
- Extractor checked live in the mass-test container against a real brownie-stub project (`solidityImplicitDefault: true`, resolved 0.7.3 ignored) and a project with an explicit `solidity` block (`false`, 0.8.28 kept).
- End-to-end re-run of the failing project on this branch: compilation analysis now resolves the scene from pragmas (solc8.34) and completes solc compilation; the run proceeds to the next phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)