### PR TITLE
CI: run pyright and pytest on `dev` pull requests

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -2,9 +2,9 @@ name: pyright-check
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, master, dev ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, master, dev ]
 
 jobs:
   pyright:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,9 @@ name: pytest-check
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, master, dev ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, master, dev ]
 
 jobs:
   pytest:


### PR DESCRIPTION
The `dev` ruleset requires the `pyright` and `pytest` checks, but both workflows only trigger on pull requests targeting `main`/`master`. A PR into `dev` therefore reports neither check, and a required check that never reports blocks the merge indefinitely. Add `dev` to the branch filters.

This applies to itself: GitHub runs `pull_request` workflows from the head-merged-into-base ref, so this PR runs the checks it is adding.