### PR TITLE
Answer every tool call of the turn that invoked verify_spec

### DIFF
--- a/composer/prover/analysis.py
+++ b/composer/prover/analysis.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from langchain_core.messages import ToolMessage, HumanMessage, AIMessage, BaseMessage, AnyMessage
 from langchain_core.runnables import Runnable
 from langchain_core.language_models.base import LanguageModelInput
@@ -6,6 +8,33 @@ from graphcore.utils import ainvoke
 
 from composer.prover.ptypes import RuleResult
 from composer.templates.loader import load_jinja_template
+
+# Stand-in result for a tool the model called alongside ``verify_spec``. That call's real
+# result belongs to the agent's own thread; this one-shot analysis only needs it present,
+# because the API rejects a ``tool_use`` block with no ``tool_result`` after it.
+_SIBLING_TOOL_PLACEHOLDER = (
+    "This tool ran alongside the prover invocation. Its result is not part of the "
+    "counter-example analysis; disregard this call."
+)
+
+
+def _unanswered_tool_call_ids(messages: Sequence[AnyMessage]) -> list[str]:
+    """Ids of tool calls in the last assistant turn that no ``ToolMessage`` answers.
+
+    The history handed to :func:`analyze_cex_raw` is the agent's live state, snapshotted
+    while the tools node is still executing: the trailing ``AIMessage`` opened every tool
+    call of that node, and none of them has a result appended yet. The model is free to
+    batch tool calls, so ``verify_spec`` is not necessarily the only one.
+    """
+    answered = {msg.tool_call_id for msg in messages if isinstance(msg, ToolMessage)}
+    for msg in reversed(messages):
+        if isinstance(msg, AIMessage):
+            return [
+                call_id
+                for call in msg.tool_calls
+                if (call_id := call.get("id")) is not None and call_id not in answered
+            ]
+    return []
 
 
 async def analyze_cex_raw(
@@ -27,6 +56,11 @@ The Certora Prover found a violation for the rule {rule.name}, with the followin
 {rule.cex_dump}
 """
         )
+    )
+    new_messages.extend(
+        ToolMessage(tool_call_id=sibling_id, content=_SIBLING_TOOL_PLACEHOLDER)
+        for sibling_id in _unanswered_tool_call_ids(m)
+        if sibling_id != tool_call_id
     )
     new_messages.append(
         HumanMessage(

--- a/tests/test_cex_analysis_messages.py
+++ b/tests/test_cex_analysis_messages.py
@@ -1,0 +1,106 @@
+"""Unit tests for the message history ``analyze_cex_raw`` builds.
+
+Counter-example analysis is a one-shot LLM call made from *inside* the ``verify_spec`` tool, so
+it inherits the agent's live history: the trailing ``AIMessage`` is the turn that opened the
+currently-executing tools node. The Messages API requires every ``tool_use`` block in that turn
+to be followed by a matching ``tool_result``, so the analysis history has to answer *all* of the
+turn's tool calls — and the model is free to batch another tool call alongside ``verify_spec``.
+"""
+
+from typing import Sequence, cast
+
+import pytest
+from langchain_core.language_models.base import LanguageModelInput
+from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import Runnable, RunnableLambda
+
+from composer.prover.analysis import analyze_cex_raw
+from composer.prover.ptypes import RulePath, RuleResult
+
+VERIFY_ID = "toolu_verify"
+SIBLING_ID = "toolu_sibling"
+
+CapturedLLM = tuple[Runnable[LanguageModelInput, BaseMessage], list[BaseMessage]]
+
+
+def _capturing_llm() -> CapturedLLM:
+    """An LLM stand-in plus the list its invocation messages land in."""
+    seen: list[BaseMessage] = []
+
+    def _record(messages: LanguageModelInput) -> BaseMessage:
+        assert isinstance(messages, list)
+        seen.extend(cast(list[BaseMessage], messages))
+        return AIMessage(content="analysis")
+
+    return RunnableLambda(_record), seen
+
+
+def _violated() -> RuleResult:
+    return RuleResult(path=RulePath(rule="count_nonneg"), cex_dump="<cex/>", status="VIOLATED")
+
+
+def _history(*tool_call_ids: str) -> list[AnyMessage]:
+    """A history ending in one assistant turn that opened ``tool_call_ids`` and nothing more."""
+    return [
+        HumanMessage(content="write a spec"),
+        AIMessage(
+            content="running the prover",
+            tool_calls=[
+                {"name": "tool", "args": {}, "id": call_id} for call_id in tool_call_ids
+            ],
+        ),
+    ]
+
+
+def _results_by_id(messages: Sequence[BaseMessage]) -> dict[str, str]:
+    return {
+        msg.tool_call_id: str(msg.content)
+        for msg in messages
+        if isinstance(msg, ToolMessage)
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_batched_sibling_call_gets_a_tool_result() -> None:
+    llm, seen = _capturing_llm()
+    await analyze_cex_raw(llm, _history(SIBLING_ID, VERIFY_ID), _violated(), VERIFY_ID)
+
+    results = _results_by_id(seen)
+    assert set(results) == {VERIFY_ID, SIBLING_ID}
+    # The prover's own result carries the counter-example; the sibling's is a stand-in.
+    assert "<cex/>" in results[VERIFY_ID]
+    assert "<cex/>" not in results[SIBLING_ID]
+
+
+@pytest.mark.asyncio
+async def test_the_lone_verify_spec_call_gets_exactly_one_tool_result() -> None:
+    llm, seen = _capturing_llm()
+    await analyze_cex_raw(llm, _history(VERIFY_ID), _violated(), VERIFY_ID)
+
+    assert list(_results_by_id(seen)) == [VERIFY_ID]
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_already_answered_are_not_answered_twice() -> None:
+    # A sibling that finished first has its result in the history already; a second
+    # ``tool_result`` for the same id is as invalid as none at all.
+    history = _history(SIBLING_ID, VERIFY_ID)
+    history.append(ToolMessage(tool_call_id=SIBLING_ID, content="sibling done"))
+
+    llm, seen = _capturing_llm()
+    await analyze_cex_raw(llm, history, _violated(), VERIFY_ID)
+
+    ids = [msg.tool_call_id for msg in seen if isinstance(msg, ToolMessage)]
+    assert sorted(ids) == sorted({SIBLING_ID, VERIFY_ID})
+    assert _results_by_id(seen)[SIBLING_ID] == "sibling done"
+
+
+@pytest.mark.asyncio
+async def test_the_caller_history_is_left_untouched() -> None:
+    history = _history(SIBLING_ID, VERIFY_ID)
+    before = list(history)
+    llm, _ = _capturing_llm()
+
+    await analyze_cex_raw(llm, history, _violated(), VERIFY_ID)
+
+    assert history == before


### PR DESCRIPTION
## Problem

Counter-example analysis (`analyze_cex_raw`) is a one-shot LLM call made from *inside* the `verify_spec` tool, and it reuses the agent's live message history. That history is snapshotted while the tools node is still executing, so its trailing `AIMessage` is the turn that opened the currently-running tool calls — none of which has a result yet.

The function appended a `ToolMessage` for `verify_spec`'s own `tool_call_id` only. When the model batches another tool call into the same turn (e.g. `feedback_tool` alongside `verify_spec`, which it does), that sibling `tool_use` block reaches the API with no `tool_result` after it and the request is rejected:

```
400 messages.N: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_…
```

The failure is deterministic for that turn shape as soon as one rule comes back `VIOLATED`, and it lands *after* the prover has run — so a CVL-generation phase can burn the better part of an hour, plus cloud prover time, and then die with nothing to show. It has hit real runs.

## Fix

Fill in a stand-in `ToolMessage` for every tool call of the trailing assistant turn that nothing has answered yet (`verify_spec`'s own result still carries the counter-example). Already-answered ids are skipped, so a sibling that finished first keeps its real result and never gets a duplicate.

## Tests

`tests/test_cex_analysis_messages.py` — batched sibling gets a result, the lone `verify_spec` case still gets exactly one, an already-answered sibling is not answered twice, and the caller's history is not mutated. The first of those fails on master.

Local: `508 passed, 9 skipped, 9 deselected`; `pyright` 0 errors.

## Validating by eye

The end-to-end path is covered by the replay harness rather than a live run:
`uv run --no-sync python -m pytest tests/ -m "not expensive" -k autoprove` exercises the `verify_spec` → counter-example-analysis round trip against the taped LLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)