### PR TITLE
Fix the stuck-rule nag detector crashing every stuck prover run

### DIFF
--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -15,7 +15,8 @@ import time
 from contextlib import contextmanager, asynccontextmanager, ExitStack, nullcontext
 from pathlib import Path
 from typing import (
-    Annotated, AsyncIterator, Callable, Iterator, override, AsyncContextManager, Sequence, Literal
+    Annotated, AsyncIterator, Callable, Container, Iterator, Mapping, override,
+    AsyncContextManager, Sequence, Literal
 )
 from typing_extensions import TypedDict, NotRequired
 
@@ -110,6 +111,69 @@ class NagMarker(TypedDict):
     sort: Literal["nag"]
 
 type ProverHistoryItem = Annotated[ProverRunLog | NagMarker, Discriminator("sort")]
+
+#: How many consecutive runs must end in the identical failure before the author is nagged
+#: about a rule. Counts the run being processed, so 3 means "this run plus the two before it".
+STUCK_RULE_NAG_THRESHOLD = 3
+
+
+def stuck_rule_warnings(
+    # Values are compared for equality only, so the looser ``str`` keeps callers free of
+    # the narrowing dance ``StatusCodes`` would otherwise force on a filtered comprehension.
+    stuck_rules: Mapping["RulePath", str],
+    prover_history: list[ProverHistoryItem],
+    known_tool_call_ids: Container[str | None],
+) -> tuple[set["RulePath"], bool]:
+    """Decide which of the currently-stuck rules the author should be nagged about.
+
+    Walks ``prover_history`` backwards counting, per stuck rule, how many *consecutive*
+    recent runs ended in the identical failure — each rule starts at 1 for the run being
+    processed. A rule leaves the tally as soon as a run breaks its streak (it either
+    passed, failed differently, or the tally is exhausted); reaching
+    :data:`STUCK_RULE_NAG_THRESHOLD` moves it to the returned warning set. A run that
+    targeted an explicit rule subset is transparent to rules it never exercised, so a
+    narrowly-scoped re-run neither extends nor breaks another rule's streak.
+
+    A ``nag`` marker means those rules were warned about already, so their streaks restart
+    there and the author isn't nagged twice for the same stretch of failures.
+
+    Returns the rules to warn about, plus whether any inspected run predates the author's
+    most recent history compaction (its tool call is no longer in ``known_tool_call_ids``)
+    — the caller footnotes the warning with that, since those runs are no longer visible
+    in the conversation.
+    """
+    stuck_count = {k: 1 for k in stuck_rules}
+    to_warn: set[RulePath] = set()
+    seen_post_compaction_history = False
+
+    history_ind = len(prover_history) - 1
+    while history_ind >= 0 and len(stuck_count) > 0:
+        it = prover_history[history_ind]
+        history_ind -= 1
+        if it["sort"] == "nag":
+            for r in it["nagged_rules"]:
+                # A previously-nagged rule need not be stuck now — drop it if present.
+                stuck_count.pop(r, None)
+            continue
+        assert it["sort"] == "run"
+        if it["tool_call_id"] not in known_tool_call_ids:
+            seen_post_compaction_history = True
+        target_rules = set(it["rules"]) if it["rules"] else None
+        # Snapshot the keys: the body deletes from ``stuck_count`` as streaks end.
+        for k in list(stuck_count.keys()):
+            if target_rules is not None and k.rule not in target_rules:
+                continue
+            if not any(
+                rp == k and stuck_rules[k] == stat for (rp, stat) in it["prover_results"]
+            ):
+                del stuck_count[k]
+            else:
+                stuck_count[k] += 1
+                if stuck_count[k] == STUCK_RULE_NAG_THRESHOLD:
+                    to_warn.add(k)
+                    del stuck_count[k]
+    return to_warn, seen_post_compaction_history
+
 
 def last_prover_run(
     l: list[ProverHistoryItem]
@@ -429,44 +493,15 @@ def get_prover_tool(
                 k: v for (k,v) in result.raw_rule_status.items() if v in ("TIMEOUT", "ERROR", "SANITY_FAILED") and k.rule not in state["rule_skips"]
             }
 
-            stuck_count = {
-                k: 1 for k in stuck_rules.keys()
-            }
-
-            to_warn : set[RulePath] = set()
-
             known_tc_ids = {
                 l["id"]
                 for msg in state["messages"] if isinstance(msg, AIMessage)
                 for l in msg.tool_calls if l["name"] == "verify_spec"
             }
 
-            seen_post_compaction_history = False
-
-            history_ind = len(state["prover_history"]) - 1
-            while history_ind >= 0 and len(stuck_count) > 0:
-                it = state["prover_history"][history_ind]
-                if it["sort"] == "nag":
-                    for r in it["nagged_rules"]:
-                        del stuck_count[r]
-                    history_ind -= 1
-                    continue
-                assert it["sort"] == "run"
-                if it["tool_call_id"] not in known_tc_ids:
-                    seen_post_compaction_history = True
-                target_rules = set(it["rules"]) if it["rules"] else None
-                for k in stuck_count.keys():
-                    if target_rules is not None and k.rule not in target_rules:
-                        continue
-                    if not any(
-                        rp == k and stuck_rules[k] == stat for (rp, stat) in it["prover_results"]
-                    ):
-                        del stuck_count[k]
-                    else:
-                        stuck_count[k] += 1
-                        if stuck_count[k] == 3:
-                            to_warn.add(k)
-                            del stuck_count[k]
+            to_warn, seen_post_compaction_history = stuck_rule_warnings(
+                stuck_rules, state["prover_history"], known_tc_ids
+            )
             
             prover_update : list[ProverHistoryItem] = [
                 ProverRunLog(

--- a/tests/test_stuck_rule_warnings.py
+++ b/tests/test_stuck_rule_warnings.py
@@ -1,0 +1,126 @@
+"""Regression tests for :func:`stuck_rule_warnings` — the prover author's "you have been
+stuck on this rule for three runs" detector.
+
+The loop this covers used to be inline in ``verify_spec`` and carried three defects:
+
+1. it iterated ``stuck_count.keys()`` while deleting from it, so any run that broke a
+   rule's streak crashed the whole CVL-generation task with ``RuntimeError: dictionary
+   changed size during iteration``;
+2. it never advanced the history index on the ``run`` branch, so it re-counted the *same*
+   prover run until the threshold tripped — every first stuck run nagged as though it had
+   already failed identically three times;
+3. it did ``del stuck_count[r]`` for previously-nagged rules, which ``KeyError``s whenever
+   a rule that was nagged before isn't stuck now.
+"""
+
+from composer.prover.ptypes import RulePath
+from composer.spec.source.prover import (
+    NagMarker, ProverHistoryItem, ProverRunLog, STUCK_RULE_NAG_THRESHOLD,
+    stuck_rule_warnings,
+)
+
+R1 = RulePath(rule="r1")
+R2 = RulePath(rule="r2")
+
+
+def _run(*results: tuple[RulePath, str], tc_id: str = "tc", rules: list[str] | None = None) -> ProverHistoryItem:
+    return ProverRunLog(
+        tool_call_id=tc_id,
+        prover_results=list(results),  # type: ignore[arg-type]
+        rules=rules,
+        spec_digest="d",
+        sort="run",
+    )
+
+
+def _warn(stuck, history, known=("tc",)):
+    return stuck_rule_warnings(stuck, history, set(known))
+
+
+def test_threshold_counts_the_current_run_plus_two_priors() -> None:
+    # Defect 2: a single stuck run must NOT nag. The tally starts at 1 for the run being
+    # processed, so it takes two prior identical failures to reach the threshold.
+    assert STUCK_RULE_NAG_THRESHOLD == 3
+
+    stuck = {R1: "TIMEOUT"}
+    assert _warn(stuck, [])[0] == set()
+    assert _warn(stuck, [_run((R1, "TIMEOUT"))])[0] == set()
+    assert _warn(stuck, [_run((R1, "TIMEOUT")), _run((R1, "TIMEOUT"))])[0] == {R1}
+
+
+def test_a_broken_streak_drops_the_rule() -> None:
+    # Defect 1: this is the shape that used to raise RuntimeError — a rule leaves the
+    # tally mid-iteration because an earlier run did not fail identically.
+    stuck = {R1: "TIMEOUT"}
+    history = [
+        _run((R1, "VIOLATED")),   # oldest: different status, breaks the streak
+        _run((R1, "TIMEOUT")),
+    ]
+    assert _warn(stuck, history)[0] == set()
+
+    # A differing status anywhere in the walk-back stops the count, even with plenty of
+    # older identical failures behind it.
+    history = [
+        _run((R1, "TIMEOUT")), _run((R1, "TIMEOUT")), _run((R1, "TIMEOUT")),
+        _run((R1, "VIOLATED")),
+        _run((R1, "TIMEOUT")),
+    ]
+    assert _warn(stuck, history)[0] == set()
+
+
+def test_rules_are_tallied_independently() -> None:
+    # Exercises the delete-during-iteration path with a survivor alongside it.
+    stuck = {R1: "TIMEOUT", R2: "ERROR"}
+    history = [
+        _run((R1, "TIMEOUT"), (R2, "VIOLATED")),
+        _run((R1, "TIMEOUT"), (R2, "ERROR")),
+    ]
+    assert _warn(stuck, history)[0] == {R1}
+
+
+def test_targeted_runs_are_transparent_to_untouched_rules() -> None:
+    # A re-run scoped to r2 neither extends nor breaks r1's streak.
+    stuck = {R1: "TIMEOUT"}
+    history = [
+        _run((R1, "TIMEOUT")),
+        _run((R2, "ERROR"), rules=["r2"]),
+        _run((R1, "TIMEOUT")),
+    ]
+    assert _warn(stuck, history)[0] == {R1}
+
+
+def test_nag_marker_restarts_the_streak() -> None:
+    stuck = {R1: "TIMEOUT"}
+    history = [
+        _run((R1, "TIMEOUT")),
+        _run((R1, "TIMEOUT")),
+        NagMarker(nagged_rules=[R1], sort="nag"),
+        _run((R1, "TIMEOUT")),
+    ]
+    # Without the marker this would be four identical failures; the marker means R1 was
+    # already warned about, so the author isn't nagged again for the same stretch.
+    assert _warn(stuck, history)[0] == set()
+
+
+def test_nag_marker_for_a_rule_that_is_no_longer_stuck() -> None:
+    # Defect 3: R2 was nagged previously but only R1 is stuck now — must not KeyError.
+    stuck = {R1: "TIMEOUT"}
+    history = [
+        _run((R1, "TIMEOUT")),
+        NagMarker(nagged_rules=[R2], sort="nag"),
+        _run((R1, "TIMEOUT")),
+    ]
+    assert _warn(stuck, history)[0] == {R1}
+
+
+def test_reports_history_older_than_the_last_compaction() -> None:
+    stuck = {R1: "TIMEOUT"}
+    visible = [_run((R1, "TIMEOUT"), tc_id="tc"), _run((R1, "TIMEOUT"), tc_id="tc")]
+    assert _warn(stuck, visible, known=("tc",)) == ({R1}, False)
+
+    compacted = [_run((R1, "TIMEOUT"), tc_id="gone"), _run((R1, "TIMEOUT"), tc_id="tc")]
+    assert _warn(stuck, compacted, known=("tc",)) == ({R1}, True)
+
+
+def test_no_stuck_rules_is_a_no_op() -> None:
+    assert _warn({}, [_run((R1, "TIMEOUT"))]) == (set(), False)


### PR DESCRIPTION
The loop in `verify_spec` that decides whether to warn the author "this rule has failed identically 3 runs in a row" carried three defects since it landed:

1. it iterated `stuck_count.keys()` while deleting from it, raising `RuntimeError: dictionary changed size during iteration`;
2. it never decremented `history_ind` on the `run` branch, so it re-counted the *same* prover run instead of walking back through history;
3. `del stuck_count[r]` for previously-nagged rules `KeyError`s when a rule that was nagged earlier is not stuck now.

1 and 2 compound. The tally starts at 1 for the current run, the same run is counted repeatedly, and on the third pass the rule trips the threshold and is deleted mid-iteration — so *any* rule coming back TIMEOUT/ERROR/SANITY_FAILED crashed the whole CVL-generation task on its first occurrence. The detector could never have fired as intended.

Lift the loop out of the closure into a module-level `stuck_rule_warnings` (it was already a pure function of the history) and fix all three: iterate a key snapshot, advance the index once per item, `pop(r, None)` for nagged rules. Behaviour is otherwise as originally intended — 3 consecutive identical failures, nag markers restart the streak, rule-scoped re-runs stay transparent to rules they did not exercise.