### PR TITLE
autosetup: never emit a conf with both solc and compiler_map

### DIFF
--- a/certora_autosetup/autosetup/autosetup.py
+++ b/certora_autosetup/autosetup/autosetup.py
@@ -426,13 +426,11 @@ class Autosetup:
         if self.compilation_config_updates:
             config.update(self.compilation_config_updates)
 
-        # solc_via_ir and solc_via_ir_map cannot coexist; the map supersedes the global flag
-        if "solc_via_ir_map" in config:
-            config.pop("solc_via_ir", None)
-
-        # Same for solc_optimize and solc_optimize_map
-        if "solc_optimize_map" in config:
-            config.pop("solc_optimize", None)
+        # A per-contract map supersedes its scalar counterpart, and certoraRun
+        # rejects a conf carrying both. The merge above can produce such pairs:
+        # the base build-system dict contributes scalars (e.g. "solc") while
+        # the compilation updates contribute the maps.
+        ConfigManager.drop_scalars_superseded_by_maps(config)
 
         # Filter per-contract maps to only include contracts in self.contract_handles
         contract_names = {ch.contract_name for ch in self.contract_handles}

--- a/certora_autosetup/setup/setup_prover.py
+++ b/certora_autosetup/setup/setup_prover.py
@@ -263,6 +263,10 @@ class SetupProver:
                         full_map[c.contract_name] = formatted
                         self.log(f"  {c.contract_name} -> {formatted} (from pragma)")
             config_dict["compiler_map"] = full_map
+            # certoraRun rejects a conf carrying both compiler_map and the
+            # scalar solc; the map is total over the scene, so the scalar
+            # carries no extra information.
+            ConfigManager.drop_scalars_superseded_by_maps(config_dict)
             self.log(
                 f"Precomputed compiler_map from build artifacts: "
                 f"{len(compiler_map)} contract(s) differ from default {default_solc}"

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -150,13 +150,21 @@ class CompilationWorkaroundManager:
 
     def _seed_compile_maps(self, config: Dict, contracts: List[ContractHandle]) -> None:
         """Promote scalar ``solc``/``solc_via_ir`` into fully-populated maps.
+
+        When a map is already present (e.g. precomputed from build artifacts,
+        or in a user conf fed through fixconf) the scalar still acts as the
+        default for contracts the map doesn't cover, and is then dropped —
+        certoraRun rejects a conf carrying both a map and its scalar.
         """
-        if "compiler_map" not in config:
-            default = config.pop("solc", None) or self.solc_default_version
-            config["compiler_map"] = {c.contract_name: default for c in contracts}
-        if "solc_via_ir_map" not in config:
-            via_ir = config.pop("solc_via_ir", False)
-            config["solc_via_ir_map"] = {c.contract_name: via_ir for c in contracts}
+        default = config.pop("solc", None) or self.solc_default_version
+        config.setdefault("compiler_map", {})
+        for c in contracts:
+            config["compiler_map"].setdefault(c.contract_name, default)
+
+        via_ir = config.pop("solc_via_ir", False)
+        config.setdefault("solc_via_ir_map", {})
+        for c in contracts:
+            config["solc_via_ir_map"].setdefault(c.contract_name, via_ir)
 
     def _normalize_compile_maps(self, config: Dict) -> None:
         """Collapse a uniform compiler_map / solc_via_ir_map back to its scalar if all values are same.
@@ -261,7 +269,13 @@ class CompilationWorkaroundManager:
         """
         # Check if global solc_via_ir is already enabled
         global_via_ir_enabled = updated_config_dict.get("solc_via_ir", False)
-        solc_already_set = "solc" in updated_config_dict
+        # An explicit compiler pin can arrive as the scalar "solc" or already
+        # folded into a compiler_map (e.g. precomputed from build artifacts);
+        # the bare "solc" binary is the environment default and needs no fallback.
+        solc_pinned = compilation_config.get("solc", "solc") != "solc" or any(
+            version != "solc"
+            for version in compilation_config.get("compiler_map", {}).values()
+        )
 
         # Names of the workarounds applied in the current pass over a failed
         # output. Cleared at the top of each pass; detect lambdas below may
@@ -289,7 +303,7 @@ class CompilationWorkaroundManager:
                 name="solc_not_found_fallback",
                 detect_fn=lambda output: self._detect_solc_not_found(output),
                 apply_fn=self._apply_solc_fallback_workaround,
-                enabled=solc_already_set and updated_config_dict.get("solc") != "solc",
+                enabled=solc_pinned,
             ),
             CompilationWorkaround(
                 name="remappings_conflict",
@@ -360,10 +374,15 @@ class CompilationWorkaroundManager:
             ),
             CompilationWorkaround(
                 name="yul_exception_add_optimizer",
+                # A solc_optimize_map (per-contract runs from foundry
+                # compilation_restrictions) is explicit project intent, and
+                # certoraRun rejects a conf carrying both the map and the
+                # scalar — skip this rung and let the ladder escalate.
                 detect_fn=lambda output: (
                     "detected"
                     if self._detect_yul_exception_stack_too_deep(output)
                     and "solc_optimize" not in compilation_config
+                    and "solc_optimize_map" not in compilation_config
                     else None
                 ),
                 apply_fn=self._apply_optimizer_for_via_ir,
@@ -376,12 +395,17 @@ class CompilationWorkaroundManager:
                 # tried, not in the same pass that just added it (the live
                 # "solc_optimize in config" check would otherwise see the value
                 # the previous workaround set seconds ago and stop asserting
-                # autofinder success without ever testing the optimizer).
+                # autofinder success without ever testing the optimizer). A
+                # solc_optimize_map counts as "optimizer already tried": it is
+                # project-configured, and the add rung never fires next to it.
                 detect_fn=lambda output: (
                     "detected"
                     if self._detect_yul_exception_stack_too_deep(output)
                     and compilation_config.get("assert_autofinder_success", False)
-                    and "solc_optimize" in compilation_config
+                    and (
+                        "solc_optimize" in compilation_config
+                        or "solc_optimize_map" in compilation_config
+                    )
                     and "yul_exception_add_optimizer" not in applied_this_pass
                     else None
                 ),

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -374,15 +374,10 @@ class CompilationWorkaroundManager:
             ),
             CompilationWorkaround(
                 name="yul_exception_add_optimizer",
-                # A solc_optimize_map (per-contract runs from foundry
-                # compilation_restrictions) is explicit project intent, and
-                # certoraRun rejects a conf carrying both the map and the
-                # scalar — skip this rung and let the ladder escalate.
                 detect_fn=lambda output: (
                     "detected"
                     if self._detect_yul_exception_stack_too_deep(output)
-                    and "solc_optimize" not in compilation_config
-                    and "solc_optimize_map" not in compilation_config
+                    and self._yul_optimizer_pending(compilation_config, contracts)
                     else None
                 ),
                 apply_fn=self._apply_optimizer_for_via_ir,
@@ -391,21 +386,18 @@ class CompilationWorkaroundManager:
             CompilationWorkaround(
                 name="yul_exception_stack_too_deep",
                 # This is the escalation step after yul_exception_add_optimizer:
-                # it must only fire on output produced AFTER the optimizer was
+                # it must only fire once the optimizer is on globally or for
+                # every scene contract (the rung above has nothing left to
+                # enable), and only on output produced AFTER the optimizer was
                 # tried, not in the same pass that just added it (the live
-                # "solc_optimize in config" check would otherwise see the value
-                # the previous workaround set seconds ago and stop asserting
-                # autofinder success without ever testing the optimizer). A
-                # solc_optimize_map counts as "optimizer already tried": it is
-                # project-configured, and the add rung never fires next to it.
+                # config check would otherwise see the value the previous
+                # workaround set seconds ago and stop asserting autofinder
+                # success without ever testing the optimizer).
                 detect_fn=lambda output: (
                     "detected"
                     if self._detect_yul_exception_stack_too_deep(output)
                     and compilation_config.get("assert_autofinder_success", False)
-                    and (
-                        "solc_optimize" in compilation_config
-                        or "solc_optimize_map" in compilation_config
-                    )
+                    and not self._yul_optimizer_pending(compilation_config, contracts)
                     and "yul_exception_add_optimizer" not in applied_this_pass
                     else None
                 ),
@@ -985,19 +977,64 @@ class CompilationWorkaroundManager:
             json.dump(compilation_config, f, indent=2)
         return updated_config_dict
 
+    @staticmethod
+    def _optimizer_off(runs: Any) -> bool:
+        """A missing/zero solc_optimize_map entry means the optimizer is off
+        for that contract."""
+        return runs in (None, 0, "0", "")
+
+    def _yul_optimizer_pending(
+        self, config: Dict, contracts: List[ContractHandle]
+    ) -> bool:
+        """True while the add-optimizer rung still has something to enable:
+        no global solc_optimize, and — when a per-contract solc_optimize_map
+        is present — at least one scene contract's entry has the optimizer
+        off. With neither key set, the global rung itself is pending."""
+        if "solc_optimize" in config:
+            return False
+        optimize_map = config.get("solc_optimize_map")
+        if optimize_map is None:
+            return True
+        return any(
+            self._optimizer_off(optimize_map.get(c.contract_name)) for c in contracts
+        )
+
     def _apply_optimizer_for_via_ir(
         self,
         _detect_result: str,
         updated_config_dict: Dict,
         compilation_config: Dict,
         config_file: Path,
-        _contracts: List[ContractHandle],
+        contracts: List[ContractHandle],
     ) -> Dict:
-        """Apply optimizer alongside via-ir to resolve YulException stack-too-deep."""
-        self.log("Detected YulException stack-too-deep with via-ir — adding solc_optimize 200", "WARNING")
+        """Apply optimizer alongside via-ir to resolve YulException stack-too-deep.
 
-        compilation_config["solc_optimize"] = "200"
-        updated_config_dict["solc_optimize"] = "200"
+        With a per-contract solc_optimize_map (foundry compilation_restrictions)
+        only the entries whose optimizer is off are enabled — explicit project
+        runs values are kept, and the scalar is never set next to the map
+        (certoraRun rejects the pair)."""
+        if "solc_optimize_map" in compilation_config:
+            optimize_map = compilation_config["solc_optimize_map"]
+            enabled = [
+                c.contract_name
+                for c in contracts
+                if self._optimizer_off(optimize_map.get(c.contract_name))
+            ]
+            for name in enabled:
+                optimize_map[name] = "200"
+            updated_config_dict["solc_optimize_map"] = optimize_map
+            self.log(
+                "Detected YulException stack-too-deep with via-ir — enabling the "
+                f"optimizer (200 runs) in solc_optimize_map for {enabled}",
+                "WARNING",
+            )
+        else:
+            self.log(
+                "Detected YulException stack-too-deep with via-ir — adding solc_optimize 200",
+                "WARNING",
+            )
+            compilation_config["solc_optimize"] = "200"
+            updated_config_dict["solc_optimize"] = "200"
 
         with open(config_file, "w") as f:
             json.dump(compilation_config, f, indent=2)

--- a/certora_autosetup/utils/enhanced_config_manager.py
+++ b/certora_autosetup/utils/enhanced_config_manager.py
@@ -762,6 +762,31 @@ class ConfigManager:
     # compilation_workarounds.
     # =========================================================================
 
+    # (scalar, per-contract map) conf-key pairs. certoraRun hard-rejects a conf
+    # that sets both members of a pair (certoraContextValidator:
+    # convert_to_compiler_map for solc/compiler_map, check_map_attributes for
+    # the rest), so a map always supersedes its scalar counterpart.
+    SCALAR_TO_MAP_KEYS = (
+        ("solc", "compiler_map"),
+        ("solc_via_ir", "solc_via_ir_map"),
+        ("solc_optimize", "solc_optimize_map"),
+        ("solc_evm_version", "solc_evm_version_map"),
+    )
+
+    @staticmethod
+    def drop_scalars_superseded_by_maps(conf_object: Dict[str, Any]) -> None:
+        """Remove every scalar compile flag whose per-contract map is present.
+
+        Any step that puts a map into a conf must call this (or pop the scalar
+        itself) before the conf reaches certoraRun — the CLI rejects the pair
+        outright ("compiler map flags cannot be set with other compiler
+        flags"), and no compilation workaround can detect that rejection since
+        it happens before any solc invocation.
+        """
+        for scalar_key, map_key in ConfigManager.SCALAR_TO_MAP_KEYS:
+            if map_key in conf_object:
+                conf_object.pop(scalar_key, None)
+
     def _solc_convention(self) -> SolcConvention:
         """Convention this manager emits: derived from the boolean
         convert_solc_to_certora_format flag for symmetry with the rest of

--- a/certora_autosetup/utils/remappings.py
+++ b/certora_autosetup/utils/remappings.py
@@ -18,6 +18,10 @@ import tomllib
 # (message, level) -> None; matches BuildSystemManager.log / CompilationWorkaroundManager.log.
 LogFn = Callable[[str, str], None]
 
+# Remapping entries whose key ends in one of these target a concrete source file, not a directory
+# prefix, so they must not receive a trailing-slash boundary (see `_merge_remapping_entry`).
+_SOURCE_SUFFIXES = (".sol", ".vy", ".yul")
+
 
 def build_packages_from_remapping_sources(base_dir: Path, log_fn: LogFn, profile: str = "default") -> List[str]:
     """Build a merged packages list from forge remappings, foundry.toml, remappings.txt, package.json.
@@ -162,13 +166,18 @@ def _merge_remapping_entry(
 ) -> None:
     """Record a single `key=path` remapping entry into the running key->path/source maps.
 
-    Both sides of the entry are whitespace-stripped and ``rstrip("/")``-normalized before
-    storage, so the merged list is internally consistent regardless of which source emitted the
-    entry (and tolerant of ``@oz/ = lib/oz/``-style spacing). Solc/forge accept the normalized
-    form (`key=path`) as long as key and path agree on trailing slashes, which this guarantees.
-    Distinct keys (e.g. ``@openzeppelin/contracts`` vs ``@openzeppelin/contracts-upgradeable``)
-    stay separate entries; solc resolves imports by longest-prefix so the more specific key wins
-    — provided it is present, which is exactly why forge remappings is the authoritative source.
+    Both sides of the entry are whitespace-stripped and normalized to a canonical *trailing-slash*
+    form (a slash is appended when missing), so the merged list is internally consistent regardless
+    of which source emitted the entry (and tolerant of ``@oz/ = lib/oz/``-style spacing). The key's
+    trailing slash is significant and MUST be preserved: a remapping key marks a path *prefix* whose
+    boundary is the slash, so ``@openzeppelin/contracts/`` must not swallow imports beginning
+    ``@openzeppelin/contracts-upgradeable/``. solc chooses among applicable remappings by longest
+    matching *context* first (only then longest prefix), so a context-scoped key like
+    ``lib/some-dependency/:@openzeppelin/contracts`` — if its boundary slash were stripped —
+    outranks the correct global ``@openzeppelin/contracts-upgradeable`` mapping and rewrites the
+    upgradeable import to a nonexistent path. Keeping the slash keeps the two packages distinct.
+    (Normalizing both sides to end in a slash also collapses ``@oz/contracts`` and
+    ``@oz/contracts/`` from different sources onto one key, so the dedup below stays correct.)
 
     Relative target paths are resolved to absolute against ``base_dir`` so the packages list is
     valid even when the process CWD differs from the project dir.
@@ -181,11 +190,23 @@ def _merge_remapping_entry(
     Caller is responsible for confirming the entry contains an ``=`` before calling.
     """
     raw_key, raw_path = entry.split("=", 1)
-    key = raw_key.strip().rstrip("/")
-    path = raw_path.strip().rstrip("/")
+    key = raw_key.strip()
+    path = raw_path.strip()
 
+    # Resolve a relative target against base_dir first (Path() drops any trailing slash).
     if not Path(path).is_absolute():
         path = str(base_dir / path)
+
+    # Canonicalize a DIRECTORY remapping to a trailing-slash form so the key's prefix boundary is
+    # preserved (see docstring) and key/path agree on that boundary. A remapping that targets a
+    # concrete source file (e.g. an import-patch entry `.../IFoo.sol=.../IFoo.sol`) must keep its
+    # exact form — appending `/` would make solc look for a directory `IFoo.sol/`. Detect the
+    # file case by a source-file extension on the key.
+    if not key.lower().endswith(_SOURCE_SUFFIXES):
+        if key and not key.endswith("/"):
+            key += "/"
+        if path and not path.endswith("/"):
+            path += "/"
 
     if key in remapping_key_to_path:
         if warn_on_mismatch and remapping_key_to_path[key] != path:

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -594,10 +594,11 @@ def test_solc_fallback_fires_when_pin_is_in_compiler_map(
 def test_yul_optimizer_rung_respects_project_optimize_map(
     manager, monkeypatch, tmp_path
 ) -> None:
-    # A per-contract solc_optimize_map (foundry compilation_restrictions) is
-    # explicit project intent: the add-optimizer rung must not put the scalar
-    # next to it (certoraRun rejects the pair), and the ladder escalates to
-    # relaxing the autofinder assertion instead.
+    # A per-contract solc_optimize_map (foundry compilation_restrictions) with
+    # the optimizer on for EVERY contract: the add-optimizer rung has nothing
+    # left to enable and must not put the scalar next to the map (certoraRun
+    # rejects the pair) — the ladder escalates to relaxing the autofinder
+    # assertion instead.
     contracts = [
         ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol"),
         ContractHandle(contract_name="Bar", source_file="contracts/Bar.sol"),
@@ -616,4 +617,36 @@ def test_yul_optimizer_rung_respects_project_optimize_map(
     assert success is True
     assert "solc_optimize" not in compilation_config
     assert compilation_config["solc_optimize_map"] == {"Foo": "1", "Bar": "200"}
+    assert compilation_config["assert_autofinder_success"] is False
+
+
+def test_yul_optimizer_rung_enables_off_entries_in_optimize_map(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # A map entry of "0" (or a missing one) means the optimizer is off for that
+    # contract — exactly the misconfiguration the add-optimizer rung exists to
+    # fix. It must enable those entries in the map (never the scalar, which
+    # cannot legally sit next to it) while keeping explicit project runs
+    # values; only once every entry is on may the ladder escalate.
+    contracts = [
+        ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol"),
+        ContractHandle(contract_name="Bar", source_file="contracts/Bar.sol"),
+    ]
+    success, _, compilation_config, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [WRAPPED_YUL_STACK_TOO_DEEP, WRAPPED_YUL_STACK_TOO_DEEP],
+        contracts,
+        extra_config={
+            "solc_optimize_map": {"Foo": "0", "Bar": "1"},
+            "assert_autofinder_success": True,
+        },
+    )
+    assert success is True
+    # Pass 1 enables Foo's optimizer; pass 2 (optimizer on everywhere, error
+    # persists) escalates; the third compile succeeds.
+    assert fake_run.calls == 3
+    assert "solc_optimize" not in compilation_config
+    assert compilation_config["solc_optimize_map"] == {"Foo": "200", "Bar": "1"}
     assert compilation_config["assert_autofinder_success"] is False

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -520,3 +520,100 @@ def test_compiler_mismatch_workaround_fires_with_global_solc(
     assert fake_run.calls == 2  # failing compile + one recompile after the fix
     assert compilation_config["compiler_map"]["DummyERC20Impl"] == "solc8.30"
     assert compilation_config["compiler_map"]["Vault"] == "solc7.3"
+
+
+# =============================================================================
+# Seeding: a precomputed compiler_map with a lingering scalar solc
+# =============================================================================
+#
+# _precompute_compiler_settings can hand the loop a conf that already carries a
+# compiler_map (from Foundry build artifacts) next to the build system's scalar
+# "solc" — certoraRun rejects that pair before invoking any solc, so no output
+# detector can ever catch it (observed in the wild on projects whose foundry.toml
+# pins one solc version while the build artifacts were produced with another).
+# Seeding must fold the scalar into the map (as the default for uncovered
+# contracts) so the very first certoraRun already gets a legal conf.
+
+
+def test_seed_folds_scalar_solc_into_existing_compiler_map(
+    manager, monkeypatch, tmp_path
+) -> None:
+    contracts = [
+        ContractHandle(contract_name="Vault", source_file="contracts/Vault.sol"),
+        ContractHandle(
+            contract_name="DummyERC20Impl", source_file="certora/mocks/DummyERC20Impl.sol"
+        ),
+    ]
+    success, updated, compilation_config, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [],
+        contracts,
+        extra_config={"solc": "solc8.30", "compiler_map": {"Vault": "solc8.35"}},
+    )
+    assert success is True
+    assert fake_run.calls == 1  # legal conf from the start — no retry needed
+    assert "solc" not in compilation_config
+    assert compilation_config["compiler_map"] == {
+        "Vault": "solc8.35",
+        "DummyERC20Impl": "solc8.30",
+    }
+    assert "solc" not in updated
+    assert updated["compiler_map"] == compilation_config["compiler_map"]
+
+
+SOLC_NOT_FOUND_OUTPUT = (
+    "attribute/flag 'compiler_map': Solidity executable solc8.35 not found in path\n"
+)
+
+
+def test_solc_fallback_fires_when_pin_is_in_compiler_map(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # The pin can arrive already folded into compiler_map with no scalar "solc"
+    # (precomputed from build artifacts) — the missing-binary fallback must
+    # still be armed, keyed on the map contents rather than the scalar.
+    monkeypatch.setattr(manager, "_pick_solc_fallback", lambda: "solc8.30")
+    contracts = [ContractHandle(contract_name="Vault", source_file="contracts/Vault.sol")]
+    success, _, compilation_config, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [SOLC_NOT_FOUND_OUTPUT],
+        contracts,
+        extra_config={"compiler_map": {"Vault": "solc8.35"}},
+    )
+    assert success is True
+    assert fake_run.calls == 2  # failing compile + one recompile on the fallback
+    # The uniform fallback map collapses back to a scalar on exit.
+    assert compilation_config["solc"] == "solc8.30"
+    assert "compiler_map" not in compilation_config
+
+
+def test_yul_optimizer_rung_respects_project_optimize_map(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # A per-contract solc_optimize_map (foundry compilation_restrictions) is
+    # explicit project intent: the add-optimizer rung must not put the scalar
+    # next to it (certoraRun rejects the pair), and the ladder escalates to
+    # relaxing the autofinder assertion instead.
+    contracts = [
+        ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol"),
+        ContractHandle(contract_name="Bar", source_file="contracts/Bar.sol"),
+    ]
+    success, _, compilation_config, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [WRAPPED_YUL_STACK_TOO_DEEP],
+        contracts,
+        extra_config={
+            "solc_optimize_map": {"Foo": "1", "Bar": "200"},
+            "assert_autofinder_success": True,
+        },
+    )
+    assert success is True
+    assert "solc_optimize" not in compilation_config
+    assert compilation_config["solc_optimize_map"] == {"Foo": "1", "Bar": "200"}
+    assert compilation_config["assert_autofinder_success"] is False

--- a/tests/test_compiler_flag_reconciliation.py
+++ b/tests/test_compiler_flag_reconciliation.py
@@ -183,3 +183,35 @@ def test_merge_drops_base_scalar_when_updates_bring_map(monkeypatch) -> None:
     assert "solc_via_ir" not in config
     assert config["compiler_map"] == {"Vault": "solc8.35", "Helper": "solc8.30"}
     assert config["solc_via_ir_map"] == {"Vault": True, "Helper": False}
+
+
+# =============================================================================
+# SCALAR_TO_MAP_KEYS vs certora-cli
+# =============================================================================
+
+
+def test_scalar_to_map_keys_match_certora_cli() -> None:
+    # The pair names are literals because importing them at runtime is not
+    # clean: certora_cli's internal modules use flat imports (`from Shared
+    # import ...`), so reaching certoraContextAttributes requires putting the
+    # certora_cli package dir on sys.path (shadow risk for generic names like
+    # `Shared`) plus the set_attribute_class() global. This test pins the
+    # literals against the installed CLI in a subprocess instead, so any
+    # rename/removal upstream fails here rather than silently desyncing.
+    import subprocess as sp
+    import sys
+
+    conf_keys = [key for pair in ConfigManager.SCALAR_TO_MAP_KEYS for key in pair]
+    probe = (
+        "import sys, json, certora_cli\n"
+        "from pathlib import Path\n"
+        "sys.path.insert(0, str(Path(certora_cli.__file__).parent))\n"
+        "import CertoraProver.certoraContextAttributes as Attrs\n"
+        "Attrs.set_attribute_class(Attrs.EvmProverAttributes)\n"
+        f"names = {conf_keys!r}\n"
+        "resolved = [getattr(Attrs.EvmProverAttributes, n.upper()).get_conf_key() for n in names]\n"
+        "print(json.dumps(resolved))\n"
+    )
+    result = sp.run([sys.executable, "-c", probe], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert __import__("json").loads(result.stdout) == conf_keys

--- a/tests/test_compiler_flag_reconciliation.py
+++ b/tests/test_compiler_flag_reconciliation.py
@@ -1,0 +1,185 @@
+"""Tests for scalar/map compiler-flag exclusivity in generated confs.
+
+certoraRun hard-rejects a conf that carries both a per-contract map and its
+scalar counterpart ("compiler map flags cannot be set with other compiler
+flags" for solc/compiler_map, "You cannot use both ..." for the other pairs),
+and the rejection happens before any solc invocation — no compilation
+workaround can detect it. Every step that puts a map into a conf must
+therefore drop the superseded scalar.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from certora_autosetup.autosetup.autosetup import Autosetup
+from certora_autosetup.cache.cache_fs import init_cache_fs
+from certora_autosetup.parsers.build_system_detector import BuildSystem
+from certora_autosetup.setup.setup_prover import SetupProver
+from certora_autosetup.utils.enhanced_config_manager import ConfigManager
+from certora_autosetup.utils.scope import Scope
+from certora_autosetup.utils.types import ContractHandle
+
+
+# =============================================================================
+# ConfigManager.drop_scalars_superseded_by_maps
+# =============================================================================
+
+
+def test_drops_solc_when_compiler_map_present() -> None:
+    conf = {"solc": "solc8.30", "compiler_map": {"Vault": "solc8.35"}}
+    ConfigManager.drop_scalars_superseded_by_maps(conf)
+    assert conf == {"compiler_map": {"Vault": "solc8.35"}}
+
+
+def test_each_pair_is_dropped_independently() -> None:
+    conf = {
+        "solc": "solc8.30",
+        "compiler_map": {"Vault": "solc8.35"},
+        "solc_via_ir": True,
+        "solc_via_ir_map": {"Vault": True},
+        "solc_optimize": "200",
+        "solc_optimize_map": {"Vault": "200"},
+        "solc_evm_version": "paris",
+        "solc_evm_version_map": {"Vault": "cancun"},
+    }
+    ConfigManager.drop_scalars_superseded_by_maps(conf)
+    assert set(conf) == {
+        "compiler_map",
+        "solc_via_ir_map",
+        "solc_optimize_map",
+        "solc_evm_version_map",
+    }
+
+
+def test_scalars_survive_without_maps() -> None:
+    conf = {"solc": "solc8.30", "solc_via_ir": True, "files": ["A.sol"]}
+    ConfigManager.drop_scalars_superseded_by_maps(conf)
+    assert conf == {"solc": "solc8.30", "solc_via_ir": True, "files": ["A.sol"]}
+
+
+def test_unrelated_pair_not_affected() -> None:
+    # A via-ir map must not drop the solc scalar and vice versa.
+    conf = {"solc": "solc8.30", "solc_via_ir_map": {"Vault": True}}
+    ConfigManager.drop_scalars_superseded_by_maps(conf)
+    assert conf == {"solc": "solc8.30", "solc_via_ir_map": {"Vault": True}}
+
+
+# =============================================================================
+# SetupProver._precompute_compiler_settings
+# =============================================================================
+#
+# The shape observed in the wild: foundry.toml pins solc 0.8.30 (the conf's
+# scalar "solc"), but the build's artifacts were produced with 0.8.35, so a
+# compiler_map is precomputed for every contract. The scalar must not survive
+# next to the map.
+
+
+class _StubExtractor:
+    def __init__(self, source_map):
+        self._source_map = source_map
+
+    def build_source_path_to_contracts_map(self):
+        return self._source_map
+
+
+@pytest.fixture
+def setup_prover(tmp_path: Path, monkeypatch) -> SetupProver:
+    monkeypatch.chdir(tmp_path)
+    init_cache_fs(str(tmp_path), force=True)
+    certora_dir = tmp_path / "certora"
+    certora_dir.mkdir()
+    sp = SetupProver(
+        log=lambda *args, **kwargs: None,
+        certora_dir=certora_dir,
+        script_dir=tmp_path,
+        additional_contracts=[],
+        extra_args=[],
+        skip_llm=True,
+        force_llm_regenerate=False,
+        stop_after_summaries=True,
+        scope=Scope(project_root=tmp_path),
+    )
+    sp.build_system = BuildSystem.FOUNDRY
+    return sp
+
+
+def test_precompute_drops_scalar_solc_when_map_is_built(
+    setup_prover, tmp_path: Path, monkeypatch
+) -> None:
+    mock_src = tmp_path / "certora" / "mocks" / "DummyERC20Impl.sol"
+    mock_src.parent.mkdir(parents=True)
+    mock_src.write_text("pragma solidity ^0.8.0;\ncontract DummyERC20Impl {}\n")
+    monkeypatch.setattr(
+        "certora_autosetup.utils.enhanced_config_manager.resolve_pragma_to_version",
+        lambda spec, **kwargs: "0.8.30",
+    )
+    monkeypatch.setattr(
+        "certora_autosetup.setup.setup_prover.FoundryContractExtractor",
+        lambda root: _StubExtractor({"src/Vault.sol": [("Vault", "0.8.35")]}),
+    )
+
+    contracts = [
+        ContractHandle(contract_name="Vault", source_file="src/Vault.sol"),
+        ContractHandle(
+            contract_name="DummyERC20Impl", source_file="certora/mocks/DummyERC20Impl.sol"
+        ),
+    ]
+    config = setup_prover._precompute_compiler_settings(
+        contracts, {"solc": "solc8.30", "files": ["src/Vault.sol", str(mock_src)]}
+    )
+
+    assert "solc" not in config
+    # Total over the scene: artifact version for Vault, pragma-resolved
+    # (biased to the old default) for the injected mock.
+    assert config["compiler_map"] == {
+        "Vault": "solc8.35",
+        "DummyERC20Impl": "solc8.30",
+    }
+
+
+def test_precompute_keeps_scalar_when_artifacts_agree(setup_prover, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "certora_autosetup.setup.setup_prover.FoundryContractExtractor",
+        lambda root: _StubExtractor({"src/Vault.sol": [("Vault", "0.8.30")]}),
+    )
+    contracts = [ContractHandle(contract_name="Vault", source_file="src/Vault.sol")]
+    config = setup_prover._precompute_compiler_settings(
+        contracts, {"solc": "solc8.30", "files": ["src/Vault.sol"]}
+    )
+    assert config["solc"] == "solc8.30"
+    assert "compiler_map" not in config
+
+
+# =============================================================================
+# Autosetup.get_build_system_config_dict_with_updates
+# =============================================================================
+#
+# The base build-system dict contributes scalars (e.g. "solc") while the
+# compilation updates contribute the maps; dict.update never deletes, so the
+# merge must drop the superseded scalars before the dict reaches a conf.
+
+
+def test_merge_drops_base_scalar_when_updates_bring_map(monkeypatch) -> None:
+    autosetup = Autosetup.__new__(Autosetup)
+    autosetup.compilation_config_updates = {
+        "compiler_map": {"Vault": "solc8.35", "Helper": "solc8.30"},
+        "solc_via_ir_map": {"Vault": True, "Helper": False},
+    }
+    autosetup.contract_handles = [
+        ContractHandle(contract_name="Vault", source_file="src/Vault.sol"),
+        ContractHandle(contract_name="Helper", source_file="src/Helper.sol"),
+    ]
+    monkeypatch.setattr(
+        autosetup,
+        "get_build_system_config_dict",
+        lambda: {"solc": "solc8.30", "solc_via_ir": True, "packages": []},
+        raising=False,
+    )
+
+    config = autosetup.get_build_system_config_dict_with_updates()
+
+    assert "solc" not in config
+    assert "solc_via_ir" not in config
+    assert config["compiler_map"] == {"Vault": "solc8.35", "Helper": "solc8.30"}
+    assert config["solc_via_ir_map"] == {"Vault": True, "Helper": False}

--- a/tests/test_remappings.py
+++ b/tests/test_remappings.py
@@ -63,9 +63,10 @@ def test_fallback_merges_foundry_toml_and_remappings_txt(tmp_path: Path, monkeyp
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
 
-    assert _keys(packages) == {"@openzeppelin/contracts", "solady", "forge-std"}
-    # relative targets resolved absolute against base_dir
-    assert _path_of(packages, "solady") == str(tmp_path / "lib/solady/src")
+    # Keys are canonicalized to a trailing-slash form (the boundary is significant).
+    assert _keys(packages) == {"@openzeppelin/contracts/", "solady/", "forge-std/"}
+    # relative targets resolved absolute against base_dir, also trailing-slash normalized
+    assert _path_of(packages, "solady/") == str(tmp_path / "lib/solady/src") + "/"
 
 
 def test_forge_remappings_take_priority_over_foundry_toml(tmp_path: Path, monkeypatch) -> None:
@@ -75,14 +76,14 @@ def test_forge_remappings_take_priority_over_foundry_toml(tmp_path: Path, monkey
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
 
-    assert _path_of(packages, "@oz") == str(tmp_path / "lib/forge-inferred-oz")
+    assert _path_of(packages, "@oz/") == str(tmp_path / "lib/forge-inferred-oz") + "/"
 
 
-def test_distinct_prefix_keys_both_kept(tmp_path: Path, monkeypatch) -> None:
-    # `@openzeppelin/contracts` must NOT swallow `@openzeppelin/contracts-upgradeable`:
-    # both distinct keys are kept so solc resolves imports by longest prefix. This is
-    # why keeping rstrip("/") is safe once the complete list is emitted — a shorter key
-    # must not shadow a more-specific longer one.
+def test_distinct_prefix_keys_keep_their_boundary_slash(tmp_path: Path, monkeypatch) -> None:
+    # `@openzeppelin/contracts/` must NOT swallow `@openzeppelin/contracts-upgradeable/`.
+    # The trailing slash is the prefix boundary: stripping it (the old `rstrip("/")`) turned
+    # `@openzeppelin/contracts` into a prefix of `@openzeppelin/contracts-upgradeable`, so a
+    # context-scoped v4 mapping mis-resolved upgradeable imports to a nonexistent path.
     _no_forge(monkeypatch)
     (tmp_path / "remappings.txt").write_text(
         "@openzeppelin/contracts/=lib/oz/contracts/\n"
@@ -91,8 +92,54 @@ def test_distinct_prefix_keys_both_kept(tmp_path: Path, monkeypatch) -> None:
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
 
-    assert "@openzeppelin/contracts" in _keys(packages)
-    assert "@openzeppelin/contracts-upgradeable" in _keys(packages)
+    keys = _keys(packages)
+    assert "@openzeppelin/contracts/" in keys
+    assert "@openzeppelin/contracts-upgradeable/" in keys
+    # the boundary-less form must NOT be emitted (that is the swallow-the-sibling bug)
+    assert "@openzeppelin/contracts" not in keys
+
+
+def test_context_scoped_key_keeps_trailing_slash(tmp_path: Path, monkeypatch) -> None:
+    # Regression: a context-scoped remapping sending one dependency's OZ imports to a
+    # vendored OZ v4 tree (a common pattern when a project mixes OZ v4 and v5). If the key's
+    # trailing slash is stripped, the scoped `@openzeppelin/contracts` prefix-matches
+    # `@openzeppelin/contracts-upgradeable/...` and — because solc ranks longest-context
+    # first — rewrites it to `lib/openzeppelin-contracts-v4/contracts-upgradeable/...`, which
+    # does not exist (v4 OZ has no contracts-upgradeable subtree).
+    _no_forge(monkeypatch)
+    (tmp_path / "remappings.txt").write_text(
+        "lib/some-dependency/:@openzeppelin/contracts/=lib/openzeppelin-contracts-v4/contracts/\n"
+        "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/\n"
+    )
+
+    packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
+
+    keys = _keys(packages)
+    assert "lib/some-dependency/:@openzeppelin/contracts/" in keys
+    assert "lib/some-dependency/:@openzeppelin/contracts" not in keys
+    # the scoped v4 target keeps its trailing slash so key/path agree on the boundary
+    assert _path_of(packages, "lib/some-dependency/:@openzeppelin/contracts/") == \
+        str(tmp_path / "lib/openzeppelin-contracts-v4/contracts") + "/"
+
+
+def test_file_level_remapping_keeps_exact_form(tmp_path: Path, monkeypatch) -> None:
+    # An import-patch entry that remaps a specific source FILE (…/IFoo.sol=…/IFoo.sol) must NOT
+    # get a trailing slash — otherwise solc looks for a directory `IFoo.sol/` and the import fails.
+    _no_forge(monkeypatch)
+    (tmp_path / "remappings.txt").write_text(
+        "src/interfaces/INoncesKeyed.sol=lib/aave-v4/src/interfaces/INoncesKeyed.sol\n"
+        "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/\n"
+    )
+
+    packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
+
+    keys = _keys(packages)
+    assert "src/interfaces/INoncesKeyed.sol" in keys           # file key: unchanged
+    assert "src/interfaces/INoncesKeyed.sol/" not in keys       # NOT slashed
+    assert _path_of(packages, "src/interfaces/INoncesKeyed.sol") == \
+        str(tmp_path / "lib/aave-v4/src/interfaces/INoncesKeyed.sol")   # file target: no slash
+    # directory remappings alongside it still get the boundary slash
+    assert "@openzeppelin/contracts/" in keys
 
 
 def test_package_json_deps_added_as_node_modules(tmp_path: Path, monkeypatch) -> None:
@@ -101,7 +148,7 @@ def test_package_json_deps_added_as_node_modules(tmp_path: Path, monkeypatch) ->
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
 
-    assert _path_of(packages, "@solmate/core") == str(tmp_path / "node_modules/@solmate/core")
+    assert _path_of(packages, "@solmate/core/") == str(tmp_path / "node_modules/@solmate/core") + "/"
 
 
 def test_empty_project_yields_no_packages(tmp_path: Path, monkeypatch) -> None:
@@ -124,8 +171,8 @@ def test_parse_config_populates_packages_from_remappings_txt(tmp_path: Path, mon
     config = manager.parse_config(foundry_toml)
 
     keys = {p.split("=", 1)[0] for p in (config.packages or [])}
-    assert "solady" in keys, "remappings.txt entry missing from parse_config packages (the bug)"
-    assert "@openzeppelin/contracts" in keys
+    assert "solady/" in keys, "remappings.txt entry missing from parse_config packages (the bug)"
+    assert "@openzeppelin/contracts/" in keys
 
 
 def test_parse_config_reads_foundry_toml_when_forge_absent(tmp_path: Path, monkeypatch) -> None:
@@ -138,7 +185,7 @@ def test_parse_config_reads_foundry_toml_when_forge_absent(tmp_path: Path, monke
     manager = FoundryManager(project_root=tmp_path, scope=None)
     config = manager.parse_config(foundry_toml)
 
-    assert config.packages and any(p.split("=", 1)[0] == "@oz" for p in config.packages)
+    assert config.packages and any(p.split("=", 1)[0] == "@oz/" for p in config.packages)
 
 
 def test_non_default_profile_remappings_read_when_forge_absent(tmp_path: Path, monkeypatch) -> None:
@@ -151,7 +198,7 @@ def test_non_default_profile_remappings_read_when_forge_absent(tmp_path: Path, m
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None, profile="ci")
 
-    assert _path_of(packages, "@oz") == str(tmp_path / "lib/ci-oz")
+    assert _path_of(packages, "@oz/") == str(tmp_path / "lib/ci-oz") + "/"
 
 
 def test_forge_run_with_foundry_profile_env(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Problem

Autosetup can generate certoraRun confs that carry BOTH a scalar `solc` and a per-contract `compiler_map`. certora-cli hard-rejects the pair:

```
compiler map flags cannot be set with other compiler flags. Got {'compiler_map': ..., 'solc': ...}
```

Observed on foundry projects whose build artifacts were produced with a different solc than the `foundry.toml` pin (`_precompute_compiler_settings` maps every contract to the artifact version while the build system's scalar `solc` stays in the conf).


🤖 Generated with [Claude Code](https://claude.com/claude-code)