### PR TITLE
autosetup: preserve the trailing slash on remapping keys (prefix boundary)

### DIFF
--- a/certora_autosetup/utils/remappings.py
+++ b/certora_autosetup/utils/remappings.py
@@ -18,6 +18,10 @@ import tomllib
 # (message, level) -> None; matches BuildSystemManager.log / CompilationWorkaroundManager.log.
 LogFn = Callable[[str, str], None]
 
+# Remapping entries whose key ends in one of these target a concrete source file, not a directory
+# prefix, so they must not receive a trailing-slash boundary (see `_merge_remapping_entry`).
+_SOURCE_SUFFIXES = (".sol", ".vy", ".yul")
+
 
 def build_packages_from_remapping_sources(base_dir: Path, log_fn: LogFn, profile: str = "default") -> List[str]:
     """Build a merged packages list from forge remappings, foundry.toml, remappings.txt, package.json.
@@ -193,12 +197,16 @@ def _merge_remapping_entry(
     if not Path(path).is_absolute():
         path = str(base_dir / path)
 
-    # Canonicalize both sides to a trailing-slash form so the key's prefix boundary is preserved
-    # (see docstring) and key/path agree on that boundary. Guard empty sides (bare `=`).
-    if key and not key.endswith("/"):
-        key += "/"
-    if path and not path.endswith("/"):
-        path += "/"
+    # Canonicalize a DIRECTORY remapping to a trailing-slash form so the key's prefix boundary is
+    # preserved (see docstring) and key/path agree on that boundary. A remapping that targets a
+    # concrete source file (e.g. an import-patch entry `.../IFoo.sol=.../IFoo.sol`) must keep its
+    # exact form — appending `/` would make solc look for a directory `IFoo.sol/`. Detect the
+    # file case by a source-file extension on the key.
+    if not key.lower().endswith(_SOURCE_SUFFIXES):
+        if key and not key.endswith("/"):
+            key += "/"
+        if path and not path.endswith("/"):
+            path += "/"
 
     if key in remapping_key_to_path:
         if warn_on_mismatch and remapping_key_to_path[key] != path:

--- a/certora_autosetup/utils/remappings.py
+++ b/certora_autosetup/utils/remappings.py
@@ -162,13 +162,18 @@ def _merge_remapping_entry(
 ) -> None:
     """Record a single `key=path` remapping entry into the running key->path/source maps.
 
-    Both sides of the entry are whitespace-stripped and ``rstrip("/")``-normalized before
-    storage, so the merged list is internally consistent regardless of which source emitted the
-    entry (and tolerant of ``@oz/ = lib/oz/``-style spacing). Solc/forge accept the normalized
-    form (`key=path`) as long as key and path agree on trailing slashes, which this guarantees.
-    Distinct keys (e.g. ``@openzeppelin/contracts`` vs ``@openzeppelin/contracts-upgradeable``)
-    stay separate entries; solc resolves imports by longest-prefix so the more specific key wins
-    — provided it is present, which is exactly why forge remappings is the authoritative source.
+    Both sides of the entry are whitespace-stripped and normalized to a canonical *trailing-slash*
+    form (a slash is appended when missing), so the merged list is internally consistent regardless
+    of which source emitted the entry (and tolerant of ``@oz/ = lib/oz/``-style spacing). The key's
+    trailing slash is significant and MUST be preserved: a remapping key marks a path *prefix* whose
+    boundary is the slash, so ``@openzeppelin/contracts/`` must not swallow imports beginning
+    ``@openzeppelin/contracts-upgradeable/``. solc chooses among applicable remappings by longest
+    matching *context* first (only then longest prefix), so a context-scoped key like
+    ``lib/some-dependency/:@openzeppelin/contracts`` — if its boundary slash were stripped —
+    outranks the correct global ``@openzeppelin/contracts-upgradeable`` mapping and rewrites the
+    upgradeable import to a nonexistent path. Keeping the slash keeps the two packages distinct.
+    (Normalizing both sides to end in a slash also collapses ``@oz/contracts`` and
+    ``@oz/contracts/`` from different sources onto one key, so the dedup below stays correct.)
 
     Relative target paths are resolved to absolute against ``base_dir`` so the packages list is
     valid even when the process CWD differs from the project dir.
@@ -181,11 +186,19 @@ def _merge_remapping_entry(
     Caller is responsible for confirming the entry contains an ``=`` before calling.
     """
     raw_key, raw_path = entry.split("=", 1)
-    key = raw_key.strip().rstrip("/")
-    path = raw_path.strip().rstrip("/")
+    key = raw_key.strip()
+    path = raw_path.strip()
 
+    # Resolve a relative target against base_dir first (Path() drops any trailing slash).
     if not Path(path).is_absolute():
         path = str(base_dir / path)
+
+    # Canonicalize both sides to a trailing-slash form so the key's prefix boundary is preserved
+    # (see docstring) and key/path agree on that boundary. Guard empty sides (bare `=`).
+    if key and not key.endswith("/"):
+        key += "/"
+    if path and not path.endswith("/"):
+        path += "/"
 
     if key in remapping_key_to_path:
         if warn_on_mismatch and remapping_key_to_path[key] != path:

--- a/tests/test_remappings.py
+++ b/tests/test_remappings.py
@@ -122,6 +122,26 @@ def test_context_scoped_key_keeps_trailing_slash(tmp_path: Path, monkeypatch) ->
         str(tmp_path / "lib/openzeppelin-contracts-v4/contracts") + "/"
 
 
+def test_file_level_remapping_keeps_exact_form(tmp_path: Path, monkeypatch) -> None:
+    # An import-patch entry that remaps a specific source FILE (…/IFoo.sol=…/IFoo.sol) must NOT
+    # get a trailing slash — otherwise solc looks for a directory `IFoo.sol/` and the import fails.
+    _no_forge(monkeypatch)
+    (tmp_path / "remappings.txt").write_text(
+        "src/interfaces/INoncesKeyed.sol=lib/aave-v4/src/interfaces/INoncesKeyed.sol\n"
+        "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/\n"
+    )
+
+    packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
+
+    keys = _keys(packages)
+    assert "src/interfaces/INoncesKeyed.sol" in keys           # file key: unchanged
+    assert "src/interfaces/INoncesKeyed.sol/" not in keys       # NOT slashed
+    assert _path_of(packages, "src/interfaces/INoncesKeyed.sol") == \
+        str(tmp_path / "lib/aave-v4/src/interfaces/INoncesKeyed.sol")   # file target: no slash
+    # directory remappings alongside it still get the boundary slash
+    assert "@openzeppelin/contracts/" in keys
+
+
 def test_package_json_deps_added_as_node_modules(tmp_path: Path, monkeypatch) -> None:
     _no_forge(monkeypatch)
     (tmp_path / "package.json").write_text('{"dependencies": {"@solmate/core": "^1.0.0"}}')

--- a/tests/test_remappings.py
+++ b/tests/test_remappings.py
@@ -63,9 +63,10 @@ def test_fallback_merges_foundry_toml_and_remappings_txt(tmp_path: Path, monkeyp
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
 
-    assert _keys(packages) == {"@openzeppelin/contracts", "solady", "forge-std"}
-    # relative targets resolved absolute against base_dir
-    assert _path_of(packages, "solady") == str(tmp_path / "lib/solady/src")
+    # Keys are canonicalized to a trailing-slash form (the boundary is significant).
+    assert _keys(packages) == {"@openzeppelin/contracts/", "solady/", "forge-std/"}
+    # relative targets resolved absolute against base_dir, also trailing-slash normalized
+    assert _path_of(packages, "solady/") == str(tmp_path / "lib/solady/src") + "/"
 
 
 def test_forge_remappings_take_priority_over_foundry_toml(tmp_path: Path, monkeypatch) -> None:
@@ -75,14 +76,14 @@ def test_forge_remappings_take_priority_over_foundry_toml(tmp_path: Path, monkey
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
 
-    assert _path_of(packages, "@oz") == str(tmp_path / "lib/forge-inferred-oz")
+    assert _path_of(packages, "@oz/") == str(tmp_path / "lib/forge-inferred-oz") + "/"
 
 
-def test_distinct_prefix_keys_both_kept(tmp_path: Path, monkeypatch) -> None:
-    # `@openzeppelin/contracts` must NOT swallow `@openzeppelin/contracts-upgradeable`:
-    # both distinct keys are kept so solc resolves imports by longest prefix. This is
-    # why keeping rstrip("/") is safe once the complete list is emitted — a shorter key
-    # must not shadow a more-specific longer one.
+def test_distinct_prefix_keys_keep_their_boundary_slash(tmp_path: Path, monkeypatch) -> None:
+    # `@openzeppelin/contracts/` must NOT swallow `@openzeppelin/contracts-upgradeable/`.
+    # The trailing slash is the prefix boundary: stripping it (the old `rstrip("/")`) turned
+    # `@openzeppelin/contracts` into a prefix of `@openzeppelin/contracts-upgradeable`, so a
+    # context-scoped v4 mapping mis-resolved upgradeable imports to a nonexistent path.
     _no_forge(monkeypatch)
     (tmp_path / "remappings.txt").write_text(
         "@openzeppelin/contracts/=lib/oz/contracts/\n"
@@ -91,8 +92,34 @@ def test_distinct_prefix_keys_both_kept(tmp_path: Path, monkeypatch) -> None:
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
 
-    assert "@openzeppelin/contracts" in _keys(packages)
-    assert "@openzeppelin/contracts-upgradeable" in _keys(packages)
+    keys = _keys(packages)
+    assert "@openzeppelin/contracts/" in keys
+    assert "@openzeppelin/contracts-upgradeable/" in keys
+    # the boundary-less form must NOT be emitted (that is the swallow-the-sibling bug)
+    assert "@openzeppelin/contracts" not in keys
+
+
+def test_context_scoped_key_keeps_trailing_slash(tmp_path: Path, monkeypatch) -> None:
+    # Regression: a context-scoped remapping sending one dependency's OZ imports to a
+    # vendored OZ v4 tree (a common pattern when a project mixes OZ v4 and v5). If the key's
+    # trailing slash is stripped, the scoped `@openzeppelin/contracts` prefix-matches
+    # `@openzeppelin/contracts-upgradeable/...` and — because solc ranks longest-context
+    # first — rewrites it to `lib/openzeppelin-contracts-v4/contracts-upgradeable/...`, which
+    # does not exist (v4 OZ has no contracts-upgradeable subtree).
+    _no_forge(monkeypatch)
+    (tmp_path / "remappings.txt").write_text(
+        "lib/some-dependency/:@openzeppelin/contracts/=lib/openzeppelin-contracts-v4/contracts/\n"
+        "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/\n"
+    )
+
+    packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
+
+    keys = _keys(packages)
+    assert "lib/some-dependency/:@openzeppelin/contracts/" in keys
+    assert "lib/some-dependency/:@openzeppelin/contracts" not in keys
+    # the scoped v4 target keeps its trailing slash so key/path agree on the boundary
+    assert _path_of(packages, "lib/some-dependency/:@openzeppelin/contracts/") == \
+        str(tmp_path / "lib/openzeppelin-contracts-v4/contracts") + "/"
 
 
 def test_package_json_deps_added_as_node_modules(tmp_path: Path, monkeypatch) -> None:
@@ -101,7 +128,7 @@ def test_package_json_deps_added_as_node_modules(tmp_path: Path, monkeypatch) ->
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
 
-    assert _path_of(packages, "@solmate/core") == str(tmp_path / "node_modules/@solmate/core")
+    assert _path_of(packages, "@solmate/core/") == str(tmp_path / "node_modules/@solmate/core") + "/"
 
 
 def test_empty_project_yields_no_packages(tmp_path: Path, monkeypatch) -> None:
@@ -124,8 +151,8 @@ def test_parse_config_populates_packages_from_remappings_txt(tmp_path: Path, mon
     config = manager.parse_config(foundry_toml)
 
     keys = {p.split("=", 1)[0] for p in (config.packages or [])}
-    assert "solady" in keys, "remappings.txt entry missing from parse_config packages (the bug)"
-    assert "@openzeppelin/contracts" in keys
+    assert "solady/" in keys, "remappings.txt entry missing from parse_config packages (the bug)"
+    assert "@openzeppelin/contracts/" in keys
 
 
 def test_parse_config_reads_foundry_toml_when_forge_absent(tmp_path: Path, monkeypatch) -> None:
@@ -138,7 +165,7 @@ def test_parse_config_reads_foundry_toml_when_forge_absent(tmp_path: Path, monke
     manager = FoundryManager(project_root=tmp_path, scope=None)
     config = manager.parse_config(foundry_toml)
 
-    assert config.packages and any(p.split("=", 1)[0] == "@oz" for p in config.packages)
+    assert config.packages and any(p.split("=", 1)[0] == "@oz/" for p in config.packages)
 
 
 def test_non_default_profile_remappings_read_when_forge_absent(tmp_path: Path, monkeypatch) -> None:
@@ -151,7 +178,7 @@ def test_non_default_profile_remappings_read_when_forge_absent(tmp_path: Path, m
 
     packages = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None, profile="ci")
 
-    assert _path_of(packages, "@oz") == str(tmp_path / "lib/ci-oz")
+    assert _path_of(packages, "@oz/") == str(tmp_path / "lib/ci-oz") + "/"
 
 
 def test_forge_run_with_foundry_profile_env(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Problem

The shared `packages` builder (`utils/remappings.py`) normalized every remapping with
`rstrip("/")`, stripping the trailing slash off the **key**. A remapping key is a path
*prefix* whose boundary is that slash, so stripping it turned `@openzeppelin/contracts` into
a prefix of `@openzeppelin/contracts-upgradeable`.

In a project that vendors two OpenZeppelin majors (v4 for a dependency, v5 for its own code),
a **context-scoped** remapping sends the dependency's `@openzeppelin/contracts/…` imports to the
v4 tree. With the boundary slash stripped, that scoped key also prefix-matched the sibling
`@openzeppelin/contracts-upgradeable/…` imports — and because solc ranks applicable remappings
by **longest matching context first** (only then longest prefix), the scoped v4 mapping won and
rewrote those imports to `…/openzeppelin-contracts-v4/contracts-upgradeable/…`, which does not
exist → `ParserError: Source "…" not found` → compilation analysis failed. The source-not-found
workaround re-derived the same stripped list, so it gave up with "conf unchanged".

(This reverses an earlier assumption that longest-*prefix* resolution made the strip safe —
solc's context-precedence means it isn't.)

## Fix

Two commits:

1. **Preserve the boundary slash.** Canonicalize both key and target to a trailing-slash form
   (append when missing) instead of stripping. Distinct packages stay distinct, key/path agree
   on the boundary, and `@x/` vs `@x` from different sources still collapse onto one dedup key.
2. **Skip file remappings.** An import-patch entry can remap a concrete source file
   (`…/IFoo.sol=…/IFoo.sol`); appending `/` there yields `IFoo.sol/`, which solc treats as a
   missing directory. Only directory-prefix keys get the boundary slash — keys ending in a
   source-file extension (`.sol`/`.vy`/`.yul`) keep their exact form.

## Tests

`tests/test_remappings.py`: existing assertions updated to the canonical trailing-slash form,
plus new regression tests for the sibling-prefix case, the context-scoped case, and the
file-level remapping case. Verified end-to-end on a build-phase corpus of Foundry projects that
mix OZ v4/v5 — the affected projects now compile, with no compile regressions.
