### PR TITLE
unbreak messages

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Fires ONLY if a step above failed. The whole point of the file.
       - name: Notify Slack on failure
-        if: false
+        if: failure()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -256,7 +256,7 @@ def get_prover_tool(
 
                 component = (spec_stem or main_contract).removeprefix("autospec_")
                 iteration = summary.prover_total_calls + 1
-                config["msg"] = f"{component} #{iteration}"
+                config["msg"] = f"{component} iteration number {iteration}"
 
                 with temp_certora_file(
                     root=project_root,


### PR DESCRIPTION
For mysterious reasons, we don't allow # in the prover call message. We have added a "#{n}" to the messages. This didn't work and breaks everything.

Unbreaking the tests!