### PR TITLE
Package composer template subdirectories in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ include = ["composer*", "sanity_analyzer*", "analyzer*", "certora_autosetup*"]
 "" = "."
 
 [tool.setuptools.package-data]
-composer = ["templates/*.j2", "scripts/init-db.sql"]
+composer = ["templates/**/*.j2", "scripts/init-db.sql"]
 # Bundled CVL summaries, spec templates, mocks and conf templates the prover
 # reads directly off disk; ship them with the wheel.
 certora_autosetup = [


### PR DESCRIPTION
`composer`'s `package-data` glob was `templates/*.j2`, which matches only the top
level of `templates/` and silently drops any subdirectory.

PR #96 (ecosystem abstraction) added three template subdirs — `shared/`, `rust/`,
`solana/` (13 `.j2` files) — and wired `application_analysis_system.j2` to
`{% from "shared/analysis_macros.j2" import input_phrase %}`. Those files are in
git but never shipped in the wheel, so a **source checkout works while the built
container fails** at component analysis:

```
TemplateNotFound: 'shared/analysis_macros.j2'
```

System analysis runs first and unconditionally, so every containerized run dies here.

## Fix

Make the glob recursive, matching the form `certora_autosetup` already uses:

```diff
-composer = ["templates/*.j2", "scripts/init-db.sql"]
+composer = ["templates/**/*.j2", "scripts/init-db.sql"]
```

## Verification

Built the wheel (`uv build --wheel`) and inspected its contents: all 13 subdir
templates now ship (including `shared/analysis_macros.j2`); the 92 top-level
templates and `init-db.sql` are unchanged.