### PR TITLE
Anchor build-system detection on the contract, not the run root

### DIFF
--- a/certora_autosetup/autosetup/autosetup.py
+++ b/certora_autosetup/autosetup/autosetup.py
@@ -51,6 +51,7 @@ from certora_autosetup.utils.paths import (
 from certora_autosetup.utils.contract_utils import split_contract_spec
 from certora_autosetup.utils.enhanced_config_manager import ConfigManager, FileContent, ProverJobSpec
 from certora_autosetup.utils.llm_util import get_ledger_rows
+from certora_autosetup.utils.project_dir import describe_build_config_dir, find_build_config_dir
 from certora_autosetup.utils.scope import Scope
 from certora_autosetup.utils.types import ContractHandle, ContractInfo
 
@@ -112,6 +113,9 @@ class Autosetup:
         self.bytes_mappings: List[tuple[ContractHandle, List[str]]] = []
         # Set during run()
         self.main_contract_handle: Optional[ContractHandle] = None
+        # Directory owning the main contract's build config; resolved in
+        # setup_build_system_config(). Equals the run root for a root-level project.
+        self.build_config_dir: Path = Path.cwd()
 
     def log(self, message: str, level: str = "INFO"):
         logger.log(message, level, COMPONENT)
@@ -235,6 +239,7 @@ class Autosetup:
         self.setup_build_system_config()
         self.setup_prover.build_system = self.build_system
         self.setup_prover.build_system_config = self.build_system_config
+        self.setup_prover.build_config_dir = self.build_config_dir
 
         # Check full-pipeline cache before running
         result_path = Path(DIR_CERTORA_INTERNAL) / FILE_AUTOSETUP_RESULT
@@ -346,8 +351,21 @@ class Autosetup:
         4. Stores the config in self.build_system_config (polymorphic)
         """
         try:
+            # A monorepo keeps its build config next to the sources it governs, so anchor
+            # detection on the main contract rather than on the run root.
+            run_root = Path.cwd()
+            if self.main_contract_handle is not None:
+                self.build_config_dir = find_build_config_dir(
+                    Path(self.main_contract_handle.source_file), run_root
+                )
+                nested = describe_build_config_dir(self.build_config_dir, run_root)
+                if nested:
+                    self.log(
+                        f"Build config for {self.main_contract_handle.contract_name} lives in {nested}/"
+                    )
+
             # Auto-detect or use explicit build system from init parameter
-            detected = BuildSystemDetector.resolve(Path.cwd(), self.config.requested_build_system)
+            detected = BuildSystemDetector.resolve(self.build_config_dir, self.config.requested_build_system)
             if self.config.requested_build_system is None or self.config.requested_build_system == 'auto':
                 self.log(f"Auto-detected build system: {detected.value}")
             else:
@@ -366,12 +384,11 @@ class Autosetup:
                 def is_file_in_scope(self, file_path):
                     return True
 
-            project_root = Path.cwd()
             scope = MinimalScope()
 
             # Get appropriate manager class and create instance
             ManagerClass = BuildSystemDetector.get_manager_class(detected)
-            manager: BuildSystemManager = ManagerClass(project_root, scope)  # type: ignore
+            manager: BuildSystemManager = ManagerClass(self.build_config_dir, scope)  # type: ignore
 
             # Auto-detect and parse config (polymorphic - returns FoundryConfig or HardhatConfig)
             self.log(f"Auto-detecting {detected.value} configuration...")

--- a/certora_autosetup/setup/setup_prover.py
+++ b/certora_autosetup/setup/setup_prover.py
@@ -127,6 +127,9 @@ class SetupProver:
         self.scope = scope
         self.build_system: Optional[BuildSystem] = None
         self.build_system_config: Optional[BuildSystemConfig] = None
+        # Directory holding the contract's build config; assigned by Autosetup alongside
+        # build_system once detection has run.
+        self.build_config_dir: Path = Path.cwd()
 
         # Track compilation configuration updates
         self.compilation_config_updates: Dict[str, Any] = {}
@@ -611,6 +614,7 @@ class SetupProver:
             project_root=Path.cwd(),
             solc_default_version=self.solc_default_version,
             verbose=self.verbose,
+            build_config_dir=self.build_config_dir,
         )
 
         return workaround_manager.run_compilation_with_workarounds(

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -126,8 +126,13 @@ class CompilationWorkaroundManager:
         solc_default_version: str = DEFAULT_SOLC_VERSION,
         verbose: int = 0,
         solc_convention: SolcConvention = SolcConvention.CERTORA,
+        build_config_dir: Optional[Path] = None,
     ):
         self.project_root = project_root
+        # Where foundry.toml / remappings.txt / package.json are read from. Distinct from
+        # project_root, which anchors the conf and generated harnesses at the run root:
+        # in a monorepo the build config lives in the sub-project owning the contract.
+        self.build_config_dir = build_config_dir or project_root
         self.solc_convention = solc_convention
         self.verbose = verbose
         self._remappings_workaround_applied = False
@@ -1477,6 +1482,7 @@ class CompilationWorkaroundManager:
         3. remappings.txt — often partially auto-generated; may drift
         4. package.json — npm-style fallback
         """
-        # The reactive path runs in the project CWD, so base_dir="." emits relative paths
-        # unchanged and runs forge in CWD.
-        return build_packages_from_remapping_sources(base_dir=Path("."), log_fn=self.log)
+        # Read from the directory that owns the build config (the run root unless the
+        # contract lives in a monorepo sub-project); the helper resolves every relative
+        # target absolute against it, so the emitted paths are valid from the run CWD.
+        return build_packages_from_remapping_sources(base_dir=self.build_config_dir, log_fn=self.log)

--- a/certora_autosetup/utils/project_dir.py
+++ b/certora_autosetup/utils/project_dir.py
@@ -1,0 +1,68 @@
+"""Locate the build-system project directory that owns the contract under analysis.
+
+A repository's Foundry/Hardhat project is not always at the repo root: monorepos keep the
+build config next to the sources it governs (``<repo>/<package>/foundry.toml``). Autosetup
+runs with CWD at the repo root, and ``BuildSystemManager.find_config_file`` only walks
+*upward* from there, so a nested project is invisible to it — detection reports ``unknown``,
+the run proceeds "without build config", and the generated conf carries neither the project's
+remappings nor its pinned solc. The symptom is a bare
+``ParserError: Source "@pkg/Foo.sol" not found ... Searched the following locations: ""``.
+
+Anchoring on the main contract's own path fixes this without any new plumbing: the directory
+that owns a contract is the nearest ancestor of that contract holding a build config.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+# Build config filenames that mark a directory as a project root, in no particular order —
+# presence of any one of them is enough to anchor there.
+BUILD_CONFIG_FILENAMES = ("foundry.toml", "hardhat.config.js", "hardhat.config.ts")
+
+
+def find_build_config_dir(contract_path: Path, root: Path) -> Path:
+    """Return the nearest ancestor of *contract_path* holding a build config.
+
+    The search starts at the contract file's own directory and walks up, stopping at (and
+    including) *root*. ``root`` is returned when no ancestor holds a build config, so the
+    caller keeps today's root-anchored behaviour whenever there is nothing better to anchor
+    on — including for a repo whose project genuinely is at the root, where the first
+    directory that matches *is* ``root``.
+
+    Args:
+        contract_path: Path to the main contract source file. May be relative to *root*.
+        root: Directory to stop the upward walk at (the autosetup run root).
+
+    Returns:
+        The owning project directory, or *root* if none was found.
+    """
+    root = root.resolve()
+    absolute_contract = contract_path if contract_path.is_absolute() else root / contract_path
+
+    # A contract outside the run root has no ancestor chain to walk within it.
+    try:
+        absolute_contract.resolve().relative_to(root)
+    except ValueError:
+        return root
+
+    current = absolute_contract.resolve().parent
+    while True:
+        if any((current / name).exists() for name in BUILD_CONFIG_FILENAMES):
+            return current
+        if current == root:
+            return root
+        current = current.parent
+
+
+def describe_build_config_dir(build_config_dir: Path, root: Path) -> Optional[str]:
+    """Return a root-relative description of *build_config_dir*, or None if it is *root*.
+
+    Used purely for logging, so a nested project announces itself and the "unknown build
+    system" case stays distinguishable from "root project with no config".
+    """
+    if build_config_dir.resolve() == root.resolve():
+        return None
+    try:
+        return str(build_config_dir.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(build_config_dir)

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import certora_autosetup.utils.remappings as remappings_mod
 from certora_autosetup.utils.compilation_workarounds import CompilationWorkaroundManager
 from certora_autosetup.utils.types import ContractHandle
 
@@ -692,3 +693,50 @@ def test_compiling_line_takes_precedence_over_source_location(manager: Compilati
     # Pattern 2 wins, mapping to the contract actually being compiled.
     contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
     assert manager._detect_stack_too_deep_errors(COMPILING_LINE_STACK_TOO_DEEP, contracts) == "Foo"
+
+
+# ---------------------------------------------------------------------------
+# Build-config directory for a monorepo sub-project
+# ---------------------------------------------------------------------------
+
+
+def _no_forge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate `forge` not being installed (the CI reality)."""
+
+    def fake_run(*_args, **_kwargs):
+        raise FileNotFoundError("forge")
+
+    monkeypatch.setattr(remappings_mod.subprocess, "run", fake_run)
+
+
+def test_packages_come_from_the_nested_build_config_dir(tmp_path: Path, monkeypatch) -> None:
+    # Regression: the workaround read remapping sources from the run root, so a repo
+    # whose Foundry project sits one level down yielded only the root package.json deps.
+    # It then recomputed the identical list on the retry and gave up with
+    # "conf and command are unchanged".
+    _no_forge(monkeypatch)
+    (tmp_path / "package.json").write_text('{"dependencies": {"ethers": "^6"}}')
+    project = tmp_path / "portal"
+    project.mkdir()
+    (project / "foundry.toml").write_text(
+        '[profile.default]\nremappings = ["@pkg/=node_modules/@pkg/artifacts/src/"]\n'
+    )
+
+    manager = CompilationWorkaroundManager(project_root=tmp_path, build_config_dir=project)
+    packages = manager._build_packages_from_remapping_sources()
+
+    keys = {p.split("=", 1)[0] for p in packages}
+    assert "@pkg/" in keys, "nested foundry.toml remapping must reach the packages list"
+    # Paths are absolute against the build config dir, so they stay valid from the run root.
+    assert f"@pkg/={project / 'node_modules/@pkg/artifacts/src'}/" in packages
+
+
+def test_build_config_dir_defaults_to_project_root(tmp_path: Path, monkeypatch) -> None:
+    # Root-level projects keep today's behaviour without the caller passing anything.
+    _no_forge(monkeypatch)
+    (tmp_path / "foundry.toml").write_text('[profile.default]\nremappings = ["@oz/=lib/oz/"]\n')
+
+    manager = CompilationWorkaroundManager(project_root=tmp_path)
+
+    assert manager.build_config_dir == tmp_path
+    assert f"@oz/={tmp_path / 'lib/oz'}/" in manager._build_packages_from_remapping_sources()

--- a/tests/test_project_dir.py
+++ b/tests/test_project_dir.py
@@ -1,0 +1,112 @@
+"""Tests for locating the build-config directory that owns the contract under analysis.
+
+Regression origin: a monorepo whose Foundry project sat one level down
+(``<pkg>/foundry.toml``) was run from the repo root, where nothing but a root
+``package.json`` existed. Build-system detection reported ``unknown``, the packages list
+was built from that root package.json alone, and solc failed with
+``Source "@pkg/Foo.sol" not found ... Searched the following locations: ""``.
+"""
+
+from pathlib import Path
+
+from certora_autosetup.utils.project_dir import (
+    describe_build_config_dir,
+    find_build_config_dir,
+)
+
+
+def test_finds_nested_foundry_project(tmp_path: Path) -> None:
+    # The shape that broke: build config one level down, only a package.json at the root.
+    (tmp_path / "package.json").write_text('{"dependencies": {"ethers": "^6"}}')
+    project = tmp_path / "portal"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text('[profile.default]\nremappings = ["@pkg/=node_modules/@pkg/"]\n')
+    contract = project / "src" / "Portal.sol"
+    contract.write_text("contract Portal {}")
+
+    assert find_build_config_dir(contract, tmp_path) == project.resolve()
+
+
+def test_accepts_a_contract_path_relative_to_root(tmp_path: Path) -> None:
+    # Contract handles carry root-relative paths, which is how autosetup calls this.
+    project = tmp_path / "portal"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text("[profile.default]\n")
+    (project / "src" / "Portal.sol").write_text("contract Portal {}")
+
+    assert find_build_config_dir(Path("portal/src/Portal.sol"), tmp_path) == project.resolve()
+
+
+def test_root_level_project_resolves_to_root(tmp_path: Path) -> None:
+    (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    (tmp_path / "src").mkdir()
+    contract = tmp_path / "src" / "Token.sol"
+    contract.write_text("contract Token {}")
+
+    assert find_build_config_dir(contract, tmp_path) == tmp_path.resolve()
+
+
+def test_no_build_config_anywhere_falls_back_to_root(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    contract = tmp_path / "src" / "Token.sol"
+    contract.write_text("contract Token {}")
+
+    assert find_build_config_dir(contract, tmp_path) == tmp_path.resolve()
+
+
+def test_nearest_ancestor_wins_over_an_outer_one(tmp_path: Path) -> None:
+    # A monorepo may carry a root foundry.toml too; the sub-project's own config governs.
+    (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    project = tmp_path / "packages" / "portal"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text("[profile.default]\n")
+    contract = project / "src" / "Portal.sol"
+    contract.write_text("contract Portal {}")
+
+    assert find_build_config_dir(contract, tmp_path) == project.resolve()
+
+
+def test_hardhat_config_also_anchors(tmp_path: Path) -> None:
+    project = tmp_path / "app"
+    (project / "contracts").mkdir(parents=True)
+    (project / "hardhat.config.ts").write_text("export default {};")
+    contract = project / "contracts" / "Vault.sol"
+    contract.write_text("contract Vault {}")
+
+    assert find_build_config_dir(contract, tmp_path) == project.resolve()
+
+
+def test_walk_stops_at_root(tmp_path: Path) -> None:
+    # A foundry.toml *above* the run root must not be picked up — the run root bounds
+    # what the conf can reference.
+    outer = tmp_path / "outer"
+    root = outer / "repo"
+    (root / "src").mkdir(parents=True)
+    (outer / "foundry.toml").write_text("[profile.default]\n")
+    contract = root / "src" / "Token.sol"
+    contract.write_text("contract Token {}")
+
+    assert find_build_config_dir(contract, root) == root.resolve()
+
+
+def test_contract_outside_root_returns_root(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root).mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "foundry.toml").write_text("[profile.default]\n")
+    contract = elsewhere / "Stray.sol"
+    contract.write_text("contract Stray {}")
+
+    assert find_build_config_dir(contract, root) == root.resolve()
+
+
+def test_describe_returns_none_for_the_root_itself(tmp_path: Path) -> None:
+    assert describe_build_config_dir(tmp_path, tmp_path) is None
+
+
+def test_describe_returns_the_relative_subdir(tmp_path: Path) -> None:
+    project = tmp_path / "packages" / "portal"
+    project.mkdir(parents=True)
+
+    assert describe_build_config_dir(project, tmp_path) == str(Path("packages") / "portal")


### PR DESCRIPTION
## Problem

Autosetup resolved the build system from the process CWD, and
`BuildSystemManager.find_config_file` only walks *upward* from there. A repository whose
Foundry/Hardhat project lives in a subdirectory (`<pkg>/foundry.toml`) is therefore invisible
when the run root is the repo root:

- `BuildSystemDetector` reports `unknown` → *"No build system detected, continuing without build config"*
- the generated conf carries neither the project's remappings nor its pinned solc/evm_version
- solc fails with a bare `ParserError: Source "@pkg/Foo.sol" not found. Searched the following locations: "".`

The reactive `source_not_found_packages` workaround could not rescue it either:
`_build_packages_from_remapping_sources` hardcoded `base_dir=Path(".")`, so it read the same
root that had nothing to offer, recomputed an **identical** packages list, and the retry guard
correctly gave up with *"Workarounds applied but the conf and command are unchanged"*. The run
died with `CompilationAnalysisError` before ever reaching the Prover.

## Fix

Anchor on the contract under analysis instead of on the run root. `find_build_config_dir`
walks up from the main contract's own path to the nearest ancestor holding a `foundry.toml` /
`hardhat.config.{js,ts}`, bounded by the run root, and that directory is used for:

- `BuildSystemDetector.resolve(...)`
- the `BuildSystemManager` instance (so `find_config_file` starts in the right place)
- `base_dir` for remapping sources in the reactive workaround

No new plumbing or arguments are needed — the main contract handle is already set before
`setup_build_system_config()` runs.

### Why this is safe for existing projects

- A root-level project resolves to the run root, so behaviour is unchanged.
- `build_packages_from_remapping_sources` already resolves relative targets **absolute**
  against `base_dir`, so the emitted packages remain valid from the run CWD.
- `CompilationWorkaroundManager.project_root` is untouched and keeps anchoring the conf and
  generated harnesses at the run root; the new `build_config_dir` is a separate concept and
  defaults to `project_root`, so the `fixconf` call site needs no change.

## Tests

- `tests/test_project_dir.py` — nested project, root-relative contract path, root-level
  project, no config anywhere, nearest-ancestor-wins over an outer config, hardhat anchor,
  walk stops at the run root, contract outside the root.
- `tests/test_compilation_workarounds.py` — the reactive workaround now picks up a nested
  `foundry.toml` remapping (the exact case that produced the identical-conf give-up), plus a
  default-to-`project_root` case.

Full suite: 271 passed, 10 pre-existing failures identical on `master` (missing `tabulate` /
`certora_cli` in the test env), and 6 pre-existing collection errors from the same missing
dependency.

## Not covered here

The pipeline knew autosetup had fatally failed but let sibling LLM extraction tasks run to
completion afterwards, burning a further ~17 minutes of model spend on a doomed run. That
fail-fast is a separate change.