### PR TITLE
autosetup: match curated library summaries across the whole scene

### DIFF
--- a/certora_autosetup/setup/setup_summaries.py
+++ b/certora_autosetup/setup/setup_summaries.py
@@ -2383,15 +2383,25 @@ Method signature: {method_signature}
         self.log(f"Matching summaries for {main_contract}...")
         # Filter to only methods that originate from this contract (compilation unit)
         contract_methods = mp.get_methods_by_originating_contract(main_contract)
+        # For a `library_names` entry, also consider every library method in the scene. A library
+        # is deduped to a single `originatingContract` that need not be `main_contract`, so an
+        # originating-scoped search alone can miss it. Restricted to `isLibrary` methods, since a
+        # library is always a resolvable CVL receiver while an inherited abstract base is not in
+        # every scene; non-library methods stay originating-scoped. Unioned with `contract_methods`
+        # so the candidate set only grows.
+        library_scene_methods = [m for m in mp.get_all_methods() if m.get("isLibrary")]
         matched_functions: Set[str] = set()
         matched_method_tuples: Set[Tuple[str, str]] = set()
 
         for func_name, func_info in self.function_summaries.items():
             self.log(f"Checking for {func_info['description']} usage...", "DEBUG")
+            candidate_methods = (
+                contract_methods + library_scene_methods if func_info.get("library_names") else contract_methods
+            )
 
             # Match by name (disjunctive - match any name in list)
             if "names" in func_info:
-                for method in contract_methods:
+                for method in candidate_methods:
                     if method["name"] in func_info["names"]:
                         # Optional: require the method to belong to one of library_names
                         if func_info.get("library_names"):
@@ -2412,7 +2422,7 @@ Method signature: {method_signature}
 
             # Match by signature (disjunctive - match any signature in list)
             if "signatures" in func_info and func_name not in matched_functions:
-                for method in contract_methods:
+                for method in candidate_methods:
                     method_sig = f"{method['name']}({','.join(method['fullSignature'])})"
                     if method_sig in func_info["signatures"]:
                         # Optional: require the method to belong to one of library_names

--- a/tests/test_curated_library_scene_matching.py
+++ b/tests/test_curated_library_scene_matching.py
@@ -1,0 +1,95 @@
+"""Regression tests for scene-wide curated library summary matching in
+``SummarySetup.match_summaries_from_all_methods``.
+
+A ``library_names`` entry must match even when the library method's
+``originatingContract`` is a foreign compilation unit (a library is deduped to a single
+originating unit in all_methods.json). Non-library inherited bases stay originating-scoped.
+"""
+
+import json
+from pathlib import Path
+
+from certora_autosetup.parsers.method_parser import MethodParser
+from certora_autosetup.setup import setup_summaries
+from certora_autosetup.setup.setup_summaries import SummarySetup
+
+# Controlled registry: one real library and one inherited abstract base.
+REGISTRY = {
+    "lib_entry": {
+        "names": ["libFn"],
+        "library_names": ["SomeLib"],
+        "summary_file": "specs/summaries/SomeLib.spec",
+        "description": "SomeLib.libFn",
+    },
+    "base_entry": {
+        "names": ["baseFn"],
+        "library_names": ["SomeBase"],
+        "summary_file": "specs/summaries/SomeBase.spec",
+        "description": "SomeBase.baseFn",
+    },
+}
+
+
+def _method(name, contract, originating, *, library):
+    """One all_methods.json entry with the fields the matcher reads."""
+    return {
+        "name": name,
+        "contractName": contract,
+        "definingContract": contract,
+        "originatingContract": originating,
+        "isLibrary": library,
+        "fullSignature": [],
+        "visibility": "internal",
+        "stateMutability": "nonpayable",
+    }
+
+
+def _match(tmp_path, monkeypatch, methods, main_contract):
+    all_methods = tmp_path / "all_methods.json"
+    all_methods.write_text(json.dumps(methods))
+    # The matcher guards on PATH_ALL_METHODS_JSON.exists() before reading via the parser.
+    monkeypatch.setattr(setup_summaries, "PATH_ALL_METHODS_JSON", all_methods)
+    obj = SummarySetup.__new__(SummarySetup)  # bypass __init__
+    obj.methods_parser = MethodParser(str(all_methods))
+    obj.function_summaries = REGISTRY
+    obj.log = lambda *a, **k: None
+    matched, _ = obj.match_summaries_from_all_methods(main_contract)
+    return matched
+
+
+def test_library_matches_despite_foreign_originating_contract(tmp_path, monkeypatch):
+    # The library method is attributed to a foreign unit yet must still match for Main.
+    methods = [
+        _method("libFn", "SomeLib", "OtherUnit", library=True),
+        _method("f", "Main", "Main", library=False),
+    ]
+    assert "lib_entry" in _match(tmp_path, monkeypatch, methods, "Main")
+
+
+def test_non_library_base_not_matched_scene_wide(tmp_path, monkeypatch):
+    # A non-library base originating from a foreign unit must not be matched scene-wide.
+    methods = [
+        _method("baseFn", "SomeBase", "OtherUnit", library=False),
+        _method("f", "Main", "Main", library=False),
+    ]
+    assert "base_entry" not in _match(tmp_path, monkeypatch, methods, "Main")
+
+
+def test_non_library_base_matches_when_originating_in_scope(tmp_path, monkeypatch):
+    # Originating-scoped matching for non-library entries is preserved.
+    methods = [_method("baseFn", "SomeBase", "Main", library=False)]
+    assert "base_entry" in _match(tmp_path, monkeypatch, methods, "Main")
+
+
+def test_library_matches_when_originating_in_scope(tmp_path, monkeypatch):
+    # The union does not disturb the ordinary in-scope case.
+    methods = [_method("libFn", "SomeLib", "Main", library=True)]
+    assert "lib_entry" in _match(tmp_path, monkeypatch, methods, "Main")
+
+
+def test_shipped_registry_getCollectionId_entry_is_library_scoped():
+    # Guard the wiring: the curated library entry the fix relies on stays shaped.
+    reg = json.loads((Path(setup_summaries.__file__).parent / "function_summaries.json").read_text())
+    entry = reg["ctHelpers_getCollectionId"]
+    assert entry["library_names"] == ["CTHelpers"]
+    assert "getCollectionId" in entry["names"]


### PR DESCRIPTION
The curated `CTHelpers.getCollectionId` summary was registered but never attached:
`match_summaries_from_all_methods` scoped candidates to
`get_methods_by_originating_contract(main_contract)`, and the library's single
`originatingContract` need not be any summarized contract — so the entry was
invisible and the scene-optimization phase kept OOM-ing on the un-summarized
arithmetic.

## Fix

For `library_names` entries, add every `isLibrary` method in the scene to the
candidate set (unioned with the originating-scoped methods):

```python
library_scene_methods = [m for m in mp.get_all_methods() if m.get("isLibrary")]
candidate_methods = (
    contract_methods + library_scene_methods if func_info.get("library_names") else contract_methods
)
```

## Tests

`tests/test_curated_library_scene_matching.py`: a foreign-originating library still
matches; a non-library base from a foreign unit does not match scene-wide but does
when it originates in scope (originating-scoped behavior preserved); and the shipped
`ctHelpers_getCollectionId` entry stays library-scoped.
