### PR TITLE
Match dependency and generated-output paths at any depth in FS_FORBIDDEN_READ

### DIFF
--- a/composer/spec/util.py
+++ b/composer/spec/util.py
@@ -61,36 +61,49 @@ def temp_certora_file(
     finally:
         os.unlink(tgt)
 
-# Matches at any depth, for path components that occur nested as readily as they do
-# at the project root: a package's own dependency tree, a submodule's ``.git``, a
-# sub-project's ``.certora_internal``.
+# Solidity is never withheld from the project source surface. Any .sol in the tree can
+# turn out to be part of the verification target: the conf's ``packages`` remappings
+# resolve into vendored dependency trees, and in a stock Foundry layout ``lib/`` and
+# ``test/`` hold real contracts.
+_KEEP_SOLIDITY = r"(?!.*\.sol\Z)"
+
+# Matches at any depth, for path components that occur nested as readily as they do at
+# the project root: a package's own dependency tree, a sub-project's build output.
 _ANY_DEPTH = r"(?:.*/)?"
 
-# Paths the agent's source tools (``list_files`` / ``get_file`` / ``grep_files``) may
-# not read, as a single ``re.fullmatch`` alternation over project-root-relative POSIX
-# paths. Each alternative therefore has to match a whole path, not a prefix of one.
-FS_FORBIDDEN_READ = "|".join([
-    # A dependency tree's Solidity stays readable: the conf's ``packages`` remappings
-    # resolve into it, so it is part of the verification target's source. The rest of
-    # the tree (its JS, docs, lockfiles) is not.
-    rf"{_ANY_DEPTH}node_modules/.*(?<!\.sol)",
-    # Deliberately root-only, unlike the rule above. A dependency keeps its own
-    # transitive Solidity under nested ``lib/`` and ``test/`` directories, and the
-    # conf remaps into those, so matching these at any depth would hide source the
-    # agent has to be able to read.
-    r"lib/.*",
-    r"test/.*",
-    r"emv-.*",
-    rf"{_ANY_DEPTH}\.certora_internal.*",
-    rf"{_ANY_DEPTH}\.git.*",
-    # Machine-generated output. Beyond being unreadable, a minified bundle or packed
+# Trees that carry source alongside content of no use to a reader. Only the
+# non-Solidity part is withheld.
+_NON_SOLIDITY_ONLY = [
+    rf"{_ANY_DEPTH}node_modules/.*",
+    rf"{_ANY_DEPTH}lib/.*",
+    rf"{_ANY_DEPTH}test/.*",
+    # Machine-generated output. Beyond being unreadable, a minified bundle or a packed
     # data blob holds its content on very few very long lines — a single line can span
     # megabytes — and a content grep reports whole matching lines.
-    r".*\.json",
     rf"{_ANY_DEPTH}dist/.*",
+    r".*\.json",
     r".*[.\-_](?:min|bundle)\.js",
     r".*\.map",
     r".*\.dat",
+]
+
+# Prover working directories and VCS internals, withheld whole. The Solidity carve-out
+# would be actively harmful here: their .sol content is a verbatim copy of a contract
+# already reachable at its canonical path, since each certoraRun invocation
+# materializes its own ``inputs/.certora_sources/**``. Analysis that wants a specific
+# report's copy reaches it through a VFS scoped to that report, not through this surface.
+_WITHHELD_WHOLE = [
+    rf"{_ANY_DEPTH}\.certora_internal.*",
+    rf"{_ANY_DEPTH}\.git.*",
+    r"emv-.*",
+]
+
+# Paths the agent's source tools (``list_files`` / ``get_file`` / ``grep_files``) may
+# not read, as a single ``re.fullmatch`` pattern over project-root-relative POSIX
+# paths. Each alternative therefore has to match a whole path, not a prefix of one.
+FS_FORBIDDEN_READ = "|".join([
+    _KEEP_SOLIDITY + "(?:" + "|".join(_NON_SOLIDITY_ONLY) + ")",
+    *_WITHHELD_WHOLE,
 ])
 
 def uniq_thread_id(prefix: str) -> str:

--- a/composer/spec/util.py
+++ b/composer/spec/util.py
@@ -61,7 +61,37 @@ def temp_certora_file(
     finally:
         os.unlink(tgt)
 
-FS_FORBIDDEN_READ = r"(^lib/.*)|(^\.certora_internal.*)|(^\.git.*)|(^test/.*)|(^emv-.*)|(.*\.json$)|(^node_modules/.*(?<!\.sol)$)"
+# Matches at any depth, for path components that occur nested as readily as they do
+# at the project root: a package's own dependency tree, a submodule's ``.git``, a
+# sub-project's ``.certora_internal``.
+_ANY_DEPTH = r"(?:.*/)?"
+
+# Paths the agent's source tools (``list_files`` / ``get_file`` / ``grep_files``) may
+# not read, as a single ``re.fullmatch`` alternation over project-root-relative POSIX
+# paths. Each alternative therefore has to match a whole path, not a prefix of one.
+FS_FORBIDDEN_READ = "|".join([
+    # A dependency tree's Solidity stays readable: the conf's ``packages`` remappings
+    # resolve into it, so it is part of the verification target's source. The rest of
+    # the tree (its JS, docs, lockfiles) is not.
+    rf"{_ANY_DEPTH}node_modules/.*(?<!\.sol)",
+    # Deliberately root-only, unlike the rule above. A dependency keeps its own
+    # transitive Solidity under nested ``lib/`` and ``test/`` directories, and the
+    # conf remaps into those, so matching these at any depth would hide source the
+    # agent has to be able to read.
+    r"lib/.*",
+    r"test/.*",
+    r"emv-.*",
+    rf"{_ANY_DEPTH}\.certora_internal.*",
+    rf"{_ANY_DEPTH}\.git.*",
+    # Machine-generated output. Beyond being unreadable, a minified bundle or packed
+    # data blob holds its content on very few very long lines — a single line can span
+    # megabytes — and a content grep reports whole matching lines.
+    r".*\.json",
+    rf"{_ANY_DEPTH}dist/.*",
+    r".*[.\-_](?:min|bundle)\.js",
+    r".*\.map",
+    r".*\.dat",
+])
 
 def uniq_thread_id(prefix: str) -> str:
     suff = uuid.uuid4().hex[:16]

--- a/tests/test_fs_forbidden_read.py
+++ b/tests/test_fs_forbidden_read.py
@@ -1,0 +1,79 @@
+"""Tests for ``FS_FORBIDDEN_READ``, the pattern gating what the agent's source tools
+(``list_files`` / ``get_file`` / ``grep_files``) are allowed to read.
+
+Two properties matter, and they pull in opposite directions. Solidity reached through the
+conf's ``packages`` remappings has to stay readable however deeply it is vendored, because
+it is part of the verification target's source. Machine-generated output has to stay
+unreadable, because a minified bundle carries megabytes on a single line and a content
+grep reports whole matching lines — one call can then exceed the model's context window.
+
+The pattern is consumed by graphcore's VFS via ``re.fullmatch``, so that is how it is
+exercised here.
+"""
+
+import re
+
+from composer.spec.util import FS_FORBIDDEN_READ
+
+_FORBIDDEN = re.compile(FS_FORBIDDEN_READ)
+
+
+def can_read(path: str) -> bool:
+    """Mirror graphcore's check: a path is readable when it does not fullmatch."""
+    return _FORBIDDEN.fullmatch(path) is None
+
+
+def test_contract_under_analysis_is_readable() -> None:
+    assert can_read("pkg/sub/src/Widget.sol")
+
+
+def test_vendored_solidity_is_readable_at_any_depth() -> None:
+    # A `packages` remapping resolves into a nested dependency tree; the Solidity there
+    # is source under analysis, including the dependency's own lib/ and test/ subtrees.
+    assert can_read("pkg/sub/node_modules/@vendor/artifacts/contracts/src/IThing.sol")
+    assert can_read("pkg/sub/node_modules/@vendor/artifacts/contracts/lib/oz/contracts/token/ERC20.sol")
+    assert can_read("pkg/sub/node_modules/@vendor/artifacts/contracts/test/Harness.sol")
+
+
+def test_non_solidity_in_a_dependency_tree_is_not_readable_at_any_depth() -> None:
+    assert not can_read("node_modules/pkg/index.js")
+    # Nested dependency trees are the common case in a monorepo, and the reason this rule
+    # cannot be bound to the project root.
+    assert not can_read("pkg/sub/node_modules/pkg/index.js")
+    assert not can_read("pkg/sub/node_modules/pkg/README.md")
+
+
+def test_root_scaffolding_is_not_readable() -> None:
+    assert not can_read("lib/forge-std/src/Test.sol")
+    assert not can_read("test/Widget.t.sol")
+    assert not can_read("emv-1-verified-Widget/Report.html")
+    assert not can_read("package.json")
+
+
+def test_internal_directories_are_not_readable_at_any_depth() -> None:
+    assert not can_read(".git/config")
+    assert not can_read(".certora_internal/autoProve/run.log")
+    # Submodules and sub-project runs put both of these below the root.
+    assert not can_read("pkg/sub/.git/config")
+    assert not can_read("pkg/sub/.certora_internal/autoProve/run.log")
+
+
+def test_generated_bundles_and_data_blobs_are_not_readable() -> None:
+    # Built web output: the payload that made a single grep exceed the context window.
+    assert not can_read("apps/dist/index.html")
+    assert not can_read("apps/dist/assets/params.dat")
+    # Bundles are named with any of the three separators in practice.
+    assert not can_read("shared/app_bundle.js")
+    assert not can_read("shared/app-bundle.js")
+    assert not can_read("shared/app.bundle.js")
+    assert not can_read("shared/vendor.min.js")
+    assert not can_read("shared/app.js.map")
+
+
+def test_ordinary_sources_are_not_caught_by_the_generated_output_rules() -> None:
+    # The bundle/minified rules key on a separator before the marker, so hand-written
+    # files whose names merely end in those words stay readable.
+    assert can_read("apps/src/bundle.js")
+    assert can_read("apps/src/min.js")
+    assert can_read("services/daemon.mjs")
+    assert can_read("README.md")

--- a/tests/test_fs_forbidden_read.py
+++ b/tests/test_fs_forbidden_read.py
@@ -1,11 +1,12 @@
 """Tests for ``FS_FORBIDDEN_READ``, the pattern gating what the agent's source tools
 (``list_files`` / ``get_file`` / ``grep_files``) are allowed to read.
 
-Two properties matter, and they pull in opposite directions. Solidity reached through the
-conf's ``packages`` remappings has to stay readable however deeply it is vendored, because
-it is part of the verification target's source. Machine-generated output has to stay
-unreadable, because a minified bundle carries megabytes on a single line and a content
-grep reports whole matching lines — one call can then exceed the model's context window.
+Two properties matter, and they pull in opposite directions. Solidity always stays
+readable, wherever it sits: the conf's ``packages`` remappings resolve into vendored
+dependency trees, and a stock Foundry layout keeps real contracts in ``lib/`` and
+``test/``. Machine-generated output stays unreadable, because a minified bundle carries
+megabytes on a single line and a content grep reports whole matching lines — one call can
+then exceed the model's context window.
 
 The pattern is consumed by graphcore's VFS via ``re.fullmatch``, so that is how it is
 exercised here.
@@ -27,12 +28,17 @@ def test_contract_under_analysis_is_readable() -> None:
     assert can_read("pkg/sub/src/Widget.sol")
 
 
-def test_vendored_solidity_is_readable_at_any_depth() -> None:
-    # A `packages` remapping resolves into a nested dependency tree; the Solidity there
-    # is source under analysis, including the dependency's own lib/ and test/ subtrees.
+def test_solidity_is_readable_wherever_it_sits() -> None:
+    # A `packages` remapping resolves into a vendored tree, at whatever depth.
     assert can_read("pkg/sub/node_modules/@vendor/artifacts/contracts/src/IThing.sol")
-    assert can_read("pkg/sub/node_modules/@vendor/artifacts/contracts/lib/oz/contracts/token/ERC20.sol")
-    assert can_read("pkg/sub/node_modules/@vendor/artifacts/contracts/test/Harness.sol")
+    assert can_read("node_modules/@vendor/contracts/IThing.sol")
+    # A stock Foundry layout keeps dependencies in lib/ and contracts in test/.
+    assert can_read("lib/openzeppelin-contracts/contracts/token/ERC20.sol")
+    assert can_read("test/Widget.t.sol")
+    assert can_read("pkg/sub/lib/forge-std/src/Test.sol")
+    assert can_read("pkg/sub/test/Harness.sol")
+    # Even a name that collides with a generated-output rule stays readable.
+    assert can_read("apps/dist/Widget.sol")
 
 
 def test_non_solidity_in_a_dependency_tree_is_not_readable_at_any_depth() -> None:
@@ -41,21 +47,8 @@ def test_non_solidity_in_a_dependency_tree_is_not_readable_at_any_depth() -> Non
     # cannot be bound to the project root.
     assert not can_read("pkg/sub/node_modules/pkg/index.js")
     assert not can_read("pkg/sub/node_modules/pkg/README.md")
-
-
-def test_root_scaffolding_is_not_readable() -> None:
-    assert not can_read("lib/forge-std/src/Test.sol")
-    assert not can_read("test/Widget.t.sol")
-    assert not can_read("emv-1-verified-Widget/Report.html")
-    assert not can_read("package.json")
-
-
-def test_internal_directories_are_not_readable_at_any_depth() -> None:
-    assert not can_read(".git/config")
-    assert not can_read(".certora_internal/autoProve/run.log")
-    # Submodules and sub-project runs put both of these below the root.
-    assert not can_read("pkg/sub/.git/config")
-    assert not can_read("pkg/sub/.certora_internal/autoProve/run.log")
+    assert not can_read("pkg/sub/lib/forge-std/README.md")
+    assert not can_read("test/fixtures/expected.txt")
 
 
 def test_generated_bundles_and_data_blobs_are_not_readable() -> None:
@@ -68,6 +61,19 @@ def test_generated_bundles_and_data_blobs_are_not_readable() -> None:
     assert not can_read("shared/app.bundle.js")
     assert not can_read("shared/vendor.min.js")
     assert not can_read("shared/app.js.map")
+    assert not can_read("package.json")
+
+
+def test_prover_working_directories_are_withheld_whole_including_solidity() -> None:
+    # Their .sol is a verbatim copy of a contract already readable at its canonical
+    # path — each certoraRun invocation leaves another one — so the Solidity carve-out
+    # deliberately does not reach here.
+    assert not can_read("emv-1-verified-Widget/inputs/.certora_sources/src/Widget.sol")
+    assert not can_read(".certora_internal/abc123/.certora_sources/src/Widget.sol")
+    assert not can_read("pkg/sub/.certora_internal/abc123/.certora_sources/src/Widget.sol")
+    assert not can_read(".certora_internal/autoProve/run.log")
+    assert not can_read(".git/config")
+    assert not can_read("pkg/sub/.git/config")
 
 
 def test_ordinary_sources_are_not_caught_by_the_generated_output_rules() -> None:


### PR DESCRIPTION
## Problem

`FS_FORBIDDEN_READ` (`composer/spec/util.py`) decides what the agent's source tools —
`list_files` / `get_file` / `grep_files` — are allowed to read. It had two defects.

**1. Its directory rules were anchored at the project root** (`^node_modules/`, `^lib/`,
`^test/`, `^\.git`, `^\.certora_internal`). In a monorepo where the Foundry project lives in
a subdirectory, none of them match: the project's dependency tree sits at
`<pkg>/<sub>/node_modules/...`. There was also no rule for built web output.

A recent dev run died in the Custom Summaries phase with

```
AnthropicContextOverflowError: prompt is too long: 1285703 tokens > 1000000 maximum
```

A single `grep_files(search_string='function consume', matching_lines=True)` returned
**2.53 MB** in one tool result. Only 13 files matched — this is not a file-count problem.
~95% of the bytes came from five built frontend bundles, each inlining a minified JS payload
whose longest single line is 2.5–4.8 MB. `grep_files` reports whole matching lines, so one
match in such a file returns megabytes. Minified content also tokenizes at roughly two
characters per token, so 2.53 MB ≈ 1.28M tokens.

**2. It withheld Solidity.** Only `node_modules` had a `.sol` carve-out. Root `lib/` and
`test/` were excluded outright — so in a stock Foundry layout, every dependency contract and
every test contract was invisible to the agent.

## Change

- **Solidity is never withheld.** The carve-out `node_modules` already had is hoisted into a
  single guard over every dependency, scaffolding and generated-output rule. Any `.sol` is
  readable wherever it sits.
- `node_modules`, `lib`, `test` and `dist` now match **at any depth**. With Solidity
  protected globally, `lib/` and `test/` no longer need to be root-only to keep dependency
  source reachable, so they are uniform with the rest.
- New rules for machine-generated output: `dist/` trees, minified and bundled JS
  (`.min.js` / `.bundle.js` and the `-` / `_` separator variants), source maps, packed
  data blobs.
- **Prover working directories and VCS internals stay withheld whole** — `.certora_internal`,
  `.git`, `emv-*`. This is the one place the Solidity carve-out deliberately does not reach:
  their `.sol` is a verbatim copy of a contract already readable at its canonical path, since
  each `certoraRun` invocation materializes its own `inputs/.certora_sources/**` (a tree can
  accumulate several), and analysis that wants a specific report's copy reaches it through a
  VFS scoped to that report rather than through this surface. Applying the carve-out here
  would hand `grep_files` N duplicate copies of every contract.

## Measured effect

Applying the `master` and branch patterns to the source bundle of the run that failed:

| | master | this PR |
|---|---|---|
| grep-visible files | 914 (209.1 MB) | 661 (9.5 MB) |
| visible `.sol` | 597 / 597 | 597 / 597 |
| longest visible line | 4,802,095 B | 6,406 B |
| the `grep_files` call that overflowed | 2.53 MB (~1.27M tok) | 1.5 KB |

That project has no root `lib/`/`test/`, so the Solidity invariant does not bite there. On a
stock Foundry layout it does:

| path | master | this PR |
|---|---|---|
| `lib/openzeppelin-contracts/contracts/token/ERC20.sol` | hidden | **readable** |
| `test/Widget.t.sol` | hidden | **readable** |
| `lib/forge-std/README.md` | hidden | hidden |
| `emv-1-.../inputs/.certora_sources/src/Widget.sol` | hidden | hidden |

## Scope

This is path hygiene, and it is deliberately not the general fix. A path pattern cannot
express "this file has megabyte-long lines", so a sufficiently odd tree can still produce an
oversized tool result. The general fix is an output cap in graphcore's `_grep_impl`, which has
no bound of any kind today; that is a separate change in a separate repo and is not included
here. Two related weaknesses also remain out of scope: the summarization router reads token
usage off the preceding AI message and so cannot see a tool result that just landed, and the
summarizer re-sends the full history and silently swallows its own overflow.

## Testing

- New `tests/test_fs_forbidden_read.py` — 6 tests covering the Solidity invariant (vendored,
  nested, root `lib/`/`test/`), the any-depth rules, generated output, the withheld-whole
  prover directories, and false positives on hand-written files whose names end in
  `bundle.js` / `min.js`.
- `pyright` clean on the changed file.
- Locally the suite is not a clean signal: 6 modules cannot be collected (`certora_cli`
  missing) and `test_rag_db` needs a running Docker daemon for its testcontainers fixtures.
  Counts are identical with and without this change, so CI is the authoritative gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
