### PR TITLE
[DEV] autosetup: detect the via-ir-required family by its remediation hint

### DIFF
--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -76,6 +76,28 @@ def _path_from_source_location_line(line: str) -> Optional[str]:
     return match.group("path") if match else None
 
 
+# The remediation hint solc attaches to every diagnostic whose fix is "compile this
+# with the IR pipeline", whatever the diagnostic itself is called: the flag spelling
+# (``--via-ir``), the Standard-JSON key (``viaIR: true``), or a mention of the pipeline
+# by name ("via-ir pipeline", "IR pipeline"). Keying on the hint rather than on one
+# diagnostic's wording covers the whole family.
+#
+# Written against whitespace-normalized text (see ``_normalize_ws``); ``-\s?`` absorbs a
+# solc hard-wrap inside a hyphenated token (``--via-\nir`` normalizes to ``--via- ir``).
+# The conf key ``solc_via_ir`` is deliberately outside the family — it appears in the
+# "unsupported solc version for solc_via_ir" error, which calls for the opposite fix —
+# so every alternative demands either the ``--`` flag spelling, the JSON key with its
+# colon, or the word "pipeline".
+_VIA_IR_HINT_RE = re.compile(
+    r"--\s?via-\s?ir\b|viaIR:\s?true|(?:via-\s?ir|IR)\s+pipeline",
+    re.IGNORECASE,
+)
+
+# Lines joined before matching ``_VIA_IR_HINT_RE`` against a window of the raw output:
+# enough to reassemble a hint solc wrapped across two breaks.
+_VIA_IR_HINT_WRAP_LINES = 3
+
+
 def _find_compiling_path_before(lines: List[str], idx: int, max_lookback: Optional[int] = None) -> Optional[str]:
     """Walk backward from ``lines[idx]`` to the nearest preceding plain
     ``Compiling <path>...`` line and return its path, or None if there is none.
@@ -773,17 +795,19 @@ class CompilationWorkaroundManager:
         the affected contract name.
 
         Contracts start on plain settings and gain via-ir strictly out of
-        necessity; this is the necessity signal for non-stack reasons, e.g.
-        "UnimplementedFeatureError: Require with a custom error is only
-        available using the via-ir pipeline." Matching is whitespace-normalized
-        per compiled unit, since solc hard-wraps the phrase.
+        necessity; this is the necessity signal for non-stack reasons. solc
+        spells the diagnostic several ways ("Require with a custom error is
+        only available using the via-ir pipeline.", "Copying of type ... to
+        storage is not supported in legacy (only supported by the IR
+        pipeline)."), so the detector keys on the remediation hint they share
+        (``_VIA_IR_HINT_RE``). Matching is whitespace-normalized per compiled
+        unit, since solc hard-wraps the text.
         """
-        marker = "only available using the via-ir pipeline"
         current_path: Optional[str] = None
         segment: List[str] = []
 
         def segment_hit() -> Optional[str]:
-            if current_path and marker in _normalize_ws("\n".join(segment)):
+            if current_path and _VIA_IR_HINT_RE.search(_normalize_ws("\n".join(segment))):
                 return self._get_contract_name_from_path(current_path, contracts)
             return None
 
@@ -801,7 +825,30 @@ class CompilationWorkaroundManager:
         hit = segment_hit()
         if hit:
             self.log(f"Detected via-ir-only feature for {hit} (path: {current_path})")
-        return hit
+            return hit
+
+        # Whole-project compile: certoraRun prints no per-file "Compiling <path>..."
+        # progress line, so no segment carries a path and the offending file is named
+        # only in the `-->` source-location line under the diagnostic. Runs last so a
+        # per-unit hit takes precedence. The hint itself may be wrapped, so it is
+        # matched over a small window of consecutive lines normalized together.
+        lines = output.split("\n")
+        for i in range(len(lines)):
+            window = _normalize_ws("\n".join(lines[i:i + _VIA_IR_HINT_WRAP_LINES]))
+            if not _VIA_IR_HINT_RE.search(window):
+                continue
+            for j in range(i + 1, min(i + 6, len(lines))):
+                src_path = _path_from_source_location_line(lines[j])
+                if src_path is None:
+                    continue
+                contract_name = self._get_contract_name_from_path(src_path, contracts)
+                if contract_name:
+                    self.log(f"Detected via-ir-only feature for {contract_name} (path: {src_path})")
+                    return contract_name
+                self.log(f"Warning: Could not map path '{src_path}' to contract name", "WARNING")
+                break
+
+        return None
 
     def _detect_yul_exception_stack_too_deep(self, output: str) -> bool:
         """Detect YulException with stack too deep error.

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -76,26 +76,38 @@ def _path_from_source_location_line(line: str) -> Optional[str]:
     return match.group("path") if match else None
 
 
-# The remediation hint solc attaches to every diagnostic whose fix is "compile this
-# with the IR pipeline", whatever the diagnostic itself is called: the flag spelling
-# (``--via-ir``), the Standard-JSON key (``viaIR: true``), or a mention of the pipeline
-# by name ("via-ir pipeline", "IR pipeline"). Keying on the hint rather than on one
-# diagnostic's wording covers the whole family.
+# The remediation hint solc attaches to a diagnostic whose fix is "compile this with the
+# IR pipeline", whatever the diagnostic itself is called: the flag spelling (``--via-ir``),
+# the Standard-JSON key (``viaIR: true``), or a mention of the pipeline by name ("via-ir
+# pipeline", "IR pipeline"). Keying on the hint rather than on one diagnostic's wording
+# covers the whole family.
 #
 # Written against whitespace-normalized text (see ``_normalize_ws``); ``-\s?`` absorbs a
 # solc hard-wrap inside a hyphenated token (``--via-\nir`` normalizes to ``--via- ir``).
-# The conf key ``solc_via_ir`` is deliberately outside the family — it appears in the
-# "unsupported solc version for solc_via_ir" error, which calls for the opposite fix —
-# so every alternative demands either the ``--`` flag spelling, the JSON key with its
-# colon, or the word "pipeline".
+# The conf key ``solc_via_ir`` is outside the family — it appears in the "unsupported solc
+# version for solc_via_ir" error, which calls for the opposite fix — so every alternative
+# demands either the ``--`` flag spelling, the JSON key with its colon, or the word
+# "pipeline". ``\bIR`` keeps prose like "through their pipeline" out.
 _VIA_IR_HINT_RE = re.compile(
-    r"--\s?via-\s?ir\b|viaIR:\s?true|(?:via-\s?ir|IR)\s+pipeline",
+    r"--\s?via-\s?ir\b|viaIR:\s?true|(?:\bvia-\s?ir|\bIR)\s+pipeline",
     re.IGNORECASE,
 )
 
-# Lines joined before matching ``_VIA_IR_HINT_RE`` against a window of the raw output:
-# enough to reassemble a hint solc wrapped across two breaks.
-_VIA_IR_HINT_WRAP_LINES = 3
+# Diagnostics that carry the same hint while via-ir is only ONE of the remedies solc
+# offers ("... while enabling the optimizer. Otherwise, try removing local variables"),
+# so the hint does not mean via-ir is required. Their escalation ladder — optimizer,
+# solc's default Yul steps, then relaxing the autofinder assertion — belongs to
+# stack_too_deep_via_ir and the yul_exception_* workarounds.
+_MULTI_REMEDY_DIAGNOSTIC_RE = re.compile(
+    r"YulException|Stack\s+too\s+deep|too\s+deep\s+in(?:side)?\s+the\s+stack",
+    re.IGNORECASE,
+)
+
+# The label opening a solc diagnostic ("Warning: ...", "TypeError: ...",
+# "UnimplementedFeatureError: ...", "YulException: ..."). It delimits one diagnostic from
+# the next, so a hint is read together with the diagnostic that owns it — and only with
+# that diagnostic's own source locations.
+_DIAGNOSTIC_START_RE = re.compile(r"^\s*(?:[A-Za-z]*Error|Warning|Info|Note|YulException)\b")
 
 
 def _find_compiling_path_before(lines: List[str], idx: int, max_lookback: Optional[int] = None) -> Optional[str]:
@@ -795,23 +807,45 @@ class CompilationWorkaroundManager:
         the affected contract name.
 
         Contracts start on plain settings and gain via-ir strictly out of
-        necessity; this is the necessity signal for non-stack reasons. solc
-        spells the diagnostic several ways ("Require with a custom error is
-        only available using the via-ir pipeline.", "Copying of type ... to
-        storage is not supported in legacy (only supported by the IR
-        pipeline)."), so the detector keys on the remediation hint they share
-        (``_VIA_IR_HINT_RE``). Matching is whitespace-normalized per compiled
-        unit, since solc hard-wraps the text.
+        necessity. solc spells this necessity several ways ("Require with a
+        custom error is only available using the via-ir pipeline.", "Copying of
+        type ... to storage is not supported in legacy (only supported by the
+        IR pipeline)."), so the detector keys on the remediation hint they share
+        (``_VIA_IR_HINT_RE``) rather than on one diagnostic's wording.
+
+        The hint alone is not the signal: solc appends it to stack-too-deep and
+        YulException diagnostics too, where via-ir is one remedy among several
+        and the optimizer/Yul ladder must be climbed first. A hint therefore
+        counts only inside a diagnostic that offers no other remedy
+        (``_MULTI_REMEDY_DIAGNOSTIC_RE``). Matching is whitespace-normalized per
+        diagnostic, since solc hard-wraps the text.
         """
+        lines = output.split("\n")
+
+        def diagnostic_blocks(unit_lines: List[str]) -> List[List[str]]:
+            """Split solc output into one group of lines per diagnostic, so a hint,
+            the diagnostic offering it and its source locations stay together and a
+            neighbouring diagnostic's ``-->`` lines stay out."""
+            blocks: List[List[str]] = [[]]
+            for line in unit_lines:
+                if _DIAGNOSTIC_START_RE.match(line) or _path_from_compiling_line(line) is not None:
+                    blocks.append([])
+                blocks[-1].append(line)
+            return blocks
+
+        def requires_via_ir(block: List[str]) -> bool:
+            normalized = _normalize_ws("\n".join(block))
+            return bool(_VIA_IR_HINT_RE.search(normalized)) and not _MULTI_REMEDY_DIAGNOSTIC_RE.search(normalized)
+
         current_path: Optional[str] = None
         segment: List[str] = []
 
         def segment_hit() -> Optional[str]:
-            if current_path and _VIA_IR_HINT_RE.search(_normalize_ws("\n".join(segment))):
+            if current_path and any(requires_via_ir(b) for b in diagnostic_blocks(segment)):
                 return self._get_contract_name_from_path(current_path, contracts)
             return None
 
-        for line in output.split("\n"):
+        for line in lines:
             path = _path_from_compiling_line(line)
             if path is not None and "to expose internal function information" not in line:
                 hit = segment_hit()
@@ -829,16 +863,13 @@ class CompilationWorkaroundManager:
 
         # Whole-project compile: certoraRun prints no per-file "Compiling <path>..."
         # progress line, so no segment carries a path and the offending file is named
-        # only in the `-->` source-location line under the diagnostic. Runs last so a
-        # per-unit hit takes precedence. The hint itself may be wrapped, so it is
-        # matched over a small window of consecutive lines normalized together.
-        lines = output.split("\n")
-        for i in range(len(lines)):
-            window = _normalize_ws("\n".join(lines[i:i + _VIA_IR_HINT_WRAP_LINES]))
-            if not _VIA_IR_HINT_RE.search(window):
+        # only in the `-->` source-location lines of the diagnostic itself. Runs last so
+        # a per-unit hit takes precedence.
+        for block in diagnostic_blocks(lines):
+            if not requires_via_ir(block):
                 continue
-            for j in range(i + 1, min(i + 6, len(lines))):
-                src_path = _path_from_source_location_line(lines[j])
+            for line in block:
+                src_path = _path_from_source_location_line(line)
                 if src_path is None:
                     continue
                 contract_name = self._get_contract_name_from_path(src_path, contracts)

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -369,6 +369,60 @@ def test_via_ir_added_out_of_necessity(manager, monkeypatch, tmp_path) -> None:
     assert updated["solc_via_ir"] is True
 
 
+# A second solc phrasing for the same condition — legacy codegen cannot do this copy,
+# the IR pipeline can — reported by a whole-project compile: no "Compiling <path>..."
+# progress line, so the file is named only in the `-->` source-location line. solc
+# hard-wraps both the "IR pipeline" phrase and the `--via-ir` flag token itself.
+BULK_VIA_IR_LEGACY_COPY = (
+    "solc8.28 had an error:\n"
+    "UnimplementedFeatureError: Copying of type struct Vault.RateTier memory[] memory \n"
+    "to storage is not supported in legacy (only supported by the IR \n"
+    "pipeline). Hint: try compiling with `--via-\n"
+    "ir` (CLI) or the equivalent `viaIR: true` (Standard JSON)\n"
+    "   --> contracts/Vault.sol:120:9:\n"
+)
+
+# The error calling for the OPPOSITE fix (turn via-ir OFF for an old compiler). It
+# names the conf key solc_via_ir, which must stay outside the via-ir-required family.
+UNSUPPORTED_SOLC_VIA_IR_OUTPUT = (
+    "Compiling contracts/Foo.sol...\n"
+    "Unsupported solc version 0.7.6 for solc_via_ir, please use 0.8.13 or later\n"
+)
+
+# A per-unit error: the "Compiling <path>..." line names Foo while the `-->` names an
+# unrelated inlined file.
+COMPILING_LINE_VIA_IR_REQUIRED = (
+    "Compiling contracts/Foo.sol...\n"
+    "solc8.26 had an error:\n"
+    "UnimplementedFeatureError: Require with a custom error is only available using \n"
+    "the via-ir pipeline.\n"
+    "   --> lib/somewhere/Inlined.sol:10:5:\n"
+)
+
+
+def test_detects_bulk_via_ir_required_via_source_location(manager) -> None:
+    # Whole-project compile: the affected file comes from `--> <path>:line:col`, and the
+    # wrapped `--via-\nir` hint must still be recognized.
+    contracts = [ContractHandle(contract_name="Vault", source_file="contracts/Vault.sol")]
+    assert manager._detect_via_ir_required(BULK_VIA_IR_LEGACY_COPY, contracts) == "Vault"
+
+
+def test_unsupported_solc_via_ir_is_not_via_ir_required(manager) -> None:
+    # Enabling via-ir here would fight the workaround that must disable it.
+    contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    assert manager._detect_via_ir_required(UNSUPPORTED_SOLC_VIA_IR_OUTPUT, contracts) is None
+
+
+def test_via_ir_compiling_line_takes_precedence_over_source_location(manager) -> None:
+    # The compiled unit is what needs via-ir; the inlined file in the `-->` line is a
+    # scene contract too, so only precedence decides the answer.
+    contracts = [
+        ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol"),
+        ContractHandle(contract_name="Inlined", source_file="lib/somewhere/Inlined.sol"),
+    ]
+    assert manager._detect_via_ir_required(COMPILING_LINE_VIA_IR_REQUIRED, contracts) == "Foo"
+
+
 def test_yul_last_resort_keeps_compile_settings(manager, monkeypatch, tmp_path) -> None:
     # Pass 1 carries a plain stack-too-deep for Foo AND a YulException with the
     # optimizer already present (e.g. supplied by the project's foundry config):

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -400,6 +400,54 @@ COMPILING_LINE_VIA_IR_REQUIRED = (
 )
 
 
+# Whole-project compile where an unrelated Warning with its own source location follows
+# the via-ir diagnostic, which names no file of its own.
+BULK_VIA_IR_FOLLOWED_BY_FOREIGN_WARNING = (
+    "solc8.28 had an error:\n"
+    "UnimplementedFeatureError: Copying of type struct Vault.RateTier memory[] memory \n"
+    "to storage is not supported in legacy (only supported by the IR pipeline).\n"
+    "Warning: Unused function parameter. Remove or comment out the variable name.\n"
+    "   --> lib/oz/ERC20.sol:80:5:\n"
+)
+
+# Each of the three hint spellings on its own, so no single fixture can cover for a
+# broken alternative. The diagnostic wording is the same in all three and mentions
+# neither the pipeline nor the flag.
+VIA_IR_HINT_FLAG_ONLY = (
+    "Compiling contracts/Foo.sol...\n"
+    "solc8.26 had an error:\n"
+    "UnimplementedFeatureError: This feature is not supported by the legacy code \n"
+    "generator. Hint: try compiling with `--via-ir` (CLI).\n"
+)
+
+# The flag token itself split by solc's hard wrap.
+VIA_IR_HINT_FLAG_WRAPPED = (
+    "Compiling contracts/Foo.sol...\n"
+    "solc8.26 had an error:\n"
+    "UnimplementedFeatureError: This feature is not supported by the legacy code \n"
+    "generator. Hint: try compiling with `--via-\n"
+    "ir` (CLI).\n"
+)
+
+VIA_IR_HINT_JSON_KEY_ONLY = (
+    "Compiling contracts/Foo.sol...\n"
+    "solc8.26 had an error:\n"
+    "UnimplementedFeatureError: This feature is not supported by the legacy code \n"
+    "generator. Hint: set `viaIR: true` (Standard JSON).\n"
+)
+
+# A diagnostic whose quoted source line happens to talk about a pipeline: prose in the
+# user's code, not a solc remediation hint.
+TYPE_ERROR_WITH_PIPELINE_PROSE = (
+    "Compiling contracts/Foo.sol...\n"
+    "solc8.26 had an error:\n"
+    'TypeError: Member "route" not found or not visible after argument-dependent lookup.\n'
+    "   --> contracts/Foo.sol:42:9:\n"
+    "    |\n"
+    " 42 |         router.route(amount); // route through their pipeline\n"
+)
+
+
 def test_detects_bulk_via_ir_required_via_source_location(manager) -> None:
     # Whole-project compile: the affected file comes from `--> <path>:line:col`, and the
     # wrapped `--via-\nir` hint must still be recognized.
@@ -421,6 +469,49 @@ def test_via_ir_compiling_line_takes_precedence_over_source_location(manager) ->
         ContractHandle(contract_name="Inlined", source_file="lib/somewhere/Inlined.sol"),
     ]
     assert manager._detect_via_ir_required(COMPILING_LINE_VIA_IR_REQUIRED, contracts) == "Foo"
+
+
+def test_via_ir_fallback_ignores_another_diagnostics_source_location(manager) -> None:
+    # The `-->` belongs to the Warning below, not to the via-ir diagnostic — enabling
+    # via-ir for that file would fix nothing and change an unrelated contract's build.
+    contracts = [ContractHandle(contract_name="ERC20", source_file="lib/oz/ERC20.sol")]
+    assert (
+        manager._detect_via_ir_required(BULK_VIA_IR_FOLLOWED_BY_FOREIGN_WARNING, contracts) is None
+    )
+
+
+@pytest.mark.parametrize(
+    "output",
+    [VIA_IR_HINT_FLAG_ONLY, VIA_IR_HINT_FLAG_WRAPPED, VIA_IR_HINT_JSON_KEY_ONLY],
+    ids=["flag", "flag-wrapped", "json-key"],
+)
+def test_each_hint_spelling_detected_on_its_own(manager, output: str) -> None:
+    # One spelling per fixture: a broken alternative cannot hide behind another one
+    # matching first.
+    contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    assert manager._detect_via_ir_required(output, contracts) == "Foo"
+
+
+def test_pipeline_prose_in_source_line_is_not_a_hint(manager) -> None:
+    contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    assert manager._detect_via_ir_required(TYPE_ERROR_WITH_PIPELINE_PROSE, contracts) is None
+
+
+def test_stack_too_deep_hint_is_not_via_ir_required(manager) -> None:
+    # solc appends the same via-ir hint to every stack-too-deep / YulException
+    # diagnostic, where via-ir is one remedy among several. Those must stay with
+    # stack_too_deep_via_ir and the yul rungs, which climb the optimizer ladder first.
+    foo = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    harness = [
+        ContractHandle(
+            contract_name="LMPStrategyInstance1",
+            source_file="certora/harnesses/LMPStrategyInstance1.sol",
+        )
+    ]
+    assert manager._detect_via_ir_required(WRAPPED_YUL_STACK_TOO_DEEP, harness) is None
+    assert manager._detect_via_ir_required(SINGLE_LINE_YUL_STACK_TOO_DEEP, foo) is None
+    assert manager._detect_via_ir_required(PERSISTENT_STACK_TOO_DEEP_OUTPUT, foo) is None
+    assert manager._detect_via_ir_required(BULK_STACK_TOO_DEEP, foo) is None
 
 
 def test_yul_last_resort_keeps_compile_settings(manager, monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Mirror of #135 onto the `dev` bleeding-edge branch.

Source branch: `shelly/via-ir-detect-family`. This branch is that head merged forward with `dev`; #135 itself is untouched and still targets `master`.

Per the `dev` branch policy this merges without review once `pyright` and `pytest` are green.