### PR TITLE
Install urllib3-future without letting it replace urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,16 @@ ragbuild = [
 ]
 
 [tool.uv]
+# urllib3-future (via niquests, via certora-cloud) ships a wheel that contains its own
+# top-level `urllib3` package plus a `urllib3_future.pth` startup hook, both of which
+# exist to substitute it for the real urllib3 in-place. Anything resolving `import
+# urllib3` then gets the fork, and an interrupted substitution leaves a tree that cannot
+# be imported at all. Building it from its sdist with URLLIB3_NO_OVERRIDE set — which the
+# project's own build hook reads, see its README's packaging notes — emits neither the
+# duplicate package nor the hook, leaving `urllib3` and `urllib3_future` as disjoint
+# installs. niquests imports urllib3_future directly, so it is unaffected.
+# The environment variable is set alongside every install site (see scripts/Dockerfile).
+no-binary-package = ["urllib3-future"]
 conflicts = [
     [{ extra = "cpu" }, { extra = "cuda" }],
     [

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -126,6 +126,13 @@ WORKDIR $AUTOPROVE_HOME/AutoProver
 # name, passed straight to `uv sync --extra`.
 ARG CERTORA_CLI_PACKAGE=certora-cli
 
+# Read by urllib3-future's build hook, which is reached because [tool.uv]
+# no-binary-package forces it to be built from its sdist. Set for the whole stage so it
+# applies to every `uv sync` below: without it that package installs a second copy of
+# `urllib3` over the real one plus a startup hook that keeps reinstating it, and `import
+# urllib3` silently resolves to the fork. See the note in pyproject.toml.
+ENV URLLIB3_NO_OVERRIDE=1
+
 # Dependency layer: lockfile-driven install of all third-party deps WITHOUT the
 # local project. Cached across rebuilds whenever pyproject.toml/uv.lock/graphcore
 # don't change. `graphcore` is the vendored submodule the [tool.uv.sources] path
@@ -145,6 +152,12 @@ COPY . ./
 RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv sync --frozen --no-editable \
       --extra cpu --extra ml --extra "$CERTORA_CLI_PACKAGE" --group ragbuild
+
+# Gate on urllib3 having survived the install as itself. Worth a build step because the
+# substitution above is silent when it succeeds: `import urllib3` keeps working, it just
+# resolves to the fork, so a lockfile bump that reintroduces it would otherwise surface
+# much later as a confusing ImportError inside a pipeline phase.
+RUN /opt/autoprove/venv/bin/python scripts/check_urllib3_identity.py
 
 # Pre-built CVL HTML — the entrypoint's setup-db reads this to populate rag_db.
 COPY --from=docs-builder /out/cvl.html $AUTOPROVE_HOME/prover-docs/cvl.html

--- a/scripts/check_urllib3_identity.py
+++ b/scripts/check_urllib3_identity.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""Assert that `import urllib3` resolves to urllib3 and not to urllib3-future.
+
+urllib3-future's default wheel installs a second copy of the `urllib3` package over the
+real one and a `urllib3_future.pth` startup hook that keeps reinstating it, so that
+`import urllib3` yields the fork. `[tool.uv] no-binary-package` plus URLLIB3_NO_OVERRIDE
+suppress both, leaving the two distributions installed side by side — see the note in
+pyproject.toml.
+
+This runs as a build step because the substitution is silent when it succeeds: `import
+urllib3` keeps working, just against different code. Only a partially-applied
+substitution raises, and it does so far from the cause — deep inside a pipeline phase,
+as an ImportError claiming a circular import. Failing the build instead keeps that
+diagnosis from having to happen twice.
+"""
+
+import importlib.metadata as metadata
+import sys
+import sysconfig
+from pathlib import Path
+
+site_packages = Path(sysconfig.get_paths()["purelib"])
+problems: list[str] = []
+
+hook = site_packages / "urllib3_future.pth"
+if hook.exists():
+    problems.append(f"{hook.name} is installed; it substitutes urllib3 on interpreter start")
+
+# urllib3-future's marker directory. Its presence under `urllib3/` means that tree is the
+# fork's, whether or not the hook is still around to have put it there.
+if (site_packages / "urllib3" / "backend").exists():
+    problems.append("urllib3/backend/ exists; the urllib3 package directory is urllib3-future's")
+
+imported_version: str | None = None
+try:
+    import urllib3
+except ImportError as exc:
+    problems.append(f"import urllib3 failed: {exc}")
+else:
+    # getattr rather than attribute access: urllib3 does not re-export __version__ in its
+    # type stubs, and a substituted package may not define it at all.
+    imported_version = getattr(urllib3, "__version__", None)
+    declared = metadata.version("urllib3")
+    if imported_version != declared:
+        problems.append(
+            f"the imported urllib3 reports version {imported_version} but the installed "
+            f"urllib3 distribution is {declared}; `import urllib3` is resolving to "
+            "another package"
+        )
+
+# The consumers that made this worth gating: requests reaches urllib3, niquests reaches
+# urllib3_future, and both must work off the same environment.
+for module in ("requests", "niquests", "urllib3_future"):
+    try:
+        __import__(module)
+    except ImportError as exc:
+        problems.append(f"import {module} failed: {exc}")
+
+if problems:
+    print("urllib3 identity check FAILED:", file=sys.stderr)
+    for problem in problems:
+        print(f"  - {problem}", file=sys.stderr)
+    print(
+        "\nExpected urllib3 and urllib3-future installed side by side. Check that "
+        "[tool.uv] no-binary-package still lists urllib3-future and that "
+        "URLLIB3_NO_OVERRIDE is set wherever the environment is installed.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    f"urllib3 identity OK: urllib3 {imported_version}, "
+    f"urllib3-future {metadata.version('urllib3-future')}"
+)


### PR DESCRIPTION
## What changes

Two lines of configuration, plus a build-time check.

```toml
# pyproject.toml, in [tool.uv]
no-binary-package = ["urllib3-future"]
```
```dockerfile
# scripts/Dockerfile, final stage, before the uv sync steps
ENV URLLIB3_NO_OVERRIDE=1
```

Either one alone is a no-op; they only work together. Explained below.

## The problem

`certora-cloud` → `niquests` → `urllib3-future`, and urllib3-future exists to *replace*
urllib3 rather than sit alongside it. Its wheel does that two ways at once. From its
`pyproject.toml`:

```toml
[tool.hatch.build.targets.wheel]
packages = ["src/urllib3", "src/urllib3_future"]
```

The wheel ships **its own top-level `urllib3` package**, so installing it overwrites the
real urllib3's files. And it force-includes a `urllib3_future.pth`, which runs on every
interpreter start and re-applies the substitution — `rmtree`ing `site-packages/urllib3` and
copying `urllib3_future` over it whenever it sees both installed and the directory
writable.

**The normal outcome is silent, not broken.** In a clean venv the substitution completes and
nothing raises: `import urllib3` reports `2.24.900` — urllib3-future — while urllib3 2.6.3
is the installed distribution. Everything reaching urllib3 (`requests`, `botocore`,
`docker`, `kubernetes`) transparently runs the fork's HTTP stack.

It only becomes visible when the substitution is interrupted, which is how it was found: a
tree carrying urllib3-future's `backend/` but no `urllib3/exceptions.py`, so every plain
`import urllib3` failed with

```
ImportError: cannot import name 'exceptions' from partially initialized module 'urllib3'
             (most likely due to a circular import)
```

The circular-import wording is a red herring — the module is simply incomplete. It took
down `setup-db` via `spacy → requests → urllib3`.

## Why these two lines

The project ships an escape hatch in `hatch_build.py`:

```python
SHOULD_PREVENT_FORK_OVERRIDE = environ.get("URLLIB3_NO_OVERRIDE", None) is not None
...
if SHOULD_PREVENT_FORK_OVERRIDE and path.exists("./src/urllib3"):
    rmtree("./src/urllib3")          # no duplicate urllib3 in the wheel
...
if self.target_name != "wheel" or SHOULD_PREVENT_FORK_OVERRIDE or version == "editable":
    return                            # no .pth either
```

and documents it in the README's packaging notes:

> When packaging for a distribution registry, set `URLLIB3_NO_OVERRIDE=1` during the build
> (e.g. `URLLIB3_NO_OVERRIDE=1 python -m build`). This prevents the in-place upgrade
> behavior

That hook is a **build** hook, so it never runs when a prebuilt wheel is installed. Hence
both lines: `no-binary-package` forces uv to build from the sdist, and the env var makes the
build take the hatch. urllib3-future is pure-Python/hatchling so the source build is cheap,
and its binary dependencies (`jh2`, `qh3`) still install as wheels.

`niquests` imports `urllib3_future` directly and is unaffected — confirmed by import.

## Measured

Clean venvs, `niquests==3.19.1` + `urllib3==2.6.3` both ways:

| | default wheel | this PR |
|---|---|---|
| `urllib3_future.pth` | present | absent |
| `urllib3/backend/` (fork's marker) | present | absent |
| `import urllib3` reports | **2.24.900** (fork) | **2.6.3** (real) |
| top-level dirs owned | overlapping | disjoint: `urllib3` / `urllib3_future` |
| `import niquests` / `requests` | ok | ok |

Also verified through `uv sync --frozen` with the extras the image uses, i.e. the exact path
`scripts/Dockerfile` takes.

## The check

`scripts/check_urllib3_identity.py` runs as a build step and fails if `import urllib3` stops
resolving to the installed urllib3 distribution. It is there because there is nothing else to
notice: a successful substitution changes no behaviour that surfaces at install time, so a
future lockfile bump would reintroduce this silently.

Verified in both directions — passes on a fixed environment, and on a default install reports:

```
urllib3 identity check FAILED:
  - urllib3_future.pth is installed; it substitutes urllib3 on interpreter start
  - urllib3/backend/ exists; the urllib3 package directory is urllib3-future's
  - the imported urllib3 reports version 2.24.900 but the installed urllib3 distribution
    is 2.6.3; `import urllib3` is resolving to another package
```

## Notes

Split out of #122, which bundled this with unrelated RAG-rebuild and results-download fixes.
#122 will drop its copy.

Anyone with an existing container or venv needs a rebuild — this only changes how the
environment is installed, so it cannot repair one already in the substituted state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)