### PR TITLE
Fix Field() description/default confusion in LLM-facing schemas

### DIFF
--- a/composer/cvl/schema.py
+++ b/composer/cvl/schema.py
@@ -2,11 +2,11 @@ from typing import Annotated, Literal, Protocol
 from pydantic import BaseModel, Field, Discriminator
 
 class ImportSpec(BaseModel):
-    spec_file: str = Field("The (relative) path to the spec file to import")
+    spec_file: str = Field(description="The (relative) path to the spec file to import")
 
 class ContractImport(BaseModel):
-    contract_name: str = Field("The name of the contract to import (e.g. ERCTokenA)")
-    as_name: str = Field("The CVL identifier to bind to, e.g. 'tokenA'")
+    contract_name: str = Field(description="The name of the contract to import (e.g. ERCTokenA)")
+    as_name: str = Field(description="The CVL identifier to bind to, e.g. 'tokenA'")
 
 class MappingType(BaseModel):
     """
@@ -329,7 +329,7 @@ class FunctionDef(BaseModel):
     block: CodeBlock = Field(description="The body of the function.")
 
 class MethodWithoutReturn(BaseModel):
-    host_contract: str | None = Field("The host contract *type* of the method (*NOT* the using alias), or None, if the contract under verification should be used")
+    host_contract: str | None = Field(description="The host contract *type* of the method (*NOT* the using alias), or None, if the contract under verification should be used")
     name: str = Field(description="The name of the method")
     params: list["NamedVMParam"] = Field(description="The formal arguments to the method")
 
@@ -368,7 +368,7 @@ class Invariant(BaseModel):
     Invariant declaration
     """
     type: Literal["invariant"]
-    name: str = Field("The name of the invariant")
+    name: str = Field(description="The name of the invariant")
     invariant_params: list[TypeAndId] = Field(description="The (non-deterministically chosen) arguments to the invariant.")
     invariant_expression: Expression = Field(description="The expression to show is invariant. Should be boolean typed.")
     filter: FilteredBlock | None = Field(description="The filter for the invariant. The `method_param` name can be arbitrarily chosen, it is always bound" \

--- a/composer/spec/system_model.py
+++ b/composer/spec/system_model.py
@@ -67,7 +67,7 @@ class SourceExplicitContract(ExplicitContract):
     """
     A concrete contract type in the system.
     """
-    path: str = Field("The relative path to the file which defines the contract type this represents")
+    path: str = Field(description="The relative path to the file which defines the contract type this represents")
 
 class HarnessDefinition(BaseModel):
     path: str

--- a/tests/test_pydantic_field_descriptions.py
+++ b/tests/test_pydantic_field_descriptions.py
@@ -1,0 +1,43 @@
+"""Guards against `Field("some prose")` in pydantic schemas.
+
+`Field`'s only positional parameter is ``default``, so a bare string there does not
+document the field — it makes the field *optional* and gives it that prose as its
+value. For the schemas we hand to an LLM that is doubly wrong: the model is never
+told what the field means, and when it omits the field we silently get the sentence
+back as data (a "path" that is a sentence, an invariant "name" that is a sentence).
+Nothing type-checks it, so the bad value only surfaces far downstream.
+
+A genuine string default is spelled `Field(default="...")`, so a string literal in
+the positional slot is always the description/default confusion. `Field(...)`
+(Ellipsis, i.e. explicitly required) is fine.
+"""
+import ast
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent / "composer"
+
+
+def _positional_string_fields(tree: ast.AST) -> list[tuple[int, str]]:
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        func = node.func
+        # matches both `Field(...)` and `pydantic.Field(...)`
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name != "Field":
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            found.append((node.lineno, first.value))
+    return found
+
+
+def test_no_prose_in_field_default_slot() -> None:
+    offenders = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for lineno, value in _positional_string_fields(tree):
+            rel = path.relative_to(PACKAGE_ROOT.parent)
+            offenders.append(f"{rel}:{lineno}: Field({value!r}) — did you mean description=?")
+    assert not offenders, "\n".join(offenders)


### PR DESCRIPTION
## The bug

`pydantic.Field`'s only positional parameter is `default`. So

```python
path: str = Field("The relative path to the file which defines the contract type this represents")
```

does not describe the field — it makes `path` **optional** and sets its default value to that sentence. Two things go wrong at once:

1. The model is never told what `path` means (no `description` reaches the JSON schema).
2. `path` is no longer required, so the model may legitimately omit it — and when it does, we silently get the sentence back as data.

Six fields were declared this way:

| field | what the bogus default becomes |
| --- | --- |
| `SourceExplicitContract.path` | a contract source path |
| `Invariant.name` | a CVL invariant name |
| `MethodWithoutReturn.host_contract` | a contract type |
| `ImportSpec.spec_file` | a spec path |
| `ContractImport.contract_name` / `.as_name` | a contract name / CVL binding |

## Why it only shows up sometimes

Nothing is broken at construction time — the model validates fine, because the sentence *is* a valid `str`. The defect only materialises when the LLM happens to omit the field on that particular call, which is a per-call sampling accident: the same repo at the same commit will produce a correct `path` on most contracts and a defaulted one occasionally. That is why this sat latent since #71 (April) and why, in the run that surfaced it, six of seven per-contract jobs on the *same commit* succeeded and one died.

There is also no type error to catch it downstream. For `SourceExplicitContract.path` the value flows into

```python
extra_files = [c.path for c in sys_desc.transitive_closure if c.solidity_identifier != source.contract_name]
```

and on into the autosetup argv, so the failure surfaces far from its origin, as

```
ValueError: Error: The relative path to the file which defines the contract type this represents is not a .sol file
```

and the run exits 1 ~25 minutes later when `prepare_formalization`'s `gather` re-raises. The other four fields fail more quietly still — a sentence as an invariant name or a contract binding just produces bad CVL.

## The fix

Spell all six `description=`. The fields become required again and the prose reaches the model as documentation, which is what it was written for.

`tests/test_pydantic_field_descriptions.py` adds an AST lint over `composer/`: a string literal in `Field`'s positional slot is always this confusion (a real string default is `Field(default=...)`), while `Field(...)` stays legal.

## Testing

- new lint passes; verified it flags `Field("prose")` and accepts `Field(...)` / `Field(description=...)`
- full suite: `327 passed, 9 skipped`, 5 failures — all 5 reproduce identically on unmodified `master` (`invariant-cvl` tape lane exhausted in the autoprove/codegen end-to-end tests; two `test_indexed_tool` cache-count assertions)
- no in-tree constructor relied on any of the six defaults, so nothing internal starts failing validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)