### PR TITLE
[DEV] autosetup: converge the compilation-workaround loop instead of timing out

### DIFF
--- a/certora_autosetup/fixconf.py
+++ b/certora_autosetup/fixconf.py
@@ -24,7 +24,10 @@ from certora_autosetup.fixconf_prechecks import (
 )
 from certora_autosetup.parsers.build_system_detector import BuildSystem, BuildSystemDetector
 from certora_autosetup.setup.solidity_import_patch import apply_patch, create_patch, revert_patch
-from certora_autosetup.utils.compilation_workarounds import CompilationWorkaroundManager
+from certora_autosetup.utils.compilation_workarounds import (
+    CompilationWorkaroundManager,
+    UnsatisfiableSolcPinError,
+)
 from certora_autosetup.utils.constants import DEFAULT_SOLC_VERSION
 from certora_autosetup.utils.contract_utils import parse_contract_files
 from certora_autosetup.utils.logger import logger
@@ -172,9 +175,16 @@ def fix_conf(
     workaround_mgr = CompilationWorkaroundManager(
         project_root, DEFAULT_SOLC_VERSION, verbose, solc_convention=solc_convention
     )
-    success, output, updated_config_dict = workaround_mgr.run_compilation_with_workarounds(
-        cmd, working_conf, working_conf_dict, contracts, updated_config_dict
-    )
+    try:
+        success, output, updated_config_dict = workaround_mgr.run_compilation_with_workarounds(
+            cmd, working_conf, working_conf_dict, contracts, updated_config_dict
+        )
+    except UnsatisfiableSolcPinError as e:
+        # The conf pins a compiler this machine cannot provide. Report it and keep
+        # going: the fixes already written to the working conf are still worth
+        # handing back.
+        logger.log(str(e), "ERROR", "fixconf")
+        success, output = False, str(e)
 
     # Import patcher fallback
     import_patcher_applied = False

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -105,6 +105,39 @@ def _path_from_source_location_line(line: str) -> Optional[str]:
     return match.group("path") if match else None
 
 
+def _flatten_conf(cmd: List[str], compilation_config: Dict, updated_config_dict: Dict) -> Dict[str, str]:
+    """Leaf path -> canonical JSON value, e.g. ``compilation_config.compiler_map.Foo``
+    -> ``'"solc6.4"'``. Recurses into dicts only; lists and scalars are leaves.
+    """
+    flat: Dict[str, str] = {}
+
+    def walk(prefix: str, value: Any) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                walk(f"{prefix}.{key}", child)
+        else:
+            flat[prefix] = json.dumps(value, sort_keys=True, default=str)
+
+    walk("cmd", cmd)
+    walk("compilation_config", compilation_config)
+    walk("updated_config_dict", updated_config_dict)
+    return flat
+
+
+def _conf_delta(before: Dict[str, str], after: Dict[str, str]) -> Tuple[Tuple[str, str], ...]:
+    """Sorted (path, new value) for every key an apply added or changed, plus
+    (path, '<removed>') for keys it deleted.
+
+    The previous value is deliberately absent: a change is identified by what it
+    sets, so "pin Foo to solc6.4" is the same change whichever value it replaced.
+    Including the old value would make each half of an A-undoes-B cycle look new
+    forever.
+    """
+    changes = [(path, value) for path, value in after.items() if before.get(path) != value]
+    changes += [(path, "<removed>") for path in before if path not in after]
+    return tuple(sorted(changes))
+
+
 def _find_compiling_path_before(lines: List[str], idx: int, max_lookback: Optional[int] = None) -> Optional[str]:
     """Walk backward from ``lines[idx]`` to the nearest preceding plain
     ``Compiling <path>...`` line and return its path, or None if there is none.
@@ -144,6 +177,11 @@ class CompilationWorkaround:
     exclusive: bool = False
     # Catch-all: only tried when no other workaround applied in the pass.
     last_resort: bool = False
+    # The workaround's progress lives outside the conf (generated sources on disk,
+    # the contracts list), so its conf delta repeats even when it is doing new work.
+    # Exempt from the repeat-detection below; such a workaround must carry its own
+    # termination guard.
+    progress_outside_conf: bool = False
 
 
 class CompilationWorkaroundManager:
@@ -172,6 +210,10 @@ class CompilationWorkaroundManager:
         # Installed compilers usable as a substitute, probed once (shutil.which +
         # subprocess per candidate) and reused across every pass of the loop.
         self._solc_candidates: Optional[List[Tuple[str, str]]] = None
+        # (workaround name, conf delta) for every application in this run. Seeing one
+        # twice means a later workaround undid it, so the loop is circling rather than
+        # converging — see the repeat check in run_compilation_with_workarounds.
+        self._applied_changes: Set[Tuple[str, str]] = set()
         # consumer -> [(lib_name, lib_path), ...] in insertion order. A second
         # firing for the same consumer (different missing library) regenerates the
         # consumer's harness covering every library it has needed so far.
@@ -524,6 +566,11 @@ class CompilationWorkaroundManager:
                 detect_fn=lambda output: self._detect_missing_library(output, contracts),
                 apply_fn=self._apply_missing_library_harness_to_config,
                 enabled=True,
+                # Firing again for the same consumer with a different library
+                # regenerates the harness source covering every library so far —
+                # real progress, but on disk and in the contracts list, leaving the
+                # conf delta unchanged. Its own _harnessed_libs guard bounds it.
+                progress_outside_conf=True,
             ),
             # Catch-all: final attempt before setup_prover falls back to the
             # import-patch pass.
@@ -604,6 +651,9 @@ class CompilationWorkaroundManager:
             # gated on conf/manager state (e.g. _remappings_workaround_applied)
             # see the pass's own effects.
             applied_this_pass.clear()
+            repeated_this_pass: List[Tuple[str, str]] = []
+            new_this_pass: List[Tuple[str, str]] = []
+            exempt_this_pass: Set[str] = set()
             state_before = self._retry_state(cmd, compilation_config, updated_config_dict)
 
             def try_workaround(workaround: CompilationWorkaround) -> bool:
@@ -613,6 +663,7 @@ class CompilationWorkaroundManager:
                 if detect_result is None:
                     return False
                 self.log(f"Applying {workaround.name} workaround")
+                conf_before = _flatten_conf(cmd, compilation_config, updated_config_dict)
                 updated_config_dict = workaround.apply_fn(
                     detect_result,
                     updated_config_dict,
@@ -620,6 +671,14 @@ class CompilationWorkaroundManager:
                     config_file,
                     contracts,
                 )
+                if workaround.progress_outside_conf:
+                    exempt_this_pass.add(workaround.name)
+                else:
+                    delta = _conf_delta(conf_before, _flatten_conf(cmd, compilation_config, updated_config_dict))
+                    if delta:
+                        change = (workaround.name, json.dumps(delta))
+                        (repeated_this_pass if change in self._applied_changes else new_this_pass).append(change)
+                        self._applied_changes.add(change)
                 # If we disabled build_cache in config, also remove from CLI command
                 if workaround.name == "cached_autofinder_failure" and "--build_cache" in cmd:
                     cmd.remove("--build_cache")
@@ -657,6 +716,19 @@ class CompilationWorkaroundManager:
                 self.log(
                     f"Workarounds applied ({', '.join(sorted(applied_this_pass))}) but the conf "
                     f"and command are unchanged — retrying would fail identically, giving up",
+                    "ERROR",
+                )
+                self._finalize_compile_maps(compilation_config, updated_config_dict, config_file)
+                return False, output, updated_config_dict
+
+            # Every change this pass has been made before, so a later workaround has
+            # been undoing an earlier one and the loop is circling rather than
+            # converging. A pass that also lands a new change is still progressing.
+            if repeated_this_pass and not new_this_pass and not exempt_this_pass:
+                repeats = ", ".join(sorted(name for name, _ in repeated_this_pass))
+                self.log(
+                    f"Workarounds applied ({repeats}) only repeat changes already made earlier — "
+                    f"another workaround is undoing them, so retrying cannot converge, giving up",
                     "ERROR",
                 )
                 self._finalize_compile_maps(compilation_config, updated_config_dict, config_file)

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -405,6 +405,11 @@ class CompilationWorkaroundManager:
         # Rebuilt from each failed output, before the workaround table runs.
         solc_fallback_plan: Optional[SolcFallbackPlan] = None
 
+        # Scoped to this loop: a caller may run the loop again on the same manager
+        # (fixconf does, once either side of the import patch), and the second run
+        # legitimately re-applies what the first one did.
+        self._applied_changes.clear()
+
         # Initialize workarounds list
         workarounds = [
             CompilationWorkaround(
@@ -568,8 +573,11 @@ class CompilationWorkaroundManager:
                 enabled=True,
                 # Firing again for the same consumer with a different library
                 # regenerates the harness source covering every library so far —
-                # real progress, but on disk and in the contracts list, leaving the
-                # conf delta unchanged. Its own _harnessed_libs guard bounds it.
+                # real progress, but on disk and in the contracts list, so its conf
+                # delta can repeat while it is still doing new work. Bounded by
+                # max_retries: its _harnessed_libs guard is keyed on the consumer
+                # name, which this apply replaces with the harness's, so a recurring
+                # link error is looked up under a name that was never recorded.
                 progress_outside_conf=True,
             ),
             # Catch-all: final attempt before setup_prover falls back to the
@@ -633,7 +641,12 @@ class CompilationWorkaroundManager:
             # is not installed and none of the installed ones satisfy its pragma.
             # Substituting one anyway reproduces this same failure next pass, so stop
             # here and name the compiler that has to be installed.
-            solc_fallback_plan = self._plan_solc_fallback(output, updated_config_dict, contracts)
+            # Only for a pin the conf actually carries: _seed_compile_maps pins every
+            # contract to the default compiler, and refusing to proceed over a pin
+            # autosetup invented itself would fail runs the user never constrained.
+            solc_fallback_plan = (
+                self._plan_solc_fallback(output, updated_config_dict, contracts) if solc_pinned else None
+            )
             if solc_fallback_plan is not None and solc_fallback_plan.blocked:
                 self._finalize_compile_maps(compilation_config, updated_config_dict, config_file)
                 installed = ", ".join(binary for binary, _ in self._solc_fallback_candidates()) or "none"
@@ -653,7 +666,6 @@ class CompilationWorkaroundManager:
             applied_this_pass.clear()
             repeated_this_pass: List[Tuple[str, str]] = []
             new_this_pass: List[Tuple[str, str]] = []
-            exempt_this_pass: Set[str] = set()
             state_before = self._retry_state(cmd, compilation_config, updated_config_dict)
 
             def try_workaround(workaround: CompilationWorkaround) -> bool:
@@ -671,9 +683,7 @@ class CompilationWorkaroundManager:
                     config_file,
                     contracts,
                 )
-                if workaround.progress_outside_conf:
-                    exempt_this_pass.add(workaround.name)
-                else:
+                if not workaround.progress_outside_conf:
                     delta = _conf_delta(conf_before, _flatten_conf(cmd, compilation_config, updated_config_dict))
                     if delta:
                         change = (workaround.name, json.dumps(delta))
@@ -724,7 +734,7 @@ class CompilationWorkaroundManager:
             # Every change this pass has been made before, so a later workaround has
             # been undoing an earlier one and the loop is circling rather than
             # converging. A pass that also lands a new change is still progressing.
-            if repeated_this_pass and not new_this_pass and not exempt_this_pass:
+            if repeated_this_pass and not new_this_pass:
                 repeats = ", ".join(sorted(name for name, _ in repeated_this_pass))
                 self.log(
                     f"Workarounds applied ({repeats}) only repeat changes already made earlier — "
@@ -1431,12 +1441,15 @@ class CompilationWorkaroundManager:
         """
         if self._solc_candidates is None:
             candidates: List[Tuple[str, str]] = []
-            plain_version = self._get_plain_solc_version()
-            if plain_version:
-                candidates.append(("solc", plain_version))
+            # The project's own default comes first: whatever `solc` happens to be on
+            # PATH is unrelated to this project and may be years older, so it is only
+            # a last resort even when a wide pragma would accept it.
             default_version = self._extract_version_from_solc_name(self.solc_default_version)
             if default_version and shutil.which(self.solc_default_version):
                 candidates.append((self.solc_default_version, default_version))
+            plain_version = self._get_plain_solc_version()
+            if plain_version:
+                candidates.append(("solc", plain_version))
             self._solc_candidates = candidates
         return self._solc_candidates
 
@@ -1447,7 +1460,7 @@ class CompilationWorkaroundManager:
 
         A contract is rewritten only to a compiler its pragma admits. An unreadable or
         unparseable pragma is no evidence of a conflict, so those contracts take the
-        first candidate — the same substitution as before.
+        first candidate.
         """
         failed_solc = self._detect_solc_not_found(output)
         if failed_solc is None:

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -28,6 +28,8 @@ from certora_autosetup.utils.paths import user_harness_path, user_harnesses_dir
 from certora_autosetup.utils.remappings import build_packages_from_remapping_sources
 from certora_autosetup.utils.solc_version_resolver import (
     extract_pragma_spec,
+    pragma_admits,
+    read_pragma_from_source_file,
     resolve_pragma_to_version,
 )
 from certora_autosetup.utils.types import ContractHandle
@@ -36,6 +38,33 @@ from certora_autosetup.utils.types import ContractHandle
 class AbstractMainContractError(Exception):
     """Raised when the main (verify-target) contract compiled to no bytecode — it is
     abstract (or lacks a constructor) and therefore cannot be verified."""
+
+
+class UnsatisfiableSolcPinError(Exception):
+    """Raised when a contract's pinned solc binary is absent and no installed compiler
+    satisfies its pragma, so no substitution can make the project compile."""
+
+
+@dataclass(frozen=True)
+class BlockedPin:
+    """A contract whose pragma no installed compiler can satisfy."""
+
+    contract_name: str
+    pragma_spec: str
+
+
+@dataclass(frozen=True)
+class SolcFallbackPlan:
+    """Per-contract substitutions for a missing solc binary.
+
+    ``rewrites`` covers the contracts an installed compiler can serve; ``blocked``
+    the ones it cannot. A plan with any ``blocked`` entry is terminal: substituting
+    a compiler the pragma rejects would fail identically on the next compile.
+    """
+
+    failed_solc: str
+    rewrites: Dict[str, str]
+    blocked: Tuple[BlockedPin, ...]
 
 
 def _normalize_ws(text: str) -> str:
@@ -140,6 +169,9 @@ class CompilationWorkaroundManager:
         # Used as a loop guard — if the prover still reports the same pair after we
         # wrapped the consumer, the workaround stops firing to avoid spinning.
         self._harnessed_libs: Set[Tuple[str, str]] = set()
+        # Installed compilers usable as a substitute, probed once (shutil.which +
+        # subprocess per candidate) and reused across every pass of the loop.
+        self._solc_candidates: Optional[List[Tuple[str, str]]] = None
         # consumer -> [(lib_name, lib_path), ...] in insertion order. A second
         # firing for the same consumer (different missing library) regenerates the
         # consumer's harness covering every library it has needed so far.
@@ -328,6 +360,9 @@ class CompilationWorkaroundManager:
         # same (stale) output.
         applied_this_pass: Set[str] = set()
 
+        # Rebuilt from each failed output, before the workaround table runs.
+        solc_fallback_plan: Optional[SolcFallbackPlan] = None
+
         # Initialize workarounds list
         workarounds = [
             CompilationWorkaround(
@@ -346,7 +381,9 @@ class CompilationWorkaroundManager:
             ),
             CompilationWorkaround(
                 name="solc_not_found_fallback",
-                detect_fn=lambda output: self._detect_solc_not_found(output),
+                # The plan is built once per pass below, because a plan with no viable
+                # substitution is terminal and has to be acted on before this table runs.
+                detect_fn=lambda output: solc_fallback_plan if (solc_fallback_plan and solc_fallback_plan.rewrites) else None,
                 apply_fn=self._apply_solc_fallback_workaround,
                 enabled=solc_pinned,
             ),
@@ -543,6 +580,21 @@ class CompilationWorkaroundManager:
                     f"Main contract '{abstract_main_contract}' compiled to no bytecode: it is abstract "
                     f"(or is missing a constructor), so it is not deployable and cannot be "
                     f"verified. Re-run with a concrete implementation as the main contract."
+                )
+
+            # Terminal, non-recoverable case: a contract is pinned to a compiler that
+            # is not installed and none of the installed ones satisfy its pragma.
+            # Substituting one anyway reproduces this same failure next pass, so stop
+            # here and name the compiler that has to be installed.
+            solc_fallback_plan = self._plan_solc_fallback(output, updated_config_dict, contracts)
+            if solc_fallback_plan is not None and solc_fallback_plan.blocked:
+                self._finalize_compile_maps(compilation_config, updated_config_dict, config_file)
+                installed = ", ".join(binary for binary, _ in self._solc_fallback_candidates()) or "none"
+                pins = "; ".join(f"{p.contract_name} requires '{p.pragma_spec}'" for p in solc_fallback_plan.blocked)
+                raise UnsatisfiableSolcPinError(
+                    f"Compiler '{solc_fallback_plan.failed_solc}' is not installed and no installed "
+                    f"compiler satisfies the pragma of: {pins}. Installed compilers considered: "
+                    f"{installed}. Install '{solc_fallback_plan.failed_solc}' to compile this project."
                 )
 
             # One pass over the failed output: apply EVERY applicable workaround
@@ -1273,20 +1325,13 @@ class CompilationWorkaroundManager:
 
     def _apply_solc_fallback_workaround(
         self,
-        failed_solc: str,
+        plan: SolcFallbackPlan,
         updated_config_dict: Dict,
         compilation_config: Dict,
         config_file: Path,
         _contracts: List[ContractHandle],
     ) -> Dict:
-        """Fall back from a missing versioned solc binary.
-
-        Checks if plain 'solc' provides the version we need; if not, uses the
-        default versioned binary (convention-aware, e.g. solc8.34 or solc-0.8.34).
-        """
-        fallback = self._pick_solc_fallback()
-        self.log(f"Falling back from '{failed_solc}' to '{fallback}'", "WARNING")
-
+        """Substitute a missing versioned solc binary per the plan."""
         # solc is seeded into compiler_map up front (see _seed_compile_maps), so
         # rewrite the bad binary there — every entry pinned to it — rather than
         # setting the scalar solc, which can't coexist with compiler_map. A
@@ -1295,29 +1340,67 @@ class CompilationWorkaroundManager:
         # so the in-place rewrite is visible in the disk write below too — no mirroring needed.
         cmap = updated_config_dict.get("compiler_map")
         assert isinstance(cmap, dict), "compiler_map is seeded before any workaround runs"
-        for name, version in cmap.items():
-            if version == failed_solc:
-                cmap[name] = fallback
+        for name, replacement in plan.rewrites.items():
+            self.log(f"Falling back from '{plan.failed_solc}' to '{replacement}' for {name}", "WARNING")
+            cmap[name] = replacement
 
         with open(config_file, "w") as f:
             json.dump(compilation_config, f, indent=2)
 
         return updated_config_dict
 
-    def _pick_solc_fallback(self) -> str:
-        """Choose the best solc fallback: plain 'solc' if it matches the desired version, else the default."""
-        desired = self._extract_version_from_solc_name(self.solc_default_version)
-        if not desired:
-            return "solc"
+    def _solc_fallback_candidates(self) -> List[Tuple[str, str]]:
+        """Installed compilers that may stand in for a missing binary, as
+        (binary name, semantic version), best first.
 
-        plain_version = self._get_plain_solc_version()
-        if plain_version and plain_version == desired:
-            return "solc"
+        Only compilers whose version is known are offered: a substitution has to be
+        checkable against a contract's pragma, and one that cannot be checked cannot
+        be defended.
+        """
+        if self._solc_candidates is None:
+            candidates: List[Tuple[str, str]] = []
+            plain_version = self._get_plain_solc_version()
+            if plain_version:
+                candidates.append(("solc", plain_version))
+            default_version = self._extract_version_from_solc_name(self.solc_default_version)
+            if default_version and shutil.which(self.solc_default_version):
+                candidates.append((self.solc_default_version, default_version))
+            self._solc_candidates = candidates
+        return self._solc_candidates
 
-        if shutil.which(self.solc_default_version):
-            return self.solc_default_version
+    def _plan_solc_fallback(
+        self, output: str, updated_config_dict: Dict, contracts: List[ContractHandle]
+    ) -> Optional[SolcFallbackPlan]:
+        """Work out, per contract, which installed compiler may replace a missing one.
 
-        return "solc"
+        A contract is rewritten only to a compiler its pragma admits. An unreadable or
+        unparseable pragma is no evidence of a conflict, so those contracts take the
+        first candidate — the same substitution as before.
+        """
+        failed_solc = self._detect_solc_not_found(output)
+        if failed_solc is None:
+            return None
+
+        cmap = updated_config_dict.get("compiler_map") or {}
+        pinned = [name for name, version in cmap.items() if version == failed_solc]
+        pragma_by_contract = {
+            handle.contract_name: read_pragma_from_source_file(Path(handle.source_file), self.project_root)
+            for handle in contracts
+        }
+        candidates = self._solc_fallback_candidates()
+
+        rewrites: Dict[str, str] = {}
+        blocked: List[BlockedPin] = []
+        for name in pinned:
+            pragma = pragma_by_contract.get(name)
+            for binary, version in candidates:
+                if pragma is None or pragma_admits(pragma, version) is not False:
+                    rewrites[name] = binary
+                    break
+            else:
+                blocked.append(BlockedPin(contract_name=name, pragma_spec=pragma or "unknown"))
+
+        return SolcFallbackPlan(failed_solc=failed_solc, rewrites=rewrites, blocked=tuple(blocked))
 
     @staticmethod
     def _extract_version_from_solc_name(solc_name: str) -> Optional[str]:

--- a/certora_autosetup/utils/solc_version_resolver.py
+++ b/certora_autosetup/utils/solc_version_resolver.py
@@ -113,10 +113,14 @@ def parse_pragma_constraint(pragma_spec: str) -> Optional[SpecifierSet]:
     Convert pragma solidity specification to packaging.SpecifierSet.
 
     Handles:
-    - Exact version: "0.8.26" -> "==0.8.26"
+    - Exact version: "0.8.26" or "=0.8.26" -> "==0.8.26"
     - Caret: "^0.8.0" -> ">=0.8.0,<0.9.0"
+    - Tilde: "~0.8.0" -> ">=0.8.0,<0.9.0"
     - Range: ">=0.8.0 <0.8.6" -> ">=0.8.0,<0.8.6"
     - GTE/LTE: ">=0.8.0" -> ">=0.8.0"
+
+    Disjunctions ("^0.6.0 || ^0.8.0") return None: a SpecifierSet is a conjunction
+    and cannot express them.
 
     Args:
         pragma_spec: Raw pragma specification string
@@ -125,9 +129,20 @@ def parse_pragma_constraint(pragma_spec: str) -> Optional[SpecifierSet]:
         SpecifierSet object or None if parsing fails
     """
     try:
-        # Handle exact version: "0.8.26"
-        if re.match(r"^\d+\.\d+\.\d+$", pragma_spec):
-            return SpecifierSet(f"=={pragma_spec}")
+        if "||" in pragma_spec:
+            return None
+
+        # Handle exact version, with or without the explicit "=": "0.8.26", "=0.8.26"
+        if re.match(r"^=?\d+\.\d+\.\d+$", pragma_spec):
+            return SpecifierSet(f"=={pragma_spec.lstrip('=')}")
+
+        # Handle tilde: "~0.8.0" -> ">=0.8.0,<0.9.0". solc follows npm semantics,
+        # where a 0.x tilde floats the patch only.
+        tilde_match = re.match(r"^~(\d+)\.(\d+)\.(\d+)$", pragma_spec)
+        if tilde_match:
+            major, minor, patch = tilde_match.groups()
+            next_minor = int(minor) + 1
+            return SpecifierSet(f">={major}.{minor}.{patch},<{major}.{next_minor}.0")
 
         # Handle caret: "^0.8.0" -> ">=0.8.0,<0.9.0"
         caret_match = re.match(r"^\^(\d+)\.(\d+)\.(\d+)$", pragma_spec)
@@ -215,7 +230,9 @@ def read_pragma_from_source_file(source_file: Path, project_root: Optional[Path]
         source_file = project_root / source_file
     try:
         return extract_pragma_spec(source_file.read_text())
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # A source carrying non-UTF-8 bytes (an accented name in a header comment is
+        # the usual cause) reads as "pragma unknown" rather than failing the caller.
         return None
 
 

--- a/certora_autosetup/utils/solc_version_resolver.py
+++ b/certora_autosetup/utils/solc_version_resolver.py
@@ -155,6 +155,26 @@ def parse_pragma_constraint(pragma_spec: str) -> Optional[SpecifierSet]:
         return None
 
 
+def pragma_admits(pragma_spec: str, version: str) -> Optional[bool]:
+    """Whether ``version`` satisfies ``pragma_spec``.
+
+    ``None`` means the spec could not be parsed into a constraint — unknown, which
+    callers must treat as "no evidence either way" rather than as a contradiction.
+
+    Examples:
+        pragma_admits("0.6.4", "0.8.34") -> False   (exact pin, cannot be widened)
+        pragma_admits("^0.8.0", "0.8.34") -> True
+        pragma_admits("~0.6.4", "0.6.4")  -> None   (spec not understood)
+    """
+    constraint = parse_pragma_constraint(pragma_spec)
+    if constraint is None:
+        return None
+    try:
+        return Version(version) in constraint
+    except Exception:
+        return None
+
+
 def extract_pragma_spec(text: str) -> str | None:
     """
     Extract pragma solidity specification from source code or error output.

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -727,6 +727,66 @@ def test_no_installed_candidate_blocks_instead_of_guessing(
         )
 
 
+# The two halves of a real cycle. A contract is pinned to a compiler that is not
+# installed; the fallback substitutes the default one; the next compile reports the
+# pragma mismatch and pins the missing compiler again. The two fire on mutually
+# exclusive outputs, so they land in different passes and neither pass repeats its
+# own conf state — the within-pass no-op guard cannot see it.
+MISSING_PIN_OUTPUT = (
+    "attribute/flag 'compiler_map': Solidity executable solc6.4 not found in path\n"
+)
+
+PIN_DEMANDED_AGAIN_OUTPUT = (
+    "Compiling contracts/Foo.sol...\n"
+    "solc8.34 had an error:\n"
+    "contracts/Foo.sol:1:1: ParserError: Source file requires different compiler version "
+    "(current compiler is 0.8.34+commit.aaaaaaaa.Linux.g++)\n"
+    "pragma solidity 0.6.4;\n"
+)
+
+
+def test_a_change_repeated_across_passes_stops_the_loop(manager, monkeypatch, tmp_path) -> None:
+    # Foo's source is not on disk, so its pragma is unreadable and the fallback plan
+    # has no constraint to refuse on — the substitution is allowed and the cycle is
+    # reachable. This is the residual case the ledger exists for.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
+    contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    success, _, _, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [MISSING_PIN_OUTPUT, PIN_DEMANDED_AGAIN_OUTPUT] * 5,
+        contracts,
+        extra_config={"compiler_map": {"Foo": "solc6.4"}},
+    )
+    assert success is False
+    # substitute, re-pin, then the substitution repeats and the loop stops.
+    assert fake_run.calls == 3
+
+
+def test_a_new_change_alongside_a_repeat_keeps_going(manager, monkeypatch, tmp_path) -> None:
+    # A pass that re-applies a known change while also landing a new one is still
+    # converging and must not be stopped.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
+    contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    success, _, compilation_config, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [
+            MISSING_PIN_OUTPUT,
+            PIN_DEMANDED_AGAIN_OUTPUT,
+            MISSING_PIN_OUTPUT + UNNAMED_RETURN_WARNING_OUTPUT,
+            PIN_DEMANDED_AGAIN_OUTPUT,
+        ],
+        contracts,
+        extra_config={"compiler_map": {"Foo": "solc6.4"}},
+    )
+    assert success is False
+    assert fake_run.calls == 4
+    assert compilation_config.get("ignore_solidity_warnings") is True
+
+
 def test_yul_optimizer_rung_respects_project_optimize_map(
     manager, monkeypatch, tmp_path
 ) -> None:

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import pytest
 
 import certora_autosetup.utils.remappings as remappings_mod
-from certora_autosetup.utils.compilation_workarounds import CompilationWorkaroundManager
+from certora_autosetup.utils.compilation_workarounds import (
+    CompilationWorkaroundManager,
+    UnsatisfiableSolcPinError,
+)
 from certora_autosetup.utils.types import ContractHandle
 
 
@@ -603,7 +606,9 @@ def test_solc_fallback_fires_when_pin_is_in_compiler_map(
     # The pin can arrive already folded into compiler_map with no scalar "solc"
     # (precomputed from build artifacts) — the missing-binary fallback must
     # still be armed, keyed on the map contents rather than the scalar.
-    monkeypatch.setattr(manager, "_pick_solc_fallback", lambda: "solc8.30")
+    # No source file on disk here, so the pragma is unreadable and the substitution
+    # is taken on the first candidate.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.30", "0.8.30")])
     contracts = [ContractHandle(contract_name="Vault", source_file="contracts/Vault.sol")]
     success, _, compilation_config, fake_run = _run_loop(
         manager,
@@ -618,6 +623,108 @@ def test_solc_fallback_fires_when_pin_is_in_compiler_map(
     # The uniform fallback map collapses back to a scalar on exit.
     assert compilation_config["solc"] == "solc8.30"
     assert "compiler_map" not in compilation_config
+
+
+def _write_pragma(tmp_path, contract: str, pragma: str) -> ContractHandle:
+    source = tmp_path / "contracts" / f"{contract}.sol"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(f"pragma solidity {pragma};\ncontract {contract} {{}}\n")
+    return ContractHandle(contract_name=contract, source_file=f"contracts/{contract}.sol")
+
+
+def test_solc_fallback_refused_when_it_contradicts_an_exact_pragma(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # An exact pragma admits exactly one compiler. Substituting any other reproduces
+    # the same ParserError next pass, so the run stops and names what to install.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
+    contracts = [_write_pragma(tmp_path, "Vault", "0.6.4")]
+    with pytest.raises(UnsatisfiableSolcPinError) as excinfo:
+        _run_loop(
+            manager,
+            monkeypatch,
+            tmp_path,
+            [SOLC_NOT_FOUND_OUTPUT.replace("solc8.35", "solc6.4")],
+            contracts,
+            extra_config={"compiler_map": {"Vault": "solc6.4"}},
+        )
+    message = str(excinfo.value)
+    assert "Vault" in message and "0.6.4" in message and "solc6.4" in message
+
+
+def test_satisfiable_range_pragma_still_falls_back(manager, monkeypatch, tmp_path) -> None:
+    # A range pragma the installed compiler satisfies must keep substituting.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
+    contracts = [_write_pragma(tmp_path, "Vault", "^0.8.0")]
+    success, _, compilation_config, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [SOLC_NOT_FOUND_OUTPUT],
+        contracts,
+        extra_config={"compiler_map": {"Vault": "solc8.35"}},
+    )
+    assert success is True
+    assert fake_run.calls == 2
+    assert compilation_config["solc"] == "solc8.34"
+
+
+def test_unparseable_pragma_is_not_treated_as_a_contradiction(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # "~0.6.4" is not a spec the resolver understands; unknown is not a conflict.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
+    contracts = [_write_pragma(tmp_path, "Vault", "~0.6.4")]
+    success, _, compilation_config, _ = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [SOLC_NOT_FOUND_OUTPUT],
+        contracts,
+        extra_config={"compiler_map": {"Vault": "solc8.35"}},
+    )
+    assert success is True
+    assert compilation_config["solc"] == "solc8.34"
+
+
+def test_fallback_is_decided_per_contract(manager, monkeypatch, tmp_path) -> None:
+    # One contract can be served and another cannot; the blocked one is named and
+    # the satisfiable one is not blamed.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
+    contracts = [
+        _write_pragma(tmp_path, "Vault", "^0.8.0"),
+        _write_pragma(tmp_path, "Legacy", "0.6.4"),
+    ]
+    with pytest.raises(UnsatisfiableSolcPinError) as excinfo:
+        _run_loop(
+            manager,
+            monkeypatch,
+            tmp_path,
+            [SOLC_NOT_FOUND_OUTPUT],
+            contracts,
+            extra_config={"compiler_map": {"Vault": "solc8.35", "Legacy": "solc8.35"}},
+        )
+    message = str(excinfo.value)
+    assert "Legacy" in message
+    assert "Vault requires" not in message
+
+
+def test_no_installed_candidate_blocks_instead_of_guessing(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # With nothing installed there is no substitution to defend, so the run stops
+    # rather than pinning a compiler that is equally absent.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [])
+    contracts = [_write_pragma(tmp_path, "Vault", "^0.8.0")]
+    with pytest.raises(UnsatisfiableSolcPinError):
+        _run_loop(
+            manager,
+            monkeypatch,
+            tmp_path,
+            [SOLC_NOT_FOUND_OUTPUT],
+            contracts,
+            extra_config={"compiler_map": {"Vault": "solc8.35"}},
+        )
 
 
 def test_yul_optimizer_rung_respects_project_optimize_map(

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -672,9 +672,10 @@ def test_satisfiable_range_pragma_still_falls_back(manager, monkeypatch, tmp_pat
 def test_unparseable_pragma_is_not_treated_as_a_contradiction(
     manager, monkeypatch, tmp_path
 ) -> None:
-    # "~0.6.4" is not a spec the resolver understands; unknown is not a conflict.
+    # A disjunction cannot be expressed as one SpecifierSet, so the resolver returns
+    # no constraint. Unknown is not a conflict, and the substitution proceeds.
     monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
-    contracts = [_write_pragma(tmp_path, "Vault", "~0.6.4")]
+    contracts = [_write_pragma(tmp_path, "Vault", "^0.6.0 || ^0.7.0")]
     success, _, compilation_config, _ = _run_loop(
         manager,
         monkeypatch,
@@ -707,6 +708,101 @@ def test_fallback_is_decided_per_contract(manager, monkeypatch, tmp_path) -> Non
     message = str(excinfo.value)
     assert "Legacy" in message
     assert "Vault requires" not in message
+
+
+def test_project_default_is_preferred_over_whatever_solc_is_on_path(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # A wide pragma admits both, and plain `solc` may be any unrelated version the
+    # machine happens to carry, so the project's own default wins.
+    monkeypatch.setattr(manager, "_get_plain_solc_version", lambda: "0.5.16")
+    monkeypatch.setattr(
+        "certora_autosetup.utils.compilation_workarounds.shutil.which", lambda _: "/usr/bin/solc8.34"
+    )
+    monkeypatch.setattr(manager, "solc_default_version", "solc8.34")
+    contracts = [_write_pragma(tmp_path, "Vault", ">=0.4.22 <0.9.0")]
+    success, _, compilation_config, _ = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [SOLC_NOT_FOUND_OUTPUT],
+        contracts,
+        extra_config={"compiler_map": {"Vault": "solc8.35"}},
+    )
+    assert success is True
+    assert compilation_config["solc"] == "solc8.34"
+
+
+def test_candidates_fall_through_to_the_next_when_the_pragma_rejects_the_first(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # Per-contract selection walks the candidate list rather than taking the head.
+    monkeypatch.setattr(
+        manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34"), ("solc6.12", "0.6.12")]
+    )
+    contracts = [_write_pragma(tmp_path, "Legacy", "^0.6.0")]
+    success, _, compilation_config, _ = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [SOLC_NOT_FOUND_OUTPUT],
+        contracts,
+        extra_config={"compiler_map": {"Legacy": "solc8.35"}},
+    )
+    assert success is True
+    assert compilation_config["solc"] == "solc6.12"
+
+
+def test_a_source_that_is_not_utf8_reads_as_an_unknown_pragma(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # An accented byte in a header comment must not abort the loop.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
+    source = tmp_path / "contracts" / "Vault.sol"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(b"// auteur: Fran\xe7ois\npragma solidity 0.6.4;\ncontract Vault {}\n")
+    contracts = [ContractHandle(contract_name="Vault", source_file="contracts/Vault.sol")]
+    success, _, compilation_config, _ = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [SOLC_NOT_FOUND_OUTPUT],
+        contracts,
+        extra_config={"compiler_map": {"Vault": "solc8.35"}},
+    )
+    assert success is True
+    assert compilation_config["solc"] == "solc8.34"
+
+
+def test_a_pin_autosetup_seeded_itself_is_not_terminal(manager, monkeypatch, tmp_path) -> None:
+    # With no pin in the conf the seeding assigns the default compiler; refusing to
+    # proceed over that would fail a run the user never constrained.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [])
+    contracts = [_write_pragma(tmp_path, "Vault", "0.6.4")]
+    success, _, _, _ = _run_loop(
+        manager, monkeypatch, tmp_path, [SOLC_NOT_FOUND_OUTPUT] * 4, contracts
+    )
+    assert success is False
+
+
+def test_the_ledger_is_scoped_to_one_loop_not_to_the_manager(
+    manager, monkeypatch, tmp_path
+) -> None:
+    # fixconf runs the loop twice on one manager, either side of the import patch;
+    # the second run must be free to re-apply what the first one did.
+    monkeypatch.setattr(manager, "_solc_fallback_candidates", lambda: [("solc8.34", "0.8.34")])
+    contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    for _ in range(2):
+        success, _, _, fake_run = _run_loop(
+            manager,
+            monkeypatch,
+            tmp_path,
+            [MISSING_PIN_OUTPUT, PIN_DEMANDED_AGAIN_OUTPUT] * 5,
+            contracts,
+            extra_config={"compiler_map": {"Foo": "solc6.4"}},
+        )
+        assert success is False
+        assert fake_run.calls == 3
 
 
 def test_no_installed_candidate_blocks_instead_of_guessing(

--- a/tests/test_solc_version_resolver.py
+++ b/tests/test_solc_version_resolver.py
@@ -45,3 +45,18 @@ def test_exact_pragma_ignores_installed_state(monkeypatch) -> None:
 def test_preferred_version_still_wins(monkeypatch) -> None:
     _with_installed(monkeypatch, {"solc8.35"})
     assert svr.resolve_pragma_to_version("^0.8.0", preferred_version="solc8.28") == "0.8.28"
+
+
+def test_pragma_admits_reports_true_false_or_unknown() -> None:
+    # An exact pin admits only itself, whichever way it is spelled.
+    assert svr.pragma_admits("0.6.4", "0.6.4") is True
+    assert svr.pragma_admits("0.6.4", "0.8.34") is False
+    assert svr.pragma_admits("=0.6.4", "0.8.34") is False
+    # Ranges admit what they cover.
+    assert svr.pragma_admits("^0.8.0", "0.8.34") is True
+    assert svr.pragma_admits("~0.6.4", "0.6.12") is True
+    assert svr.pragma_admits("~0.6.4", "0.7.0") is False
+    assert svr.pragma_admits(">=0.4.22 <0.9.0", "0.5.16") is True
+    # A disjunction is not expressible as one SpecifierSet, so it is unknown rather
+    # than a contradiction — callers must not read None as "rejected".
+    assert svr.pragma_admits("^0.6.0 || ^0.8.0", "0.8.34") is None


### PR DESCRIPTION
Mirror of #134 onto the `dev` bleeding-edge branch.

Source branch: `shelly/workaround-loop-convergence`. This branch is that head merged forward with `dev`; #134 itself is untouched and still targets `master`.

Per the `dev` branch policy this merges without review once `pyright` and `pytest` are green.