### PR TITLE
autosetup: record all originating contracts per method (originatingContracts)

### DIFF
--- a/certora_autosetup/autosetup/autosetup.py
+++ b/certora_autosetup/autosetup/autosetup.py
@@ -752,14 +752,13 @@ class Autosetup:
                         *((path, name) for path, name in parsed_additional),
                     }
                     extra_libs = [
-                        h.to_config_str()
+                        h
                         for h in autosetup.libraries_for_contracts(in_scene_units)
                         if (h.source_file, h.contract_name) not in in_scene_handles
                     ]
                     files_to_include = (
                         [contract_handle.to_config_str()]
                         + autosetup.config.additional_contracts
-                        + extra_libs
                     )
                     props = {"files": files_to_include}
                     autosetup.log(
@@ -767,6 +766,13 @@ class Autosetup:
                         f"--additional-contracts, and {len(extra_libs)} library file(s) used by them"
                     )
                     autosetup.config_manager.update_config_with_properties(enhanced_config.path, props)
+                    # Add the libraries via add_files_to_config so their compiler_map / solc_via_ir_map
+                    # / solc_optimize_map entries are filled; a raw files= write leaves the maps
+                    # unreconciled and certoraRun rejects the unmatched files.
+                    if extra_libs:
+                        autosetup.config_manager.add_files_to_config(
+                            enhanced_config.path, new_contract_files=extra_libs
+                        )
 
                 # Fix the base config with typechecker
                 typechecker_success = await asyncio.to_thread(

--- a/certora_autosetup/parsers/method_parser.py
+++ b/certora_autosetup/parsers/method_parser.py
@@ -40,7 +40,7 @@ class MethodParser:
 
     def get_methods_by_originating_contract(self, contract_name: str) -> List[Dict]:
         """Get all methods whose compilation unit includes ``contract_name``."""
-        return [m for m in self.methods if contract_name in m.get('originatingContracts', [])]
+        return [m for m in self.methods if contract_name in m['originatingContracts']]
 
     def get_methods_by_name(self, method_name: str) -> List[Dict]:
         """Get all methods with a specific name across all contracts."""

--- a/certora_autosetup/parsers/method_parser.py
+++ b/certora_autosetup/parsers/method_parser.py
@@ -39,8 +39,8 @@ class MethodParser:
         return [m for m in self.methods if m['contractName'] == contract_name]
 
     def get_methods_by_originating_contract(self, contract_name: str) -> List[Dict]:
-        """Get all methods that originate from a specific contract (compilation unit)."""
-        return [m for m in self.methods if m.get('originatingContract') == contract_name]
+        """Get all methods whose compilation unit includes ``contract_name``."""
+        return [m for m in self.methods if contract_name in m.get('originatingContracts', [])]
 
     def get_methods_by_name(self, method_name: str) -> List[Dict]:
         """Get all methods with a specific name across all contracts."""

--- a/certora_autosetup/setup/setup_prover.py
+++ b/certora_autosetup/setup/setup_prover.py
@@ -641,7 +641,7 @@ class SetupProver:
     def _process_method_info(
         self,
         method: Dict,
-        methods_set: set,
+        methods_by_sig: Dict,
         all_methods: List,
         method_counts: Dict,
         originating_contract: str,
@@ -699,7 +699,8 @@ class SetupProver:
             # the per-function defining contract, best emitted upstream by certoraBuild.py from the
             # function node's ``certora_contract_name``, which would also remove this file heuristic.
             "definingContract": self._sole_contract_declared_in(method.get("originalFile", "")),
-            "originatingContract": originating_contract,
+            # Every compilation unit that inlines this method; repeats union their unit here.
+            "originatingContracts": [originating_contract] if originating_contract else [],
             "isLibrary": method.get("isLibrary", False),
             "name": method.get("name", ""),
             "nonpayable": method.get("nonpayable", False)
@@ -731,10 +732,14 @@ class SetupProver:
             tuple(method_info["fullSignature"]),
         )
 
-        # Only add if not already seen
-        if method_signature not in methods_set:
-            methods_set.add(method_signature)
+        # Add on first sight; on a repeat (same method reached via another compilation unit),
+        # union the extra originating unit into the already-kept entry instead of dropping it.
+        existing = methods_by_sig.get(method_signature)
+        if existing is None:
+            methods_by_sig[method_signature] = method_info
             all_methods.append(method_info)
+        elif originating_contract and originating_contract not in existing["originatingContracts"]:
+            existing["originatingContracts"].append(originating_contract)
 
     def _build_declared_contracts_by_file(self) -> Dict[str, Set[str]]:
         """Map each source file (relative path) to the concrete contracts/libraries it declares.
@@ -771,10 +776,10 @@ class SetupProver:
 
     def generate_all_methods_json(self, build_data: Dict) -> None:
         """Extract and write all methods information to all_methods.json."""
-        # Extract all methods from all contracts
-        # Use a set to avoid duplicates during collection, then convert to list
+        # Extract all methods from all contracts. A method reached via multiple compilation units
+        # is kept once (keyed by signature); each unit is unioned into its ``originatingContracts``.
         self._declared_contracts_by_file = self._build_declared_contracts_by_file()
-        methods_set: set = set()
+        methods_by_sig: Dict = {}
         all_methods: list = []
         method_counts: dict = {}  # For calculating overload counts
 
@@ -791,7 +796,7 @@ class SetupProver:
                         for method in contract["allMethods"]:
                             self._process_method_info(
                                 method,
-                                methods_set,
+                                methods_by_sig,
                                 all_methods,
                                 method_counts,
                                 originating_contract,
@@ -806,7 +811,7 @@ class SetupProver:
                                 method = func_data["method"]
                                 self._process_method_info(
                                     method,
-                                    methods_set,
+                                    methods_by_sig,
                                     all_methods,
                                     method_counts,
                                     originating_contract,

--- a/certora_autosetup/setup/setup_summaries.py
+++ b/certora_autosetup/setup/setup_summaries.py
@@ -1700,7 +1700,7 @@ Method signature: {method_signature}
             contract_files: Set of Solidity files to analyze
             methods_to_skip: Set of (contract, method) pairs to skip (already marked for
                 summarization by non-LLM step or matched by previous LLM recipes)
-            main_contract: Optional main contract name to filter methods by originatingContract
+            main_contract: Optional main contract name to filter methods to its compilation unit
 
         Returns:
             List of methods that match the criteria, excluding methods in methods_to_skip
@@ -1719,13 +1719,13 @@ Method signature: {method_signature}
 
         mp = self.methods_parser
 
-        # Filter methods by properties and originatingContract
+        # Filter methods by properties and compilation-unit membership
         all_methods = mp.get_all_methods()
         filtered_methods = []
 
         for method in all_methods:
-            # Filter by originating contract if main_contract is specified
-            if main_contract and method.get("originatingContract") != main_contract:
+            # Filter to the main contract's compilation unit if specified
+            if main_contract and main_contract not in method.get("originatingContracts", []):
                 continue
             method_key = (method["contractName"], method["name"])
 
@@ -2300,7 +2300,7 @@ Method signature: {method_signature}
     ) -> bool:
         """Run all LLM recipes for one compilation unit and emit per-summarized-contract specs.
 
-        Filters methods by ``originatingContract == contract_name``. Each match is appended
+        Filters methods to those whose compilation unit includes ``contract_name``. Each match is appended
         to ``self._methods_per_contract[match["contractName"]]`` and the corresponding
         ``certora/specs/summaries/{contractName}_summaries.spec`` file is (re-)written with
         the full set of methods seen so far for that contract — methods already in
@@ -2308,7 +2308,7 @@ Method signature: {method_signature}
         across iterations doesn't duplicate summaries even when compilation units overlap.
 
         Args:
-            contract_name: Compilation unit to analyze (matched against ``originatingContract``).
+            contract_name: Compilation unit to analyze (matched against ``originatingContracts``).
             contract_files: Solidity source files passed to ``analyze_with_llm``.
             methods_to_skip: ``(contractName, methodName)`` pairs already handled by the
                 non-LLM step or otherwise not to be reanalyzed. Always merged with
@@ -2381,27 +2381,18 @@ Method signature: {method_signature}
         mp = self.methods_parser
 
         self.log(f"Matching summaries for {main_contract}...")
-        # Filter to only methods that originate from this contract (compilation unit)
+        # Methods in this contract's compilation unit. Membership (originatingContracts) rather
+        # than a single attribution, so a shared library inlined into the unit still matches.
         contract_methods = mp.get_methods_by_originating_contract(main_contract)
-        # For a `library_names` entry, also consider every library method in the scene. A library
-        # is deduped to a single `originatingContract` that need not be `main_contract`, so an
-        # originating-scoped search alone can miss it. Restricted to `isLibrary` methods, since a
-        # library is always a resolvable CVL receiver while an inherited abstract base is not in
-        # every scene; non-library methods stay originating-scoped. Unioned with `contract_methods`
-        # so the candidate set only grows.
-        library_scene_methods = [m for m in mp.get_all_methods() if m.get("isLibrary")]
         matched_functions: Set[str] = set()
         matched_method_tuples: Set[Tuple[str, str]] = set()
 
         for func_name, func_info in self.function_summaries.items():
             self.log(f"Checking for {func_info['description']} usage...", "DEBUG")
-            candidate_methods = (
-                contract_methods + library_scene_methods if func_info.get("library_names") else contract_methods
-            )
 
             # Match by name (disjunctive - match any name in list)
             if "names" in func_info:
-                for method in candidate_methods:
+                for method in contract_methods:
                     if method["name"] in func_info["names"]:
                         # Optional: require the method to belong to one of library_names
                         if func_info.get("library_names"):
@@ -2422,7 +2413,7 @@ Method signature: {method_signature}
 
             # Match by signature (disjunctive - match any signature in list)
             if "signatures" in func_info and func_name not in matched_functions:
-                for method in candidate_methods:
+                for method in contract_methods:
                     method_sig = f"{method['name']}({','.join(method['fullSignature'])})"
                     if method_sig in func_info["signatures"]:
                         # Optional: require the method to belong to one of library_names

--- a/certora_autosetup/setup/setup_summaries.py
+++ b/certora_autosetup/setup/setup_summaries.py
@@ -1725,7 +1725,7 @@ Method signature: {method_signature}
 
         for method in all_methods:
             # Filter to the main contract's compilation unit if specified
-            if main_contract and main_contract not in method.get("originatingContracts", []):
+            if main_contract and main_contract not in method["originatingContracts"]:
                 continue
             method_key = (method["contractName"], method["name"])
 

--- a/certora_autosetup/setup/solidity_utils.py
+++ b/certora_autosetup/setup/solidity_utils.py
@@ -392,7 +392,7 @@ def find_libraries_used_by(
     """
     used: set[str] = set()
     for method in methods:
-        if contract_name not in method.get("originatingContracts", []):
+        if contract_name not in method["originatingContracts"]:
             continue
         ref = method.get("contractName")
         if ref in library_name_to_file:

--- a/certora_autosetup/setup/solidity_utils.py
+++ b/certora_autosetup/setup/solidity_utils.py
@@ -375,7 +375,7 @@ def find_libraries_used_by(
     """Return ContractHandles for libraries whose methods appear in ``contract_name``'s compilation unit.
 
     A library counts as "used by" ``contract_name`` if at least one method in
-    ``methods`` has ``originatingContract == contract_name`` and ``contractName ==
+    ``methods`` has ``contract_name`` among its ``originatingContracts`` and ``contractName ==
     {library_name}``. Use this to add only the libraries the contract actually
     calls to the prover scene, instead of dumping every library file in the project.
 
@@ -392,7 +392,7 @@ def find_libraries_used_by(
     """
     used: set[str] = set()
     for method in methods:
-        if method.get("originatingContract") != contract_name:
+        if contract_name not in method.get("originatingContracts", []):
             continue
         ref = method.get("contractName")
         if ref in library_name_to_file:

--- a/tests/test_compiler_flag_reconciliation.py
+++ b/tests/test_compiler_flag_reconciliation.py
@@ -269,3 +269,35 @@ def test_update_optimize_map_noop_when_already_present(tmp_path: Path) -> None:
         conf, ContractHandle(contract_name="Sample_1", source_file="certora/harnesses/Sample_1.sol")
     ) is False
     assert conf["solc_optimize_map"] == {"Sample_1": "22300"}
+
+
+def test_update_via_ir_map_adds_new_contract_with_default(tmp_path: Path) -> None:
+    # A via-ir map covering existing files but not a newly-added library file must gain an entry,
+    # else certoraRun rejects the library as "not matched in solc_via_ir_map".
+    mgr = _config_manager(tmp_path)
+    conf = {"solc_via_ir_map": {"Sample": True}}
+    added = mgr.update_via_ir_map_for_contract(
+        conf, ContractHandle(contract_name="Sample_1", source_file="lib/dep/Sample_1.sol")
+    )
+    assert added is True
+    assert conf["solc_via_ir_map"]["Sample_1"] is True
+
+
+def test_update_via_ir_map_prefers_reference_value(tmp_path: Path) -> None:
+    mgr = _config_manager(tmp_path)
+    conf = {"solc_via_ir_map": {"Sample": True}}
+    mgr.update_via_ir_map_for_contract(
+        conf,
+        ContractHandle(contract_name="Sample_1", source_file="lib/dep/Sample_1.sol"),
+        reference_maps={"solc_via_ir_map": {"Sample_1": False}},
+    )
+    assert conf["solc_via_ir_map"]["Sample_1"] is False
+
+
+def test_update_via_ir_map_noop_when_already_present(tmp_path: Path) -> None:
+    mgr = _config_manager(tmp_path)
+    conf = {"solc_via_ir_map": {"Sample_1": True}}
+    assert mgr.update_via_ir_map_for_contract(
+        conf, ContractHandle(contract_name="Sample_1", source_file="lib/dep/Sample_1.sol")
+    ) is False
+    assert conf["solc_via_ir_map"] == {"Sample_1": True}

--- a/tests/test_curated_library_scene_matching.py
+++ b/tests/test_curated_library_scene_matching.py
@@ -1,9 +1,10 @@
-"""Regression tests for scene-wide curated library summary matching in
+"""Regression tests for compilation-unit curated summary matching in
 ``SummarySetup.match_summaries_from_all_methods``.
 
-A ``library_names`` entry must match even when the library method's
-``originatingContract`` is a foreign compilation unit (a library is deduped to a single
-originating unit in all_methods.json). Non-library inherited bases stay originating-scoped.
+A curated ``library_names`` entry must match for a contract whose compilation unit contains the
+library method — even a shared library inlined into several units — and must NOT match for a
+contract whose unit does not contain it. Membership comes from the method's
+``originatingContracts`` (all units that inline it), not a single attribution.
 """
 
 import json
@@ -13,7 +14,6 @@ from certora_autosetup.parsers.method_parser import MethodParser
 from certora_autosetup.setup import setup_summaries
 from certora_autosetup.setup.setup_summaries import SummarySetup
 
-# Controlled registry: one real library and one inherited abstract base.
 REGISTRY = {
     "lib_entry": {
         "names": ["libFn"],
@@ -21,33 +21,25 @@ REGISTRY = {
         "summary_file": "specs/summaries/SomeLib.spec",
         "description": "SomeLib.libFn",
     },
-    "base_entry": {
-        "names": ["baseFn"],
-        "library_names": ["SomeBase"],
-        "summary_file": "specs/summaries/SomeBase.spec",
-        "description": "SomeBase.baseFn",
-    },
 }
 
 
-def _method(name, contract, originating, *, library):
-    """One all_methods.json entry with the fields the matcher reads."""
+def _method(name, contract, units):
     return {
         "name": name,
         "contractName": contract,
         "definingContract": contract,
-        "originatingContract": originating,
-        "isLibrary": library,
+        "originatingContracts": units,
+        "isLibrary": True,
         "fullSignature": [],
         "visibility": "internal",
-        "stateMutability": "nonpayable",
+        "stateMutability": "pure",
     }
 
 
 def _match(tmp_path, monkeypatch, methods, main_contract):
     all_methods = tmp_path / "all_methods.json"
     all_methods.write_text(json.dumps(methods))
-    # The matcher guards on PATH_ALL_METHODS_JSON.exists() before reading via the parser.
     monkeypatch.setattr(setup_summaries, "PATH_ALL_METHODS_JSON", all_methods)
     obj = SummarySetup.__new__(SummarySetup)  # bypass __init__
     obj.methods_parser = MethodParser(str(all_methods))
@@ -57,38 +49,32 @@ def _match(tmp_path, monkeypatch, methods, main_contract):
     return matched
 
 
-def test_library_matches_despite_foreign_originating_contract(tmp_path, monkeypatch):
-    # The library method is attributed to a foreign unit yet must still match for Main.
-    methods = [
-        _method("libFn", "SomeLib", "OtherUnit", library=True),
-        _method("f", "Main", "Main", library=False),
-    ]
+def test_library_matches_when_unit_includes_it(tmp_path, monkeypatch):
+    # Shared library inlined into several units; Main is among them -> matches for Main.
+    methods = [_method("libFn", "SomeLib", ["OtherUnit", "Main"])]
     assert "lib_entry" in _match(tmp_path, monkeypatch, methods, "Main")
 
 
-def test_non_library_base_not_matched_scene_wide(tmp_path, monkeypatch):
-    # A non-library base originating from a foreign unit must not be matched scene-wide.
+def test_not_matched_when_unit_excludes_it(tmp_path, monkeypatch):
+    # Library present in the scene but not in Main's unit -> not matched (no over-match).
     methods = [
-        _method("baseFn", "SomeBase", "OtherUnit", library=False),
-        _method("f", "Main", "Main", library=False),
+        _method("libFn", "SomeLib", ["OtherUnit"]),
+        _method("f", "Main", ["Main"]),
     ]
-    assert "base_entry" not in _match(tmp_path, monkeypatch, methods, "Main")
+    assert "lib_entry" not in _match(tmp_path, monkeypatch, methods, "Main")
 
 
-def test_non_library_base_matches_when_originating_in_scope(tmp_path, monkeypatch):
-    # Originating-scoped matching for non-library entries is preserved.
-    methods = [_method("baseFn", "SomeBase", "Main", library=False)]
-    assert "base_entry" in _match(tmp_path, monkeypatch, methods, "Main")
-
-
-def test_library_matches_when_originating_in_scope(tmp_path, monkeypatch):
-    # The union does not disturb the ordinary in-scope case.
-    methods = [_method("libFn", "SomeLib", "Main", library=True)]
-    assert "lib_entry" in _match(tmp_path, monkeypatch, methods, "Main")
+def test_library_scoped_per_unit_across_sibling_contracts(tmp_path, monkeypatch):
+    # A library in one contract's unit must NOT be matched for a sibling whose unit lacks it.
+    methods = [
+        _method("libFn", "SomeLib", ["A"]),  # library only in A's unit
+        _method("g", "B", ["B"]),            # B's own method, no library
+    ]
+    assert "lib_entry" in _match(tmp_path, monkeypatch, methods, "A")
+    assert "lib_entry" not in _match(tmp_path, monkeypatch, methods, "B")
 
 
 def test_shipped_registry_getCollectionId_entry_is_library_scoped():
-    # Guard the wiring: the curated library entry the fix relies on stays shaped.
     reg = json.loads((Path(setup_summaries.__file__).parent / "function_summaries.json").read_text())
     entry = reg["ctHelpers_getCollectionId"]
     assert entry["library_names"] == ["CTHelpers"]


### PR DESCRIPTION
## Summary

Two related fixes to per-compilation-unit handling.

**1. Record all originating contracts per method.** `all_methods.json` kept a single,
first-seen `originatingContract` per method (the field was excluded from the dedup key, so
repeats were dropped). A method inlined into several units — e.g. a shared library — kept only
one arbitrary unit, so any consumer scoping to a contract's compilation unit missed it for the
others. Replace it with **`originatingContracts`** (every unit that inlines the method) and match
by **membership**; drop the singular field.

Applied to all four readers:
1. `setup_prover.py` — dedup keyed into a dict; repeats union their unit into `originatingContracts`.
2. `method_parser.get_methods_by_originating_contract` — membership test.
3. `setup_summaries.py` — matcher + `analyze_with_llm` scoping use membership (removing the
   scene-wide `isLibrary` union).
4. `solidity_utils.py` — used-libraries scan uses membership.

For curated matching this both attaches a library summary for a contract whose unit inlines the
library (previously missed) and avoids matching every scene library onto every contract.

**2. Reconcile compiler maps for warmup libraries.** The warmup path wrote the resolved library
files into `files=` with a plain `update_config_with_properties`, which trims
`solc_via_ir_map` / `compiler_map` / `solc_optimize_map` to the contracts left in `files=` —
leaving the just-added libraries in `files=` but absent from the maps, so certoraRun rejected them
as *not matched in `solc_via_ir_map`*. Route the extra library handles through
`add_files_to_config` so their map entries are filled. (Main + `--additional-contracts` already get
theirs from `create_base_config`, so they stay on the plain write.)

## Tests

- `tests/test_curated_library_scene_matching.py` — drives `match_summaries_from_all_methods` over an
  in-memory `all_methods.json`: library in the unit → matched; not in the unit → not matched;
  per-unit isolation across siblings; shipped registry entry stays library-scoped. Non-vacuous by
  mutation (old singular logic fails the inclusion cases).
- `tests/test_compiler_flag_reconciliation.py` — adds `update_via_ir_map_for_contract` coverage
  mirroring the existing `solc_optimize_map` tests.

Reproduced the warmup fix end to end on a real project (pinned commit): the map is trimmed to 1
entry, the two library files are re-added to `solc_via_ir_map`, and `certoraRun
--compilation_steps_only` (the failing step) passes.
