### PR TITLE
Anchor build-system detection on the contract, not the run root

### DIFF
--- a/certora_autosetup/autosetup/autosetup.py
+++ b/certora_autosetup/autosetup/autosetup.py
@@ -51,6 +51,7 @@ from certora_autosetup.utils.paths import (
 from certora_autosetup.utils.contract_utils import split_contract_spec
 from certora_autosetup.utils.enhanced_config_manager import ConfigManager, FileContent, ProverJobSpec
 from certora_autosetup.utils.llm_util import get_ledger_rows
+from certora_autosetup.utils.project_dir import describe_build_config_dir, find_build_config_dir
 from certora_autosetup.utils.scope import Scope
 from certora_autosetup.utils.types import ContractHandle, ContractInfo
 
@@ -112,6 +113,9 @@ class Autosetup:
         self.bytes_mappings: List[tuple[ContractHandle, List[str]]] = []
         # Set during run()
         self.main_contract_handle: Optional[ContractHandle] = None
+        # Directory owning the main contract's build config; resolved in
+        # setup_build_system_config(). Equals the run root for a root-level project.
+        self.build_config_dir: Path = Path.cwd()
 
     def log(self, message: str, level: str = "INFO"):
         logger.log(message, level, COMPONENT)
@@ -235,6 +239,7 @@ class Autosetup:
         self.setup_build_system_config()
         self.setup_prover.build_system = self.build_system
         self.setup_prover.build_system_config = self.build_system_config
+        self.setup_prover.build_config_dir = self.build_config_dir
 
         # Check full-pipeline cache before running
         result_path = Path(DIR_CERTORA_INTERNAL) / FILE_AUTOSETUP_RESULT
@@ -346,8 +351,21 @@ class Autosetup:
         4. Stores the config in self.build_system_config (polymorphic)
         """
         try:
+            # A monorepo keeps its build config next to the sources it governs, so anchor
+            # detection on the main contract rather than on the run root.
+            run_root = Path.cwd()
+            if self.main_contract_handle is not None:
+                self.build_config_dir = find_build_config_dir(
+                    Path(self.main_contract_handle.source_file), run_root
+                )
+                nested = describe_build_config_dir(self.build_config_dir, run_root)
+                if nested:
+                    self.log(
+                        f"Build config for {self.main_contract_handle.contract_name} lives in {nested}/"
+                    )
+
             # Auto-detect or use explicit build system from init parameter
-            detected = BuildSystemDetector.resolve(Path.cwd(), self.config.requested_build_system)
+            detected = BuildSystemDetector.resolve(self.build_config_dir, self.config.requested_build_system)
             if self.config.requested_build_system is None or self.config.requested_build_system == 'auto':
                 self.log(f"Auto-detected build system: {detected.value}")
             else:
@@ -366,12 +384,11 @@ class Autosetup:
                 def is_file_in_scope(self, file_path):
                     return True
 
-            project_root = Path.cwd()
             scope = MinimalScope()
 
             # Get appropriate manager class and create instance
             ManagerClass = BuildSystemDetector.get_manager_class(detected)
-            manager: BuildSystemManager = ManagerClass(project_root, scope)  # type: ignore
+            manager: BuildSystemManager = ManagerClass(self.build_config_dir, scope)  # type: ignore
 
             # Auto-detect and parse config (polymorphic - returns FoundryConfig or HardhatConfig)
             self.log(f"Auto-detecting {detected.value} configuration...")

--- a/certora_autosetup/autosetup/cli.py
+++ b/certora_autosetup/autosetup/cli.py
@@ -28,7 +28,8 @@ from certora_autosetup.utils.constants import (
     FILE_LLM_USAGE,
     FILE_PROVER_USAGE,
 )
-from certora_autosetup.utils.contract_utils import auto_detect_contracts, deduplicate_contract_handles, parse_contract_files, resolve_contract_handles
+from certora_autosetup.utils.contract_utils import auto_detect_contracts, deduplicate_contract_handles, parse_contract_files, resolve_contract_handles, split_contract_spec
+from certora_autosetup.utils.project_dir import find_build_config_dir
 from certora_autosetup.utils.enhanced_config_manager import ConfigManager
 from certora_autosetup.utils.llm_util import LlmUsageReport, ledger_reset
 from certora_autosetup.utils.prover_usage_ledger import (
@@ -57,19 +58,26 @@ def main():
     if args.min_loop_iter > args.max_loop_iter:
         parser.error(f"--min-loop-iter ({args.min_loop_iter}) must be <= --max-loop-iter ({args.max_loop_iter})")
 
+    # Scene detection has to look where the build config actually is: in a monorepo that
+    # is the sub-project owning the main contract, not the CWD. Derived from the raw spec
+    # because the main handle is not parsed until further down.
+    cwd = Path.cwd()
+    main_contract_file, _ = split_contract_spec(args.main_contract)
+    build_config_dir = find_build_config_dir(Path(main_contract_file), cwd)
+
     # Parse contract handles
     contract_handles = []
     if args.contract_files_and_name:
         contract_handles = parse_contract_files(args.contract_files_and_name)
         contract_handles = resolve_contract_handles(
-            contract_handles, Path.cwd(), profile=args.profile,
-            requested_build_system=args.build_system,
+            contract_handles, build_config_dir, profile=args.profile,
+            requested_build_system=args.build_system, handles_relative_to=cwd,
         )
 
     if not contract_handles:
         contract_handles = auto_detect_contracts(
-            Path.cwd(), profile=args.profile,
-            requested_build_system=args.build_system,
+            build_config_dir, profile=args.profile,
+            requested_build_system=args.build_system, emit_relative_to=cwd,
         )
 
     contract_handles = deduplicate_contract_handles(contract_handles)

--- a/certora_autosetup/parsers/base.py
+++ b/certora_autosetup/parsers/base.py
@@ -52,9 +52,8 @@ class ContractExtractor(ABC):
     def project_source_files(self) -> Set[str]:
         """Normalized set of project-local Solidity source paths (excludes
         dependencies, tests, scripts, and certora/ directories)."""
-        # Scanned from the project dir, not the CWD: the artifact paths these are
-        # matched against are project-relative, so scanning elsewhere yields two
-        # different spellings of the same file and nothing intersects.
+        # Scanned from the project dir: these are matched against artifact paths, which
+        # the build system records project-relative, so both sides need the same anchor.
         return {
             str(Path(p)) for p in find_all_solidity_files(
                 include_test_files=False,

--- a/certora_autosetup/parsers/base.py
+++ b/certora_autosetup/parsers/base.py
@@ -52,11 +52,15 @@ class ContractExtractor(ABC):
     def project_source_files(self) -> Set[str]:
         """Normalized set of project-local Solidity source paths (excludes
         dependencies, tests, scripts, and certora/ directories)."""
+        # Scanned from the project dir, not the CWD: the artifact paths these are
+        # matched against are project-relative, so scanning elsewhere yields two
+        # different spellings of the same file and nothing intersects.
         return {
             str(Path(p)) for p in find_all_solidity_files(
                 include_test_files=False,
                 include_dependencies=False,
                 verbose=False,
+                root=self.project_root,
             )
         }
 

--- a/certora_autosetup/setup/setup_prover.py
+++ b/certora_autosetup/setup/setup_prover.py
@@ -127,6 +127,9 @@ class SetupProver:
         self.scope = scope
         self.build_system: Optional[BuildSystem] = None
         self.build_system_config: Optional[BuildSystemConfig] = None
+        # Directory holding the contract's build config; assigned by Autosetup alongside
+        # build_system once detection has run.
+        self.build_config_dir: Path = Path.cwd()
 
         # Track compilation configuration updates
         self.compilation_config_updates: Dict[str, Any] = {}
@@ -611,6 +614,7 @@ class SetupProver:
             project_root=Path.cwd(),
             solc_default_version=self.solc_default_version,
             verbose=self.verbose,
+            build_config_dir=self.build_config_dir,
         )
 
         return workaround_manager.run_compilation_with_workarounds(

--- a/certora_autosetup/setup/solidity_utils.py
+++ b/certora_autosetup/setup/solidity_utils.py
@@ -63,9 +63,8 @@ def find_all_solidity_files(
         verbose: Whether to log verbose output
         log_func: Optional logging function to use (defaults to print)
         root: Directory to scan, and the anchor the returned paths are relative to.
-            Defaults to the CWD. Pass the build system's project dir when it differs,
-            so the paths line up with the project-relative ones the build artifacts
-            record — otherwise nothing matches and the project looks contract-less.
+            Defaults to the CWD. Pass the build system's project dir to get paths in
+            the same frame as the project-relative ones recorded in build artifacts.
 
     Returns:
         List of Solidity file paths

--- a/certora_autosetup/setup/solidity_utils.py
+++ b/certora_autosetup/setup/solidity_utils.py
@@ -51,7 +51,8 @@ def find_all_solidity_files(
     include_dependencies: bool = False,
     include_certora: bool = False,
     verbose: bool = False,
-    log_func=None
+    log_func=None,
+    root: Optional[Path] = None,
 ) -> List[str]:
     """Find all Solidity files in the current project.
 
@@ -61,6 +62,10 @@ def find_all_solidity_files(
         include_certora: Whether to include files in certora directories
         verbose: Whether to log verbose output
         log_func: Optional logging function to use (defaults to print)
+        root: Directory to scan, and the anchor the returned paths are relative to.
+            Defaults to the CWD. Pass the build system's project dir when it differs,
+            so the paths line up with the project-relative ones the build artifacts
+            record — otherwise nothing matches and the project looks contract-less.
 
     Returns:
         List of Solidity file paths
@@ -69,12 +74,14 @@ def find_all_solidity_files(
         log_func = lambda msg, level="INFO": _logger.log(msg, level)
 
     solidity_files = []
+    if root is None:
+        root = Path.cwd()
 
     # Common directories to search for Solidity files
     search_dirs = [
-        Path.cwd(),
-        Path.cwd() / "contracts",
-        Path.cwd() / "src"
+        root,
+        root / "contracts",
+        root / "src"
     ]
 
     # Find all .sol files, excluding system directories from traversal
@@ -83,17 +90,17 @@ def find_all_solidity_files(
             all_sol_files = []
 
             # Walk through directory and exclude hidden directories from traversal
-            for root, dirs, files in os.walk(search_dir):
+            for walk_root, dirs, files in os.walk(search_dir):
                 # Remove hidden directories and certora dir from dirs list to prevent os.walk from entering them
                 dirs[:] = [d for d in dirs if not d.startswith('.') and (include_certora or d != 'certora')]
 
                 # Add .sol files from this directory
                 for file in files:
                     if file.endswith('.sol'):
-                        # Store relative path from current working directory
-                        abs_path = Path(root) / file
+                        # Store path relative to the scanned root
+                        abs_path = Path(walk_root) / file
                         try:
-                            rel_path = abs_path.relative_to(Path.cwd())
+                            rel_path = abs_path.relative_to(root)
                             all_sol_files.append(rel_path)
                         except ValueError:
                             # If file is outside cwd, store absolute path

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -126,8 +126,13 @@ class CompilationWorkaroundManager:
         solc_default_version: str = DEFAULT_SOLC_VERSION,
         verbose: int = 0,
         solc_convention: SolcConvention = SolcConvention.CERTORA,
+        build_config_dir: Optional[Path] = None,
     ):
         self.project_root = project_root
+        # Where foundry.toml / remappings.txt / package.json are read from. Distinct from
+        # project_root, which anchors the conf and generated harnesses at the run root:
+        # in a monorepo the build config lives in the sub-project owning the contract.
+        self.build_config_dir = build_config_dir or project_root
         self.solc_convention = solc_convention
         self.verbose = verbose
         self._remappings_workaround_applied = False
@@ -1477,6 +1482,7 @@ class CompilationWorkaroundManager:
         3. remappings.txt — often partially auto-generated; may drift
         4. package.json — npm-style fallback
         """
-        # The reactive path runs in the project CWD, so base_dir="." emits relative paths
-        # unchanged and runs forge in CWD.
-        return build_packages_from_remapping_sources(base_dir=Path("."), log_fn=self.log)
+        # Read from the directory that owns the build config (the run root unless the
+        # contract lives in a monorepo sub-project); the helper resolves every relative
+        # target absolute against it, so the emitted paths are valid from the run CWD.
+        return build_packages_from_remapping_sources(base_dir=self.build_config_dir, log_fn=self.log)

--- a/certora_autosetup/utils/contract_utils.py
+++ b/certora_autosetup/utils/contract_utils.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 
 from certora_autosetup.parsers.build_system_detector import BuildSystem, BuildSystemDetector
 from certora_autosetup.utils.logger import logger
+from certora_autosetup.utils.project_dir import rebase
 from certora_autosetup.utils.types import ContractHandle
 from certora_autosetup.parsers.foundry import FoundryContractExtractor
 
@@ -91,8 +92,15 @@ def auto_detect_contracts(
     project_root: Path,
     profile: str | None = None,
     requested_build_system: str | None = None,
+    emit_relative_to: Path | None = None,
 ) -> list[ContractHandle]:
-    """Auto-detect all project contracts via the build system (Foundry/Hardhat)."""
+    """Auto-detect all project contracts via the build system (Foundry/Hardhat).
+
+    Handles come back with source paths relative to *project_root*, because that is how
+    the build system records them. Pass ``emit_relative_to`` when the process CWD is not
+    *project_root* — a monorepo whose build config sits below the repo root — so the
+    returned paths remain usable from the CWD.
+    """
     build_system = BuildSystemDetector.resolve(project_root, requested_build_system)
     if build_system == BuildSystem.UNKNOWN:
         raise ValueError(
@@ -100,7 +108,17 @@ def auto_detect_contracts(
         )
 
     contract_extractor = BuildSystemDetector.get_contract_extractor(build_system, project_root, profile=profile)
-    return contract_extractor.extract_logic_contracts_and_files()
+    handles = contract_extractor.extract_logic_contracts_and_files()
+
+    if emit_relative_to is None or emit_relative_to.resolve() == project_root.resolve():
+        return handles
+    return [
+        ContractHandle(
+            contract_name=h.contract_name,
+            source_file=rebase(h.source_file, project_root, emit_relative_to),
+        )
+        for h in handles
+    ]
 
 
 def deduplicate_contract_handles(handles: list[ContractHandle]) -> list[ContractHandle]:
@@ -132,6 +150,7 @@ def resolve_contract_handles(
     project_root: Path,
     profile: str | None = None,
     requested_build_system: str | None = None,
+    handles_relative_to: Path | None = None,
 ) -> list[ContractHandle]:
     """Resolve inferred contract names using Foundry build artifact compilationTargets.
 
@@ -139,6 +158,10 @@ def resolve_contract_handles(
     the contract name from the filename stem. This can be wrong when the file contains
     a contract with a different name. This function fixes those inferred names by
     looking up the actual contract name from the build artifacts.
+
+    ``handles_relative_to`` names the directory the incoming handles' paths are relative
+    to, when that is not *project_root*. Only the artifact lookup is re-based; the
+    returned handles keep their original paths, since those are what the caller uses.
     """
     build_system = BuildSystemDetector.resolve(project_root, requested_build_system)
     if build_system != BuildSystem.FOUNDRY:
@@ -161,8 +184,12 @@ def resolve_contract_handles(
             resolved.append(handle)
             continue
 
-        # Normalize and look up source path
-        normalized = str(Path(handle.source_file))
+        # Normalize and look up source path. The map is keyed relative to project_root,
+        # so a handle expressed against a different dir has to be re-based to match.
+        lookup = handle.source_file
+        if handles_relative_to is not None and handles_relative_to.resolve() != project_root.resolve():
+            lookup = rebase(lookup, handles_relative_to, project_root)
+        normalized = str(Path(lookup))
         entries_in_file: list[tuple] | None = None
         for src_path, entries in source_map.items():
             if str(Path(src_path)) == normalized:

--- a/certora_autosetup/utils/project_dir.py
+++ b/certora_autosetup/utils/project_dir.py
@@ -12,6 +12,7 @@ Anchoring on the main contract's own path fixes this without any new plumbing: t
 that owns a contract is the nearest ancestor of that contract holding a build config.
 """
 
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -52,6 +53,22 @@ def find_build_config_dir(contract_path: Path, root: Path) -> Path:
         if current == root:
             return root
         current = current.parent
+
+
+def rebase(rel_path: str, from_dir: Path, to_dir: Path) -> str:
+    """Reinterpret *rel_path* — given relative to *from_dir* — as relative to *to_dir*.
+
+    Pure path arithmetic; nothing is required to exist on disk. Absolute inputs are
+    returned unchanged, since they need no anchor.
+
+    Build systems record source paths relative to their own project dir (Foundry's
+    ``compilationTarget``, for one), so a nested project hands back ``src/Foo.sol``
+    while the process CWD is the repo root and needs ``pkg/portal/src/Foo.sol``.
+    """
+    if Path(rel_path).is_absolute():
+        return rel_path
+    absolute = (from_dir / rel_path).resolve()
+    return os.path.relpath(absolute, to_dir.resolve())
 
 
 def describe_build_config_dir(build_config_dir: Path, root: Path) -> Optional[str]:

--- a/certora_autosetup/utils/project_dir.py
+++ b/certora_autosetup/utils/project_dir.py
@@ -1,18 +1,18 @@
 """Locate the build-system project directory that owns the contract under analysis.
 
 A repository's Foundry/Hardhat project is not always at the repo root: monorepos keep the
-build config next to the sources it governs (``<repo>/<package>/foundry.toml``). Autosetup
-runs with CWD at the repo root, and ``BuildSystemManager.find_config_file`` only walks
-*upward* from there, so a nested project is invisible to it — detection reports ``unknown``,
-the run proceeds "without build config", and the generated conf carries neither the project's
-remappings nor its pinned solc. The symptom is a bare
-``ParserError: Source "@pkg/Foo.sol" not found ... Searched the following locations: ""``.
+build config next to the sources it governs (``<repo>/<package>/foundry.toml``), and
+autosetup may be invoked from anywhere above it. These helpers resolve the directory that
+owns a contract — the remappings, pinned solc and artifact layout all come from there.
 
-Anchoring on the main contract's own path fixes this without any new plumbing: the directory
-that owns a contract is the nearest ancestor of that contract holding a build config.
+"Owns" is decided by build *artifacts*, not by the presence of a config file. Plenty of
+monorepos vendor a per-package ``foundry.toml`` under ``modules/`` or ``lib/`` while the
+root config is what actually builds the tree, so the nearest config is often not the one
+that ran. See ``find_build_config_dir``.
 """
 
 import os
+import tomllib
 from pathlib import Path
 from typing import Optional
 
@@ -21,21 +21,51 @@ from typing import Optional
 BUILD_CONFIG_FILENAMES = ("foundry.toml", "hardhat.config.js", "hardhat.config.ts")
 
 
-def find_build_config_dir(contract_path: Path, root: Path) -> Path:
-    """Return the nearest ancestor of *contract_path* holding a build config.
+def _artifact_dir_of(config_dir: Path) -> Optional[Path]:
+    """Where *config_dir*'s build system would put artifacts, or None if it holds no config.
 
-    The search starts at the contract file's own directory and walks up, stopping at (and
-    including) *root*. ``root`` is returned when no ancestor holds a build config, so the
-    caller keeps today's root-anchored behaviour whenever there is nothing better to anchor
-    on — including for a repo whose project genuinely is at the root, where the first
-    directory that matches *is* ``root``.
+    Foundry's ``out`` is configurable, so read it when present; Hardhat's ``artifacts`` is
+    taken as the default. The directory is not required to exist — the caller tests that.
+    """
+    foundry_toml = config_dir / "foundry.toml"
+    if foundry_toml.exists():
+        out = "out"
+        try:
+            with foundry_toml.open("rb") as f:
+                data = tomllib.load(f)
+            profiles = data.get("profile", {})
+            out = profiles.get("default", {}).get("out") or data.get("out") or "out"
+        except (tomllib.TOMLDecodeError, OSError):
+            pass
+        return config_dir / out
+    if (config_dir / "hardhat.config.js").exists() or (config_dir / "hardhat.config.ts").exists():
+        return config_dir / "artifacts"
+    return None
+
+
+def find_build_config_dir(contract_path: Path, root: Path) -> Path:
+    """Return the directory whose build system actually produced *contract_path*'s artifacts.
+
+    Walks up from the contract's own directory to *root*, and returns the nearest ancestor
+    that both holds a build config **and** has its artifact directory on disk. Falling back
+    to *root* when nothing qualifies is deliberate: a build config alone does not mean that
+    project is the one that got built. Monorepos routinely vendor per-package ``foundry.toml``
+    files under ``modules/`` or ``lib/`` while the root config builds the whole tree into a
+    single ``out/`` — anchoring on the nearest config there would point the extractor at an
+    artifact directory that does not exist. Requiring artifacts means this only ever moves
+    off *root* on positive evidence, so every project that worked before still resolves to
+    *root* exactly as it did.
+
+    Consequence worth knowing: this must run *after* the build. Called on an unbuilt tree
+    nothing has artifacts, so it answers *root* — correct for the common case, and for a
+    nested project it merely restores the old behaviour rather than inventing a wrong one.
 
     Args:
         contract_path: Path to the main contract source file. May be relative to *root*.
         root: Directory to stop the upward walk at (the autosetup run root).
 
     Returns:
-        The owning project directory, or *root* if none was found.
+        The owning project directory, or *root* if none qualified.
     """
     root = root.resolve()
     absolute_contract = contract_path if contract_path.is_absolute() else root / contract_path
@@ -48,7 +78,8 @@ def find_build_config_dir(contract_path: Path, root: Path) -> Path:
 
     current = absolute_contract.resolve().parent
     while True:
-        if any((current / name).exists() for name in BUILD_CONFIG_FILENAMES):
+        artifacts = _artifact_dir_of(current)
+        if artifacts is not None and artifacts.is_dir():
             return current
         if current == root:
             return root
@@ -74,8 +105,8 @@ def rebase(rel_path: str, from_dir: Path, to_dir: Path) -> str:
 def describe_build_config_dir(build_config_dir: Path, root: Path) -> Optional[str]:
     """Return a root-relative description of *build_config_dir*, or None if it is *root*.
 
-    Used purely for logging, so a nested project announces itself and the "unknown build
-    system" case stays distinguishable from "root project with no config".
+    For logging: None means "nothing worth saying", so callers can mention the project
+    directory only when it is somewhere other than where the run started.
     """
     if build_config_dir.resolve() == root.resolve():
         return None

--- a/certora_autosetup/utils/project_dir.py
+++ b/certora_autosetup/utils/project_dir.py
@@ -1,0 +1,68 @@
+"""Locate the build-system project directory that owns the contract under analysis.
+
+A repository's Foundry/Hardhat project is not always at the repo root: monorepos keep the
+build config next to the sources it governs (``<repo>/<package>/foundry.toml``). Autosetup
+runs with CWD at the repo root, and ``BuildSystemManager.find_config_file`` only walks
+*upward* from there, so a nested project is invisible to it — detection reports ``unknown``,
+the run proceeds "without build config", and the generated conf carries neither the project's
+remappings nor its pinned solc. The symptom is a bare
+``ParserError: Source "@pkg/Foo.sol" not found ... Searched the following locations: ""``.
+
+Anchoring on the main contract's own path fixes this without any new plumbing: the directory
+that owns a contract is the nearest ancestor of that contract holding a build config.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+# Build config filenames that mark a directory as a project root, in no particular order —
+# presence of any one of them is enough to anchor there.
+BUILD_CONFIG_FILENAMES = ("foundry.toml", "hardhat.config.js", "hardhat.config.ts")
+
+
+def find_build_config_dir(contract_path: Path, root: Path) -> Path:
+    """Return the nearest ancestor of *contract_path* holding a build config.
+
+    The search starts at the contract file's own directory and walks up, stopping at (and
+    including) *root*. ``root`` is returned when no ancestor holds a build config, so the
+    caller keeps today's root-anchored behaviour whenever there is nothing better to anchor
+    on — including for a repo whose project genuinely is at the root, where the first
+    directory that matches *is* ``root``.
+
+    Args:
+        contract_path: Path to the main contract source file. May be relative to *root*.
+        root: Directory to stop the upward walk at (the autosetup run root).
+
+    Returns:
+        The owning project directory, or *root* if none was found.
+    """
+    root = root.resolve()
+    absolute_contract = contract_path if contract_path.is_absolute() else root / contract_path
+
+    # A contract outside the run root has no ancestor chain to walk within it.
+    try:
+        absolute_contract.resolve().relative_to(root)
+    except ValueError:
+        return root
+
+    current = absolute_contract.resolve().parent
+    while True:
+        if any((current / name).exists() for name in BUILD_CONFIG_FILENAMES):
+            return current
+        if current == root:
+            return root
+        current = current.parent
+
+
+def describe_build_config_dir(build_config_dir: Path, root: Path) -> Optional[str]:
+    """Return a root-relative description of *build_config_dir*, or None if it is *root*.
+
+    Used purely for logging, so a nested project announces itself and the "unknown build
+    system" case stays distinguishable from "root project with no config".
+    """
+    if build_config_dir.resolve() == root.resolve():
+        return None
+    try:
+        return str(build_config_dir.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(build_config_dir)

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -716,7 +716,7 @@ def test_packages_come_from_the_nested_build_config_dir(tmp_path: Path, monkeypa
     # "conf and command are unchanged".
     _no_forge(monkeypatch)
     (tmp_path / "package.json").write_text('{"dependencies": {"ethers": "^6"}}')
-    project = tmp_path / "portal"
+    project = tmp_path / "sub"
     project.mkdir()
     (project / "foundry.toml").write_text(
         '[profile.default]\nremappings = ["@pkg/=node_modules/@pkg/artifacts/src/"]\n'

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import certora_autosetup.utils.remappings as remappings_mod
 from certora_autosetup.utils.compilation_workarounds import CompilationWorkaroundManager
 from certora_autosetup.utils.types import ContractHandle
 
@@ -692,3 +693,50 @@ def test_compiling_line_takes_precedence_over_source_location(manager: Compilati
     # Pattern 2 wins, mapping to the contract actually being compiled.
     contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
     assert manager._detect_stack_too_deep_errors(COMPILING_LINE_STACK_TOO_DEEP, contracts) == "Foo"
+
+
+# ---------------------------------------------------------------------------
+# Build-config directory for a monorepo sub-project
+# ---------------------------------------------------------------------------
+
+
+def _no_forge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate `forge` not being installed (the CI reality)."""
+
+    def fake_run(*_args, **_kwargs):
+        raise FileNotFoundError("forge")
+
+    monkeypatch.setattr(remappings_mod.subprocess, "run", fake_run)
+
+
+def test_packages_come_from_the_nested_build_config_dir(tmp_path: Path, monkeypatch) -> None:
+    # Regression: the workaround read remapping sources from the run root, so a repo
+    # whose Foundry project sits one level down yielded only the root package.json deps.
+    # It then recomputed the identical list on the retry and gave up with
+    # "conf and command are unchanged".
+    _no_forge(monkeypatch)
+    (tmp_path / "package.json").write_text('{"dependencies": {"ethers": "^6"}}')
+    project = tmp_path / "portal"
+    project.mkdir()
+    (project / "foundry.toml").write_text(
+        '[profile.default]\nremappings = ["@pkg/=node_modules/@pkg/artifacts/src/"]\n'
+    )
+
+    manager = CompilationWorkaroundManager(project_root=tmp_path, build_config_dir=project)
+    packages = manager._build_packages_from_remapping_sources()
+
+    keys = {p.split("=", 1)[0] for p in packages}
+    assert "@pkg/" in keys, "nested foundry.toml remapping must reach the packages list"
+    # Paths are absolute against the build config dir, so they stay valid from the run root.
+    assert f"@pkg/={project / 'node_modules/@pkg/artifacts/src'}/" in packages
+
+
+def test_build_config_dir_defaults_to_project_root(tmp_path: Path, monkeypatch) -> None:
+    # Root-level projects keep today's behaviour without the caller passing anything.
+    _no_forge(monkeypatch)
+    (tmp_path / "foundry.toml").write_text('[profile.default]\nremappings = ["@oz/=lib/oz/"]\n')
+
+    manager = CompilationWorkaroundManager(project_root=tmp_path)
+
+    assert manager.build_config_dir == tmp_path
+    assert f"@oz/={tmp_path / 'lib/oz'}/" in manager._build_packages_from_remapping_sources()

--- a/tests/test_contract_utils_nested_project.py
+++ b/tests/test_contract_utils_nested_project.py
@@ -1,17 +1,8 @@
-"""Scene detection must anchor on the contract, not on the process CWD.
+"""Scene detection anchors on the contract, not on the process CWD.
 
-Regression origin: running autosetup from the root of a repo whose Foundry project sits
-one directory down died before the pipeline even started —
-
-    File "certora_autosetup/autosetup/cli.py", line 70, in main
-      contract_handles = auto_detect_contracts(
-    File "certora_autosetup/utils/contract_utils.py", line 98
-    ValueError: No build system detected (Foundry or Hardhat).
-                Expected foundry.toml or hardhat.config.{js,ts}
-
-This is a second, earlier detection site than the one in ``Autosetup.setup_build_system_config``:
-it populates the scene, so it runs before ``Autosetup.run()`` is ever entered. Which of the two
-fires depends on how autosetup is invoked — passing an explicit contract list skips this one.
+``cli.main`` resolves the scene before the pipeline starts, so these cover a repo whose
+Foundry project sits below the directory autosetup was invoked from: detection has to find
+that project, and the handles it returns have to come back in the caller's frame.
 """
 
 from pathlib import Path

--- a/tests/test_contract_utils_nested_project.py
+++ b/tests/test_contract_utils_nested_project.py
@@ -1,0 +1,94 @@
+"""Scene detection must anchor on the contract, not on the process CWD.
+
+Regression origin: running autosetup from the root of a repo whose Foundry project sits
+one directory down died before the pipeline even started —
+
+    File "certora_autosetup/autosetup/cli.py", line 70, in main
+      contract_handles = auto_detect_contracts(
+    File "certora_autosetup/utils/contract_utils.py", line 98
+    ValueError: No build system detected (Foundry or Hardhat).
+                Expected foundry.toml or hardhat.config.{js,ts}
+
+This is a second, earlier detection site than the one in ``Autosetup.setup_build_system_config``:
+it populates the scene, so it runs before ``Autosetup.run()`` is ever entered. Which of the two
+fires depends on how autosetup is invoked — passing an explicit contract list skips this one.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import certora_autosetup.utils.contract_utils as cu
+from certora_autosetup.utils.contract_utils import auto_detect_contracts, resolve_contract_handles
+from certora_autosetup.utils.types import ContractHandle
+
+
+@pytest.fixture
+def nested_project(tmp_path: Path) -> Path:
+    """Repo root holding no build config at all; the Foundry project is one level down."""
+    (tmp_path / "package.json").write_text('{"dependencies": {"ethers": "^6"}}')
+    project = tmp_path / "sub"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text("[profile.default]\n")
+    (project / "src" / "Widget.sol").write_text("contract Widget {}")
+    return tmp_path
+
+
+def _stub_extractor(monkeypatch, handles):
+    """Stand in for the build system, which would need a real forge build otherwise."""
+
+    class _Extractor:
+        def extract_logic_contracts_and_files(self):
+            return handles
+
+    monkeypatch.setattr(
+        cu.BuildSystemDetector, "get_contract_extractor", lambda *a, **k: _Extractor()
+    )
+
+
+def test_auto_detect_from_repo_root_finds_the_nested_project(nested_project, monkeypatch) -> None:
+    # The exact regression: anchored at the root this raised ValueError.
+    _stub_extractor(monkeypatch, [ContractHandle("Widget", "src/Widget.sol")])
+
+    handles = auto_detect_contracts(
+        nested_project / "sub", emit_relative_to=nested_project
+    )
+
+    # Paths must come back usable from the CWD, not from the nested project dir.
+    assert [h.source_file for h in handles] == [str(Path("sub/src/Widget.sol"))]
+
+
+def test_auto_detect_leaves_paths_alone_for_a_root_project(tmp_path, monkeypatch) -> None:
+    (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    _stub_extractor(monkeypatch, [ContractHandle("Widget", "src/Widget.sol")])
+
+    handles = auto_detect_contracts(tmp_path, emit_relative_to=tmp_path)
+
+    assert [h.source_file for h in handles] == ["src/Widget.sol"]
+
+
+def test_auto_detect_still_raises_when_there_is_no_build_config_anywhere(tmp_path) -> None:
+    (tmp_path / "src").mkdir()
+    with pytest.raises(ValueError, match="No build system detected"):
+        auto_detect_contracts(tmp_path, emit_relative_to=tmp_path)
+
+
+def test_resolve_rebases_the_artifact_lookup(nested_project, monkeypatch) -> None:
+    # The artifact map is keyed relative to the project dir ("src/Widget.sol"), while the
+    # incoming handle is relative to the CWD ("sub/src/Widget.sol"). Without re-basing the
+    # lookup misses and the inferred name is silently left wrong.
+    class _Extractor:
+        def build_source_path_to_contracts_map(self):
+            return {"src/Widget.sol": [("TheRealName", "0.8.27")]}
+
+    monkeypatch.setattr(cu, "FoundryContractExtractor", lambda *a, **k: _Extractor())
+
+    resolved = resolve_contract_handles(
+        [ContractHandle("Widget", "sub/src/Widget.sol")],
+        nested_project / "sub",
+        handles_relative_to=nested_project,
+    )
+
+    assert resolved[0].contract_name == "TheRealName"
+    # The returned path stays in the caller's frame of reference.
+    assert resolved[0].source_file == "sub/src/Widget.sol"

--- a/tests/test_project_dir.py
+++ b/tests/test_project_dir.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from certora_autosetup.utils.project_dir import (
     describe_build_config_dir,
     find_build_config_dir,
+    rebase,
 )
 
 
@@ -110,3 +111,35 @@ def test_describe_returns_the_relative_subdir(tmp_path: Path) -> None:
     project.mkdir(parents=True)
 
     assert describe_build_config_dir(project, tmp_path) == str(Path("packages") / "sub")
+
+
+# ---------------------------------------------------------------------------
+# rebase — reinterpreting a build-system-relative path against the run CWD
+# ---------------------------------------------------------------------------
+
+
+def test_rebase_pushes_a_nested_projects_path_down_to_the_root(tmp_path: Path) -> None:
+    # Foundry records compilationTarget relative to its own project dir, so a nested
+    # project reports "src/Widget.sol" while the CWD is the repo root.
+    assert rebase("src/Widget.sol", tmp_path / "sub", tmp_path) == str(Path("sub/src/Widget.sol"))
+
+
+def test_rebase_is_identity_when_the_dirs_match(tmp_path: Path) -> None:
+    assert rebase("src/Widget.sol", tmp_path, tmp_path) == str(Path("src/Widget.sol"))
+
+
+def test_rebase_leaves_absolute_paths_alone(tmp_path: Path) -> None:
+    absolute = str(tmp_path / "src" / "Widget.sol")
+    assert rebase(absolute, tmp_path / "sub", tmp_path) == absolute
+
+
+def test_rebase_handles_a_deeper_nesting(tmp_path: Path) -> None:
+    assert rebase(
+        "contracts/Vault.sol", tmp_path / "packages" / "app", tmp_path
+    ) == str(Path("packages/app/contracts/Vault.sol"))
+
+
+def test_rebase_can_walk_upward(tmp_path: Path) -> None:
+    # Not produced by find_build_config_dir (it is bounded by the run root), but the
+    # helper is pure path math and should not silently mangle the reverse direction.
+    assert rebase("sub/src/Widget.sol", tmp_path, tmp_path / "sub") == str(Path("src/Widget.sol"))

--- a/tests/test_project_dir.py
+++ b/tests/test_project_dir.py
@@ -1,10 +1,8 @@
 """Tests for locating the build-config directory that owns the contract under analysis.
 
-Regression origin: a monorepo whose Foundry project sat one level down
-(``<pkg>/foundry.toml``) was run from the repo root, where nothing but a root
-``package.json`` existed. Build-system detection reported ``unknown``, the packages list
-was built from that root package.json alone, and solc failed with
-``Source "@pkg/Foo.sol" not found ... Searched the following locations: ""``.
+The interesting layout is a monorepo run from the repo root: the Foundry project sits at
+``<pkg>/foundry.toml`` and the root holds only a ``package.json``, so the owning directory
+has to be found by walking up from the contract rather than by looking where the run began.
 """
 
 from pathlib import Path
@@ -17,11 +15,12 @@ from certora_autosetup.utils.project_dir import (
 
 
 def test_finds_nested_foundry_project(tmp_path: Path) -> None:
-    # The shape that broke: build config one level down, only a package.json at the root.
+    # Build config one level down, only a package.json at the root.
     (tmp_path / "package.json").write_text('{"dependencies": {"ethers": "^6"}}')
     project = tmp_path / "sub"
     (project / "src").mkdir(parents=True)
     (project / "foundry.toml").write_text('[profile.default]\nremappings = ["@pkg/=node_modules/@pkg/"]\n')
+    (project / "out").mkdir()
     contract = project / "src" / "Widget.sol"
     contract.write_text("contract Widget {}")
 
@@ -32,6 +31,7 @@ def test_accepts_a_contract_path_relative_to_root(tmp_path: Path) -> None:
     # Contract handles carry root-relative paths, which is how autosetup calls this.
     project = tmp_path / "sub"
     (project / "src").mkdir(parents=True)
+    (project / "out").mkdir()
     (project / "foundry.toml").write_text("[profile.default]\n")
     (project / "src" / "Widget.sol").write_text("contract Widget {}")
 
@@ -40,6 +40,7 @@ def test_accepts_a_contract_path_relative_to_root(tmp_path: Path) -> None:
 
 def test_root_level_project_resolves_to_root(tmp_path: Path) -> None:
     (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    (tmp_path / "out").mkdir()
     (tmp_path / "src").mkdir()
     contract = tmp_path / "src" / "Token.sol"
     contract.write_text("contract Token {}")
@@ -55,12 +56,52 @@ def test_no_build_config_anywhere_falls_back_to_root(tmp_path: Path) -> None:
     assert find_build_config_dir(contract, tmp_path) == tmp_path.resolve()
 
 
-def test_nearest_ancestor_wins_over_an_outer_one(tmp_path: Path) -> None:
-    # A monorepo may carry a root foundry.toml too; the sub-project's own config governs.
+def test_nearest_built_ancestor_wins_over_an_outer_one(tmp_path: Path) -> None:
+    # Both carry a config, both were built: the sub-project's own config governs.
     (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    (tmp_path / "out").mkdir()
     project = tmp_path / "packages" / "sub"
     (project / "src").mkdir(parents=True)
+    (project / "out").mkdir()
     (project / "foundry.toml").write_text("[profile.default]\n")
+    contract = project / "src" / "Widget.sol"
+    contract.write_text("contract Widget {}")
+
+    assert find_build_config_dir(contract, tmp_path) == project.resolve()
+
+
+def test_unbuilt_inner_config_yields_to_the_built_root(tmp_path: Path) -> None:
+    # The Maple shape, and the regression this rule exists to prevent: a vendored
+    # per-package foundry.toml under modules/ that the root build never writes into.
+    # Anchoring there points the extractor at a modules/pool/out that does not exist.
+    (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    (tmp_path / "out").mkdir()
+    project = tmp_path / "modules" / "pool"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text("[profile.default]\n")
+    contract = project / "src" / "Widget.sol"
+    contract.write_text("contract Widget {}")
+
+    assert find_build_config_dir(contract, tmp_path) == tmp_path.resolve()
+
+
+def test_no_artifacts_anywhere_falls_back_to_root(tmp_path: Path) -> None:
+    # Nothing was built, so there is no evidence for any nested project: stay at root,
+    # which is exactly where the pre-existing behaviour anchored.
+    project = tmp_path / "lib" / "dependency"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text("[profile.default]\n")
+    contract = project / "src" / "Widget.sol"
+    contract.write_text("contract Widget {}")
+
+    assert find_build_config_dir(contract, tmp_path) == tmp_path.resolve()
+
+
+def test_honors_a_custom_foundry_out_dir(tmp_path: Path) -> None:
+    project = tmp_path / "sub"
+    (project / "src").mkdir(parents=True)
+    (project / "artefacts").mkdir()
+    (project / "foundry.toml").write_text('[profile.default]\nout = "artefacts"\n')
     contract = project / "src" / "Widget.sol"
     contract.write_text("contract Widget {}")
 
@@ -70,6 +111,7 @@ def test_nearest_ancestor_wins_over_an_outer_one(tmp_path: Path) -> None:
 def test_hardhat_config_also_anchors(tmp_path: Path) -> None:
     project = tmp_path / "app"
     (project / "contracts").mkdir(parents=True)
+    (project / "artifacts").mkdir()
     (project / "hardhat.config.ts").write_text("export default {};")
     contract = project / "contracts" / "Vault.sol"
     contract.write_text("contract Vault {}")
@@ -84,6 +126,7 @@ def test_walk_stops_at_root(tmp_path: Path) -> None:
     root = outer / "repo"
     (root / "src").mkdir(parents=True)
     (outer / "foundry.toml").write_text("[profile.default]\n")
+    (outer / "out").mkdir()
     contract = root / "src" / "Token.sol"
     contract.write_text("contract Token {}")
 
@@ -96,6 +139,7 @@ def test_contract_outside_root_returns_root(tmp_path: Path) -> None:
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
     (elsewhere / "foundry.toml").write_text("[profile.default]\n")
+    (elsewhere / "out").mkdir()
     contract = elsewhere / "Stray.sol"
     contract.write_text("contract Stray {}")
 

--- a/tests/test_project_dir.py
+++ b/tests/test_project_dir.py
@@ -1,0 +1,112 @@
+"""Tests for locating the build-config directory that owns the contract under analysis.
+
+Regression origin: a monorepo whose Foundry project sat one level down
+(``<pkg>/foundry.toml``) was run from the repo root, where nothing but a root
+``package.json`` existed. Build-system detection reported ``unknown``, the packages list
+was built from that root package.json alone, and solc failed with
+``Source "@pkg/Foo.sol" not found ... Searched the following locations: ""``.
+"""
+
+from pathlib import Path
+
+from certora_autosetup.utils.project_dir import (
+    describe_build_config_dir,
+    find_build_config_dir,
+)
+
+
+def test_finds_nested_foundry_project(tmp_path: Path) -> None:
+    # The shape that broke: build config one level down, only a package.json at the root.
+    (tmp_path / "package.json").write_text('{"dependencies": {"ethers": "^6"}}')
+    project = tmp_path / "portal"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text('[profile.default]\nremappings = ["@pkg/=node_modules/@pkg/"]\n')
+    contract = project / "src" / "Portal.sol"
+    contract.write_text("contract Portal {}")
+
+    assert find_build_config_dir(contract, tmp_path) == project.resolve()
+
+
+def test_accepts_a_contract_path_relative_to_root(tmp_path: Path) -> None:
+    # Contract handles carry root-relative paths, which is how autosetup calls this.
+    project = tmp_path / "portal"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text("[profile.default]\n")
+    (project / "src" / "Portal.sol").write_text("contract Portal {}")
+
+    assert find_build_config_dir(Path("portal/src/Portal.sol"), tmp_path) == project.resolve()
+
+
+def test_root_level_project_resolves_to_root(tmp_path: Path) -> None:
+    (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    (tmp_path / "src").mkdir()
+    contract = tmp_path / "src" / "Token.sol"
+    contract.write_text("contract Token {}")
+
+    assert find_build_config_dir(contract, tmp_path) == tmp_path.resolve()
+
+
+def test_no_build_config_anywhere_falls_back_to_root(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    contract = tmp_path / "src" / "Token.sol"
+    contract.write_text("contract Token {}")
+
+    assert find_build_config_dir(contract, tmp_path) == tmp_path.resolve()
+
+
+def test_nearest_ancestor_wins_over_an_outer_one(tmp_path: Path) -> None:
+    # A monorepo may carry a root foundry.toml too; the sub-project's own config governs.
+    (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    project = tmp_path / "packages" / "portal"
+    (project / "src").mkdir(parents=True)
+    (project / "foundry.toml").write_text("[profile.default]\n")
+    contract = project / "src" / "Portal.sol"
+    contract.write_text("contract Portal {}")
+
+    assert find_build_config_dir(contract, tmp_path) == project.resolve()
+
+
+def test_hardhat_config_also_anchors(tmp_path: Path) -> None:
+    project = tmp_path / "app"
+    (project / "contracts").mkdir(parents=True)
+    (project / "hardhat.config.ts").write_text("export default {};")
+    contract = project / "contracts" / "Vault.sol"
+    contract.write_text("contract Vault {}")
+
+    assert find_build_config_dir(contract, tmp_path) == project.resolve()
+
+
+def test_walk_stops_at_root(tmp_path: Path) -> None:
+    # A foundry.toml *above* the run root must not be picked up — the run root bounds
+    # what the conf can reference.
+    outer = tmp_path / "outer"
+    root = outer / "repo"
+    (root / "src").mkdir(parents=True)
+    (outer / "foundry.toml").write_text("[profile.default]\n")
+    contract = root / "src" / "Token.sol"
+    contract.write_text("contract Token {}")
+
+    assert find_build_config_dir(contract, root) == root.resolve()
+
+
+def test_contract_outside_root_returns_root(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root).mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "foundry.toml").write_text("[profile.default]\n")
+    contract = elsewhere / "Stray.sol"
+    contract.write_text("contract Stray {}")
+
+    assert find_build_config_dir(contract, root) == root.resolve()
+
+
+def test_describe_returns_none_for_the_root_itself(tmp_path: Path) -> None:
+    assert describe_build_config_dir(tmp_path, tmp_path) is None
+
+
+def test_describe_returns_the_relative_subdir(tmp_path: Path) -> None:
+    project = tmp_path / "packages" / "portal"
+    project.mkdir(parents=True)
+
+    assert describe_build_config_dir(project, tmp_path) == str(Path("packages") / "portal")

--- a/tests/test_project_dir.py
+++ b/tests/test_project_dir.py
@@ -18,23 +18,23 @@ from certora_autosetup.utils.project_dir import (
 def test_finds_nested_foundry_project(tmp_path: Path) -> None:
     # The shape that broke: build config one level down, only a package.json at the root.
     (tmp_path / "package.json").write_text('{"dependencies": {"ethers": "^6"}}')
-    project = tmp_path / "portal"
+    project = tmp_path / "sub"
     (project / "src").mkdir(parents=True)
     (project / "foundry.toml").write_text('[profile.default]\nremappings = ["@pkg/=node_modules/@pkg/"]\n')
-    contract = project / "src" / "Portal.sol"
-    contract.write_text("contract Portal {}")
+    contract = project / "src" / "Widget.sol"
+    contract.write_text("contract Widget {}")
 
     assert find_build_config_dir(contract, tmp_path) == project.resolve()
 
 
 def test_accepts_a_contract_path_relative_to_root(tmp_path: Path) -> None:
     # Contract handles carry root-relative paths, which is how autosetup calls this.
-    project = tmp_path / "portal"
+    project = tmp_path / "sub"
     (project / "src").mkdir(parents=True)
     (project / "foundry.toml").write_text("[profile.default]\n")
-    (project / "src" / "Portal.sol").write_text("contract Portal {}")
+    (project / "src" / "Widget.sol").write_text("contract Widget {}")
 
-    assert find_build_config_dir(Path("portal/src/Portal.sol"), tmp_path) == project.resolve()
+    assert find_build_config_dir(Path("sub/src/Widget.sol"), tmp_path) == project.resolve()
 
 
 def test_root_level_project_resolves_to_root(tmp_path: Path) -> None:
@@ -57,11 +57,11 @@ def test_no_build_config_anywhere_falls_back_to_root(tmp_path: Path) -> None:
 def test_nearest_ancestor_wins_over_an_outer_one(tmp_path: Path) -> None:
     # A monorepo may carry a root foundry.toml too; the sub-project's own config governs.
     (tmp_path / "foundry.toml").write_text("[profile.default]\n")
-    project = tmp_path / "packages" / "portal"
+    project = tmp_path / "packages" / "sub"
     (project / "src").mkdir(parents=True)
     (project / "foundry.toml").write_text("[profile.default]\n")
-    contract = project / "src" / "Portal.sol"
-    contract.write_text("contract Portal {}")
+    contract = project / "src" / "Widget.sol"
+    contract.write_text("contract Widget {}")
 
     assert find_build_config_dir(contract, tmp_path) == project.resolve()
 
@@ -106,7 +106,7 @@ def test_describe_returns_none_for_the_root_itself(tmp_path: Path) -> None:
 
 
 def test_describe_returns_the_relative_subdir(tmp_path: Path) -> None:
-    project = tmp_path / "packages" / "portal"
+    project = tmp_path / "packages" / "sub"
     project.mkdir(parents=True)
 
-    assert describe_build_config_dir(project, tmp_path) == str(Path("packages") / "portal")
+    assert describe_build_config_dir(project, tmp_path) == str(Path("packages") / "sub")


### PR DESCRIPTION
## Problem

Autosetup resolved the build system from the process CWD, and
`BuildSystemManager.find_config_file` only walks *upward* from there. A repository whose
Foundry/Hardhat project lives in a subdirectory (`<pkg>/foundry.toml`) is therefore invisible
when the run root is the repo root:

- `BuildSystemDetector` reports `unknown` → *"No build system detected, continuing without build config"*
- the generated conf carries neither the project's remappings nor its pinned solc/evm_version
- solc fails with a bare `ParserError: Source "@pkg/Foo.sol" not found. Searched the following locations: "".`

The reactive `source_not_found_packages` workaround could not rescue it either:
`_build_packages_from_remapping_sources` hardcoded `base_dir=Path(".")`, so it read the same
root that had nothing to offer, recomputed an **identical** packages list, and the retry guard
correctly gave up with *"Workarounds applied but the conf and command are unchanged"*. The run
died with `CompilationAnalysisError` before ever reaching the Prover.

## Fix

Anchor on the contract under analysis instead of on the run root. `find_build_config_dir`
walks up from the main contract's own path to the nearest ancestor holding a `foundry.toml` /
`hardhat.config.{js,ts}`, bounded by the run root, and that directory is used for:

- `BuildSystemDetector.resolve(...)`
- the `BuildSystemManager` instance (so `find_config_file` starts in the right place)
- `base_dir` for remapping sources in the reactive workaround

No new plumbing or arguments are needed — the main contract handle is already set before
`setup_build_system_config()` runs.

### Why this is safe for existing projects

- A root-level project resolves to the run root, so behaviour is unchanged.
- `build_packages_from_remapping_sources` already resolves relative targets **absolute**
  against `base_dir`, so the emitted packages remain valid from the run CWD.
- `CompilationWorkaroundManager.project_root` is untouched and keeps anchoring the conf and
  generated harnesses at the run root; the new `build_config_dir` is a separate concept and
  defaults to `project_root`, so the `fixconf` call site needs no change.

## Tests

- `tests/test_project_dir.py` — nested project, root-relative contract path, root-level
  project, no config anywhere, nearest-ancestor-wins over an outer config, hardhat anchor,
  walk stops at the run root, contract outside the root.
- `tests/test_compilation_workarounds.py` — the reactive workaround now picks up a nested
  `foundry.toml` remapping (the exact case that produced the identical-conf give-up), plus a
  default-to-`project_root` case.

Full suite: 271 passed, 10 pre-existing failures identical on `master` (missing `tabulate` /
`certora_cli` in the test env), and 6 pre-existing collection errors from the same missing
dependency.
