### PR TITLE
Key families

### DIFF
--- a/composer/cli/cache_autoprove.py
+++ b/composer/cli/cache_autoprove.py
@@ -36,43 +36,38 @@ from composer.ui.cache_explorer import (
 )
 from composer.spec.context import WorkflowContext, CVLGeneration, CVLJudge, CacheKey
 from composer.spec.source.harness import (
-    config_key,
-    system_setup_key,
-    harness_generation_key,
-    HARNESS_ANALYSIS_KEY,
     ContractSetup,
     SystemDescriptionHarnessed,
     AgentSystemDescription,
     HarnessResult,
 )
 from composer.pipeline.cli import root_cache_key, user_ns
-from composer.pipeline.core import (
-    COMMON_SYSTEM_CACHE_KEY, PROPERTIES_KEY,
-    _component_cache_key, _batch_cache_key, _pre_property_cache_key,
+from composer.pipeline.keys import (
+    AGENT_RESULT_KEY, AGENT_ROUND_KEY, BUG_ANALYSIS_KEY,
+    COMMON_SYSTEM_CACHE_KEY, COMPONENT_KEY, FORMALIZATION_KEY,
+    PRE_PROPERTY_KEY, PROPERTIES_KEY, SYSTEM_ANALYSIS_KEY,
 )
 from composer.pipeline.plugins import applicable_plugin_manifest, manifest_digest
 from composer.pipeline.run_tags import AutoProveCacheTags, CACHE_ROOT_RECORD
 from composer.core.user import get_uid
 from composer.workflow.services import store_context
 from composer.io.run_index import get_run_data
-from composer.spec.source.summarizer import _summary_key, _SummaryCache
-from composer.spec.source.struct_invariant import STRUCTURAL_INV_KEY, Invariants
-from composer.spec.source.pipeline import INV_CVL_KEY, AP_PROPERTIES_KEY_NAME
+from composer.spec.source.keys import (
+    AP_PROPERTIES_KEY_NAME, CVL_JUDGE_KEY, HARNESS_ANALYSIS_KEY,
+    HARNESS_GENERATION_KEY, INV_CVL_KEY, LAST_ATTEMPT_KEY, STRUCTURAL_INV_KEY,
+    SUMMARY_KEY, SYSTEM_SETUP_KEY, config_key,
+)
+from composer.spec.source.summarizer import _SummaryCache
+from composer.spec.source.struct_invariant import Invariants
 from composer.spec.prop_inference import (
     _BugAnalysisCache, _AgentResult, _AgentRoundWithHistory,
-    bug_analysis_key_from_digest, agent_round_key, AGENT_RESULT_KEY,
 )
-from composer.spec.cvl_generation import GeneratedCVL, _LastAttemptCache, LAST_ATTEMPT_KEY, CVL_JUDGE_KEY
+from composer.spec.cvl_generation import GeneratedCVL, _LastAttemptCache
 from composer.spec.system_model import (
     SourceApplication, SourceExplicitContract, SourceExternalActor,
     HarnessedApplication, HarnessedExplicitContract, HarnessDefinition,
     ContractInstance, ContractComponentInstance,
 )
-
-
-# The driver writes the analyzed SourceApplication under CacheKey(COMMON_SYSTEM_CACHE_KEY)
-# (pipeline.core.run_pipeline); mirror that key here to read it back.
-SYSTEM_ANALYSIS_KEY = CacheKey[None, SourceApplication](COMMON_SYSTEM_CACHE_KEY)
 
 
 # ---------------------------------------------------------------------------
@@ -179,14 +174,14 @@ async def _resolve_bug_key(
     written before the ``interactive`` tag existed leave it ``None``, in
     which case probe both variants and use whichever was written."""
     if tags.interactive is not None:
-        return bug_analysis_key_from_digest(
+        return BUG_ANALYSIS_KEY(
             tags.threat_model_digest, with_refinement=tags.interactive,
         )
     for refine in (False, True):
-        candidate = bug_analysis_key_from_digest(tags.threat_model_digest, refine)
+        candidate = BUG_ANALYSIS_KEY(tags.threat_model_digest, refine)
         if await feat_ctx.child(candidate).cache_get(_BugAnalysisCache) is not None:
             return candidate
-    return bug_analysis_key_from_digest(tags.threat_model_digest, with_refinement=False)
+    return BUG_ANALYSIS_KEY(tags.threat_model_digest, with_refinement=False)
 
 
 async def _build_cvl_gen_nodes(
@@ -202,13 +197,13 @@ async def _build_component_nodes(
     store: BaseStore,
     tags: AutoProveCacheTags,
 ) -> AsyncGenerator[CacheTreeNode[AutoProveCachedValue], None]:
-    comp_key = _component_cache_key(feat, manifest_digest(tags.plugins))
+    comp_key = COMPONENT_KEY(feat, manifest_digest(tags.plugins))
     async with node_for(prop_ctx, comp_key, feat.component.name) as feat_ctx:
         # Per-plugin pre-inference namespaces are siblings of the component
         # key under PROPERTIES_KEY, but they're per-component work — surface
         # them inside the component's subtree.
         for plugin in tags.plugins:
-            pre_ctx = prop_ctx.child(_pre_property_cache_key(feat, plugin))
+            pre_ctx = prop_ctx.child(PRE_PROPERTY_KEY(feat, plugin))
             with node(CacheNode(label=f"Plugin pre-inference: {plugin}", ctx=pre_ctx)):
                 async for n in _enumerate_raw_subtree(store, pre_ctx):
                     yield n
@@ -222,7 +217,7 @@ async def _build_component_nodes(
                 i = 0
                 while True:
                     round_node = await leaf(
-                        agent_ctx, agent_round_key(i),
+                        agent_ctx, AGENT_ROUND_KEY(i),
                         f"Round {i + 1}", _AgentRoundWithHistory,
                     )
                     if round_node.value is None:
@@ -233,7 +228,7 @@ async def _build_component_nodes(
         bug_cache = await feat_ctx.child(bug_key).cache_get(_BugAnalysisCache)
         if bug_cache is None:
             return
-        batch_key = _batch_cache_key(bug_cache.items)
+        batch_key = FORMALIZATION_KEY(GeneratedCVL, bug_cache.items)
         async with node_for(feat_ctx, batch_key, "CVL Generation", GeneratedCVL) as cvl_ctx:
             async for n in _build_cvl_gen_nodes(cvl_ctx.abstract(CVLGeneration)):
                 yield n
@@ -244,7 +239,11 @@ async def build_tree_inner(
     store: BaseStore,
     tags: AutoProveCacheTags,
 ) -> AsyncGenerator[CacheTreeNode[AutoProveCachedValue], None]:
-    sa_leaf = await leaf(root_ctx, SYSTEM_ANALYSIS_KEY, "system-analysis", SourceApplication)
+    sa_leaf = await leaf(
+        root_ctx,
+        SYSTEM_ANALYSIS_KEY(SourceApplication, COMMON_SYSTEM_CACHE_KEY),
+        "system-analysis", SourceApplication,
+    )
     yield sa_leaf
 
     # Read config value upfront so we can derive the summary key outside the with block
@@ -252,20 +251,20 @@ async def build_tree_inner(
 
     async with node_for(root_ctx, config_key, "config", ContractSetup) as config_ctx:
         if sa_leaf.value is not None:
-            async with node_for(config_ctx, system_setup_key(sa_leaf.value), "setup", SystemDescriptionHarnessed) as setup_ctx:
+            async with node_for(config_ctx, SYSTEM_SETUP_KEY(sa_leaf.value), "setup", SystemDescriptionHarnessed) as setup_ctx:
                 ha_leaf = await leaf(setup_ctx, HARNESS_ANALYSIS_KEY, "harness-analysis", AgentSystemDescription)
                 yield ha_leaf
                 if ha_leaf.value is not None and ha_leaf.value.needs_harnessing():
                     yield await leaf(
                         setup_ctx,
-                        harness_generation_key(ha_leaf.value),
+                        HARNESS_GENERATION_KEY(ha_leaf.value),
                         "harness-generation",
                         HarnessResult,
                     )
 
     # Summary — key derivable only once ContractSetup is cached
     if config_val is not None:
-        yield await leaf(root_ctx, _summary_key(config_val), "summary", _SummaryCache)
+        yield await leaf(root_ctx, SUMMARY_KEY(config_val), "summary", _SummaryCache)
 
     yield await leaf(root_ctx, STRUCTURAL_INV_KEY, "structural-inv", Invariants)
     async with node_for(root_ctx, INV_CVL_KEY, "invariant-cvl", GeneratedCVL) as inv_cvl_ctx:

--- a/composer/cli/cache_natspec.py
+++ b/composer/cli/cache_natspec.py
@@ -42,7 +42,7 @@ from composer.spec.natspec.models import (
 )
 from composer.spec.prop_inference import (
     _BugAnalysisCache, _AgentResult, _AgentRoundWithHistory,
-    bug_analysis_key, AGENT_RESULT_KEY, agent_round_key,
+    BUG_ANALYSIS_KEY, AGENT_RESULT_KEY, AGENT_ROUND_KEY,
 )
 from composer.spec.cvl_generation import (
     _LastAttemptCache, CVL_JUDGE_KEY, LAST_ATTEMPT_KEY,
@@ -145,7 +145,7 @@ async def build_component_tree(
     async with node_for(contract_ctx, key, comp.name) as feat_ctx:
         # Bug analysis cache: aggregate (_BugAnalysisCache.items) → agent
         # result (_AgentResult) → per-round (_AgentRoundWithHistory).
-        bug_key = bug_analysis_key(None, with_refinement=with_refinement)
+        bug_key = BUG_ANALYSIS_KEY(None, with_refinement=with_refinement)
         async with node_for(feat_ctx, bug_key, "Bug Analysis", _BugAnalysisCache) as bug_ctx:
             async with node_for(
                 bug_ctx, AGENT_RESULT_KEY, "Agent result", _AgentResult,
@@ -155,7 +155,7 @@ async def build_component_tree(
                 i = 0
                 while True:
                     round_node = await leaf(
-                        agent_ctx, agent_round_key(i),
+                        agent_ctx, AGENT_ROUND_KEY(i),
                         f"Round {i + 1}", _AgentRoundWithHistory,
                     )
                     if round_node.value is None:

--- a/composer/foundry/pipeline.py
+++ b/composer/foundry/pipeline.py
@@ -33,10 +33,10 @@ from composer.pipeline.core import (
     Formalizer, PreparedSystem, PipelineRun,
     GaveUp, SystemAnalysisSpec,
     CorePhases, CorePipelineResult,
-    COMMON_SYSTEM_CACHE_KEY
 )
 from composer.pipeline.ptypes import Curtailed
 from composer.pipeline.ecosystem import main_instance
+from composer.pipeline.keys import COMMON_SYSTEM_CACHE_KEY
 from composer.foundry.artifacts import FoundryTestArtifact
 from composer.spec.source.report.collect import Formalized, Verdict
 from composer.spec.context import (

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -30,10 +30,10 @@ from contextlib import nullcontext
 from composer.io.multi_job import TaskInfo
 from composer.spec.artifacts import ArtifactStore
 from composer.spec.context import (
-    WorkflowContext, CacheKey, Properties, ComponentGroup, SourceCode
+    WorkflowContext, ComponentGroup
 )
 from composer.spec.system_model import (
-    BaseApplication, ContractComponentInstance, FeatureUnit
+    BaseApplication, FeatureUnit
 )
 from composer.spec.types import PropertyFormulation, ArtifactIdentifier
 from composer.spec.system_analysis import run_component_analysis
@@ -41,7 +41,6 @@ from composer.spec.prop_inference import (
     run_property_inference, AnyPropertyGenerationInput, CacheablePropertyGenerationInput,
 )
 from composer.llm.types import CacheLevel
-from composer.spec.util import string_hash
 from composer.input.files import Document
 from composer.spec.source.report.build import build_report
 from composer.spec.source.report.collect import ReportComponentInput, Verdict, EvidenceFetcher, Formalized
@@ -53,13 +52,17 @@ from composer.spec.source.task_ids import SYSTEM_ANALYSIS_TASK_ID, REPORT_TASK_I
 from composer.pipeline.ecosystem import Ecosystem
 from .ptypes import (
     BackendJob, BackendResult, ComponentOutcome, CorePhases, CorePipelineResult, Delivered, GaveUp,
+    FinalProperties,
     PipelineRun, SystemAnalysisSpec, RunBudget, Curtailed
+)
+from .keys import (
+    COMPONENT_KEY, FINAL_PROPERTIES_KEY, FORMALIZATION_KEY,
+    POST_PROPERTY_KEY, PRE_PROPERTY_KEY, PROPERTIES_KEY, SYSTEM_ANALYSIS_KEY,
 )
 from composer.diagnostics.budget import total_budget, named_budget_or_nop, time_budget
 from .plugin_api import PrePropertyInference, PostPropertyInference
 from .plugins import load_plugins, PluginManager, PluginPhaseManager, PluginPhaseRunner
 
-COMMON_SYSTEM_CACHE_KEY = "system-analysis"
 
 _log = logging.getLogger(__name__)
 
@@ -186,31 +189,10 @@ class PipelineBackend[P: enum.Enum, FormT: BackendResult, H, A: ArtifactIdentifi
     def to_artifact_id(self, c: U) -> A: ...
 
 
-# ---- shared helpers (the de-duplicated cache keys + batch) -------------------
-def PROPERTIES_KEY(nm: str):
-    return CacheKey[None, Properties](nm)
-
-
+# ---- the per-unit batch -------------------------------------------------------
 @dataclass
 class _Batch[U: FeatureUnit](BackendJob[U]):
     feat_ctx: WorkflowContext[ComponentGroup]
-
-def _component_digest(c: FeatureUnit) -> str:
-    # ``cache_material`` is the ecosystem-agnostic view of what identifies a unit; EVM's
-    # implementation reproduces the previous inline key (app JSON | ind | contract ind) exactly.
-    return string_hash(c.cache_material())
-
-def _component_cache_key(c: FeatureUnit, plugin_digest: str | None) -> CacheKey[Properties, ComponentGroup]:
-    raw_digest = _component_digest(c)
-    if plugin_digest is not None:
-        raw_digest += f"-{plugin_digest}"
-    return CacheKey(raw_digest)
-
-
-def _batch_cache_key[FormT: BackendResult](
-    props: list[PropertyFormulation],
-) -> CacheKey[ComponentGroup, FormT]:  # pyright: ignore[reportInvalidTypeVarUse]
-    return CacheKey(string_hash("|".join(p.model_dump_json() for p in props)))
 
 
 def extract_task_id(idx: int) -> str:
@@ -293,7 +275,8 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
         analyzed = await run.runner(
             TaskInfo(SYSTEM_ANALYSIS_TASK_ID, "System Analysis", phases["analysis"]),
             lambda: run_component_analysis(
-                ty=ecosystem.system_model, child_ctxt=run.ctx.child(CacheKey(spec.analysis_key)),
+                ty=ecosystem.system_model,
+                child_ctxt=run.ctx.child(SYSTEM_ANALYSIS_KEY(ecosystem.system_model, spec.analysis_key)),
                 input=source, env=run.env,
                 extra_input=[*ecosystem.analysis_extra_input(source), *spec.extra_input],
                 expected_main_id=source.contract_name,
@@ -349,8 +332,21 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
     async def _run(batch: _Batch[U]) -> ComponentOutcome[FormT, U]:
         result_key = backend.to_artifact_id(batch.feat)
         backend.artifact_store.write_properties(result_key, batch.props)
+
+        # Record the formalization edge's exact derivation inputs — the final
+        # (post-plugin) batch and the gated plugin ids — as a first-class cache
+        # entry, keyed like the bug analysis (the component namespace is shared
+        # across runs). Offline walkers reconstruct the edge from this instead
+        # of sniffing the store.
+        await batch.feat_ctx.child(
+            FINAL_PROPERTIES_KEY(
+                threat_model.to_digest() if threat_model is not None else None,
+                interactive,
+            )
+        ).cache_put(FinalProperties(items=batch.props))
+
         child : WorkflowContext[FormT] = await batch.feat_ctx.child(
-            _batch_cache_key(batch.props),
+            FORMALIZATION_KEY(formalizer.formalized_type, batch.props),
             {"properties": [p.model_dump() for p in batch.props]},
         )
         cached_result: FormT | None = await child.cache_get(formalizer.formalized_type)
@@ -366,6 +362,15 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                     ),
                     lambda: formalizer.formalize(label, batch.feat, batch.props, child, run),
                 )
+            # Snapshot what the tools registered: a cache replay of this
+            # formalization never runs the tools, so the artifacts must ride
+            # the cache alongside the result they accompany.
+            if not isinstance(result, GaveUp):
+                # A curtailed partial is never the
+                # component's cached result — a later run redoes the
+                # formalization under a fresh budget.
+                if not isinstance(result, Curtailed):
+                    await child.cache_put(result)
         else:
             result = cached_result
 
@@ -428,17 +433,6 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
 
     return _tally(outcomes)
 
-def _pre_property_cache_key(feat: FeatureUnit, plugin: str) -> CacheKey[Properties, PrePropertyInference]:
-    key = f"{_component_digest(feat)}-{string_hash(plugin)}-pre"
-    return CacheKey(key)
-
-def _post_property_cache_key(feat: FeatureUnit, plugin: str, curr_props: list[PropertyFormulation]) -> CacheKey[Properties, PostPropertyInference]:
-    props = string_hash("|".join(
-        p.model_dump_json() for p in curr_props
-    ))
-    key = f"{_component_digest(feat)}-{string_hash(plugin)}-{props}"
-    return CacheKey(key)
-
 async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
     prop_key: str,
     main: Main, backend_guidance: str, run: PipelineRun[P, H],
@@ -453,7 +447,7 @@ async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
     async def _pre_plugin_inputs(feat: U) -> list[AnyPropertyGenerationInput]:
         async def run_one(runner: PluginPhaseRunner[P, U]) -> AnyPropertyGenerationInput | None:
             ctxt = await prop_ctx.child(
-                _pre_property_cache_key(feat, runner.plugin_id), {"plugin-name": runner.plugin_id}
+                PRE_PROPERTY_KEY(feat, runner.plugin_id), {"plugin-name": runner.plugin_id}
             )
             return await runner.plugin.property_inference_input_hook(
                 feat, runner.bind(str(feat.unit_index), ctxt)
@@ -474,7 +468,7 @@ async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
             sub_phase_id="post-inference", sub_phase_label="Property Post-Process", sorted_run=True
         ):
             ctxt = await prop_ctx.child(
-                _post_property_cache_key(feat, runner.plugin_id, accum),
+                POST_PROPERTY_KEY(feat, runner.plugin_id, accum),
                 {
                     "plugin-name": runner.plugin_id,
                     "props": [p.model_dump() for p in accum],
@@ -505,7 +499,7 @@ async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
             ]
 
         feat_ctx = await prop_ctx.child(
-            _component_cache_key(feat, plugins.plugin_digest),
+            COMPONENT_KEY(feat, plugins.plugin_digest),
             {**feat.context_tag(), "plugins": plugins.plugin_manifest},
         )
         props = await run.runner(

--- a/composer/pipeline/keys.py
+++ b/composer/pipeline/keys.py
@@ -1,0 +1,134 @@
+"""The Auto-Prove driver's cache tree, declared in one place.
+
+Every edge the backend-agnostic driver (``composer.pipeline.core``)
+traverses below the run root, in tree order::
+
+    run root  (``composer.pipeline.cli``: ``user_ns(cache_ns, root_cache_key(...))``)
+    ├── {analysis key}                         SYSTEM_ANALYSIS_KEY  → ecosystem App model
+    └── {properties key}                       PROPERTIES_KEY       → Properties
+        ├── {unit digest}[-{plugin digest}]    COMPONENT_KEY        → ComponentGroup
+        │   ├── bug_analysis[|refine][-tm-…]   BUG_ANALYSIS_KEY     → _BugAnalysisCache
+        │   │   └── agent_bug_analysis         AGENT_RESULT_KEY     → _AgentResult
+        │   │       └── round-{i}              AGENT_ROUND_KEY      → _AgentRoundWithHistory
+        │   ├── final_props[|refine][-tm-…]    FINAL_PROPERTIES_KEY → FinalProperties
+        │   └── {props digest}                 FORMALIZATION_KEY    → backend result (FormT)
+        │       └── plugin-artifacts           PLUGIN_ARTIFACTS_KEY → RegisteredArtifacts
+        ├── {unit digest}-{plugin}-pre         PRE_PROPERTY_KEY     → PrePropertyInference
+        └── {unit digest}-{plugin}-{props}     POST_PROPERTY_KEY    → PostPropertyInference
+
+The extraction-layer families (bug analysis, agent rounds) are declared
+in ``composer.spec.prop_inference`` beside their cache models and
+re-exported here. The prover backend's sub-chain (config / harness /
+autosetup / summaries / invariants / CVL generation) has its own
+registry: ``composer.spec.source.keys``.
+"""
+
+from typing import Any
+
+from composer.pipeline.ptypes import FinalProperties
+from composer.spec.context import ComponentGroup, Properties
+from composer.spec.key_family import KeyFamily, PolyKeyFamily
+from composer.spec.prop_inference import (
+    AGENT_RESULT_KEY, AGENT_ROUND_KEY, BUG_ANALYSIS_KEY,
+)
+from composer.spec.system_model import FeatureUnit
+from composer.spec.types import PropertyFormulation
+from composer.spec.util import string_hash
+
+from .plugin_api import PostPropertyInference, PrePropertyInference
+
+__all__ = [
+    "AGENT_RESULT_KEY",
+    "AGENT_ROUND_KEY",
+    "BUG_ANALYSIS_KEY",
+    "COMMON_SYSTEM_CACHE_KEY",
+    "COMPONENT_KEY",
+    "FINAL_PROPERTIES_KEY",
+    "FORMALIZATION_KEY",
+    "POST_PROPERTY_KEY",
+    "PRE_PROPERTY_KEY",
+    "PROPERTIES_KEY",
+    "SYSTEM_ANALYSIS_KEY",
+    "component_digest",
+]
+
+#: The analysis-slot name both current backends declare in their
+#: ``SystemAnalysisSpec``.
+COMMON_SYSTEM_CACHE_KEY = "system-analysis"
+
+
+def _slot_name(name: str) -> str:
+    return name
+
+
+def component_digest(c: FeatureUnit) -> str:
+    """``cache_material`` is the ecosystem-agnostic view of what identifies a
+    unit; EVM's implementation reproduces the previous inline key
+    (app JSON | ind | contract ind) exactly."""
+    return string_hash(c.cache_material())
+
+
+def _props_digest(props: list[PropertyFormulation]) -> str:
+    return string_hash("|".join(p.model_dump_json() for p in props))
+
+
+#: System analysis, keyed by the backend's declared slot name
+#: (``SystemAnalysisSpec.analysis_key``). The child is the ecosystem's
+#: analyzed model — pass ``ecosystem.system_model``.
+SYSTEM_ANALYSIS_KEY = PolyKeyFamily(type(None), _slot_name)
+
+#: The per-backend properties subtree root
+#: (``SystemAnalysisSpec.properties_key``).
+PROPERTIES_KEY = KeyFamily(type(None), Properties, _slot_name)
+
+
+def _component_key(feat: FeatureUnit, plugin_digest: str | None) -> str:
+    raw_digest = component_digest(feat)
+    if plugin_digest is not None:
+        raw_digest += f"-{plugin_digest}"
+    return raw_digest
+
+#: One unit's extraction subtree; the whole subtree moves when the active
+#: plugin set changes (``plugins.manifest_digest``).
+COMPONENT_KEY = KeyFamily(Properties, ComponentGroup, _component_key)
+
+def _final_properties_key(threat_model_digest: str | None, with_refinement: bool) -> str:
+    # Parameterized exactly like BUG_ANALYSIS_KEY: the component namespace is
+    # shared across runs, so the entry must be keyed by what distinguishes one
+    # run's extraction from another's — a single fixed leaf would be
+    # last-write-wins across divergent runs.
+    base_key = "final_props"
+    if with_refinement:
+        base_key += "|refine"
+    if threat_model_digest is None:
+        return base_key
+    return base_key + "-tm-" + threat_model_digest
+
+#: The property batch as it left the property pipeline (post-inference plugin
+#: rewrites applied) plus the tool-contributing plugin ids — the exact
+#: derivation inputs of the FORMALIZATION_KEY sibling. Written by the driver;
+#: read by offline walkers (``composer.meta.run``) to reconstruct that edge.
+FINAL_PROPERTIES_KEY = KeyFamily(ComponentGroup, FinalProperties, _final_properties_key)
+
+#: One unit's formalization result, keyed by the exact property batch. The
+#: child is the backend's result type — pass ``formalizer.formalized_type``.
+FORMALIZATION_KEY = PolyKeyFamily(ComponentGroup, _props_digest)
+
+
+def _pre_property_key(feat: FeatureUnit, plugin: str) -> str:
+    return f"{component_digest(feat)}-{string_hash(plugin)}-pre"
+
+#: A plugin's private pre-inference namespace: sibling of the unit's
+#: COMPONENT_KEY subtree, one per (unit, plugin).
+PRE_PROPERTY_KEY = KeyFamily(Properties, PrePropertyInference, _pre_property_key)
+
+
+def _post_property_key(
+    feat: FeatureUnit, plugin: str, curr_props: list[PropertyFormulation]
+) -> str:
+    return f"{component_digest(feat)}-{string_hash(plugin)}-{_props_digest(curr_props)}"
+
+#: A plugin's post-inference namespace, additionally keyed by the property
+#: list entering the hook (each plugin in the post chain sees — and is keyed
+#: by — its predecessor's output).
+POST_PROPERTY_KEY = KeyFamily(Properties, PostPropertyInference, _post_property_key)

--- a/composer/pipeline/ptypes.py
+++ b/composer/pipeline/ptypes.py
@@ -80,6 +80,16 @@ class BackendJob[U: FeatureUnit]:
     feat: U
     props: list[PropertyFormulation]
 
+class FinalProperties(BaseModel):
+    """A component's property batch as it left the property pipeline — after
+    every post-inference plugin rewrite. This is exactly the input
+    ``FORMALIZATION_KEY`` is derived from, so an offline walker
+    can reconstruct the formalization edge without
+    sniffing the store. Written by the driver at formalization time; the
+    pre-rewrite batch remains ``_BugAnalysisCache``."""
+    items: list[PropertyFormulation]
+
+
 @dataclass(frozen=True)
 class Delivered[FormT: BackendResult]:
     """A formalization result and the project-relative path it was persisted to. The path exists

--- a/composer/spec/key_family.py
+++ b/composer/spec/key_family.py
@@ -1,0 +1,87 @@
+"""Declared cache-key derivation rules.
+
+``WorkflowContext.child`` walks the cache tree one typed edge at a time:
+a ``CacheKey[Parent, Child]`` names the child slot and carries the
+(phantom) evidence that the transition is legal. The key *strings*,
+though, were historically minted by ad-hoc helpers — file-local
+functions gluing digests together with f-strings, each returning a bare
+``CacheKey(...)`` whose type arguments were whatever the annotation
+happened to claim. Nothing tied a derivation rule to the edge it
+produces, and consumers that re-derive keys (the cache explorers) had
+to import private helpers from whichever module each rule happened to
+live in.
+
+A :class:`KeyFamily` makes the rule the declared object: one value
+pinning the parent type, the child type, and the derivation from the
+parameters that identify a member of the family. Calling the family is
+the only way to mint that edge's key, so every producer and every
+explorer agree on the string and the types by construction.
+
+Conventions:
+
+- Families are declared next to their cache models (usually the module
+  of the producing agent) and named ``*_KEY``, like the constant
+  ``CacheKey`` slots they generalize.
+- Each application gathers its families into a registry module —
+  ``composer.pipeline.keys`` for the Auto-Prove driver chain,
+  ``composer.spec.source.keys`` for the prover backend's sub-chain — so
+  one file shows the whole cache tree. Registries import producers,
+  never the reverse.
+"""
+
+from dataclasses import dataclass
+from typing import Callable
+
+from composer.spec.context import CacheKey
+
+
+@dataclass(frozen=True)
+class KeyFamily[Parent, Child, **P]:
+    """The derivation rule for a ``Parent → Child`` cache edge.
+
+    ``parent`` / ``child`` are runtime witnesses that bind the type
+    parameters (``CacheKey``'s are phantom, so nothing else could);
+    ``derive`` maps the values identifying one member of the family to
+    its key string. Calling the family yields the typed key::
+
+        AUTOSETUP_KEY = KeyFamily(ContractSetup, SetupSuccess, _autosetup_key)
+        ...
+        ctx.child(AUTOSETUP_KEY(app, prover_opts))
+
+    A fixed edge (no parameters) is just a ``CacheKey`` constant; declare
+    a family only when there is something to derive.
+    """
+
+    parent: type[Parent]
+    child: type[Child]
+    derive: Callable[P, str]
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> CacheKey[Parent, Child]:
+        return CacheKey(self.derive(*args, **kwargs))
+
+
+@dataclass(frozen=True)
+class PolyKeyFamily[Parent, **P]:
+    """A :class:`KeyFamily` whose child type is a call-site parameter.
+
+    For the edges the driver traverses generically — the formalization
+    result is the *backend's* result type, the analyzed system model is
+    the *ecosystem's* — no static declaration can name the child. The
+    caller passes the child's runtime witness instead, which is exactly
+    what those call sites already hold (``formalizer.formalized_type``,
+    ``ecosystem.system_model``), and inference does the rest — no
+    ``CacheKey[...]`` respelling, no annotation-steered inference of an
+    unparameterized call::
+
+        child_ctx = await ctx.child(
+            FORMALIZATION_KEY(formalizer.formalized_type, batch.props)
+        )
+    """
+
+    parent: type[Parent]
+    derive: Callable[P, str]
+
+    def __call__[Child](
+        self, child: type[Child], /, *args: P.args, **kwargs: P.kwargs
+    ) -> CacheKey[Parent, Child]:
+        return CacheKey(self.derive(*args, **kwargs))

--- a/composer/spec/prop_inference.py
+++ b/composer/spec/prop_inference.py
@@ -17,6 +17,7 @@ from composer.input.files import Document
 from composer.llm.types import CacheLevel
 from composer.spec.gen_types import TypedTemplate
 from composer.spec.context import WorkflowContext, CacheKey, ComponentGroup
+from composer.spec.key_family import KeyFamily
 from composer.spec.gen_types import TypedTemplate
 from composer.spec.graph_builder import bind_standard, run_to_completion
 from composer.spec.types import PropertyFormulation
@@ -111,33 +112,28 @@ def render_evm_property_prompt(
 class _AgentRoundWithHistory(_AgentRoundResult):
     agent_conversation: list[AnyMessage]
 
-def bug_analysis_key_from_digest(
+def _bug_analysis_key(
     threat_model_digest: str | None,
     with_refinement: bool
-) -> CacheKey[ComponentGroup, _BugAnalysisCache]:
+) -> str:
     base_key = "bug_analysis"
     if with_refinement:
         base_key += "|refine"
     if threat_model_digest is None:
-        return CacheKey[ComponentGroup, _BugAnalysisCache](base_key)
-    return CacheKey[ComponentGroup, _BugAnalysisCache](base_key + "-tm-" + threat_model_digest)
+        return base_key
+    return base_key + "-tm-" + threat_model_digest
 
-def bug_analysis_key(
-    threat_model: Document | None,
-    with_refinement: bool
-) -> CacheKey[ComponentGroup, _BugAnalysisCache]:
-    return bug_analysis_key_from_digest(
-        threat_model.to_digest() if threat_model is not None else None,
-        with_refinement,
-    )
+#: Parameterized on the threat model's *digest* (not the document) so a
+#: recorded digest — e.g. from a run's cache tags — can rebuild the key.
+BUG_ANALYSIS_KEY = KeyFamily(ComponentGroup, _BugAnalysisCache, _bug_analysis_key)
 
 class _AgentResult(_BugAnalysisCache):
     final_history: list[AnyMessage]
 
-def agent_round_key(
-    i: int
-) -> CacheKey[_AgentResult, _AgentRoundWithHistory]:
-    return CacheKey[_AgentResult, _AgentRoundWithHistory](f"round-{i}")
+def _agent_round_key(i: int) -> str:
+    return f"round-{i}"
+
+AGENT_ROUND_KEY = KeyFamily(_AgentResult, _AgentRoundWithHistory, _agent_round_key)
 
 AGENT_RESULT_KEY = CacheKey[_BugAnalysisCache, _AgentResult]("agent_bug_analysis")
 
@@ -268,7 +264,7 @@ async def _run_bug_round(
     prev: list[_AgentRoundResult],
     system_prompt: str
 ) -> _AgentRoundWithHistory:
-    round_ctx = ctx.child(agent_round_key(round))
+    round_ctx = ctx.child(AGENT_ROUND_KEY(round))
     if (cached := await round_ctx.cache_get(_AgentRoundWithHistory)) is not None:
         return cached
 
@@ -393,7 +389,10 @@ async def run_property_inference[U: FeatureUnit](
     the cached prefix.
     """
 
-    component_analysis = ctx.child(bug_analysis_key(threat_model, refinement is not None))
+    component_analysis = ctx.child(BUG_ANALYSIS_KEY(
+        threat_model.to_digest() if threat_model is not None else None,
+        refinement is not None,
+    ))
     if (cached := await component_analysis.cache_get(_BugAnalysisCache)) is not None:
         return cached.items
 

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -794,7 +794,8 @@ async def batch_cvl_generation(
                 prover_history=[],
                 reminders_channel=[],
                 vfs=restored_vfs,
-                version_history=restored_history
+                version_history=restored_history,
+                spec_stem=spec_stem
             )
         )
     except BudgetExceeded as e:

--- a/composer/spec/source/harness.py
+++ b/composer/spec/source/harness.py
@@ -36,14 +36,13 @@ from composer.spec.graph_builder import run_to_completion, bind_standard
 from composer.spec.source.autosetup import run_autosetup, read_autosetup_usage, read_autosetup_prover_usage, SetupFailure, SetupSuccess
 from composer.spec.service_host import ServiceHost
 from composer.spec.context import WorkflowContext, SourceCode, CacheKey
+from composer.spec.key_family import KeyFamily
 from composer.spec.util import string_hash
 from composer.spec.gen_types import TypedTemplate, certora_relative_to_project, under_project
-from composer.spec.system_model import SolidityIdentifier, SourceApplication, SourceExternalActor, SourceExplicitContract
-
-def system_setup_key(s: SourceApplication) -> CacheKey["ContractSetup", "SystemDescriptionHarnessed"]:
-    return CacheKey["ContractSetup", "SystemDescriptionHarnessed"](
-        "system-setup-" + string_hash(s.model_dump_json())
-    )
+from composer.spec.system_model import (
+    HarnessDefinition, HarnessedApplication, HarnessedExplicitContract,
+    SolidityIdentifier, SourceApplication, SourceExternalActor, SourceExplicitContract,
+)
 
 class LinkField(BaseModel):
     """
@@ -127,6 +126,45 @@ class HarnessAnalysisParams(TypedDict):
 class ContractSetup(BaseModel):
     system_description: SystemDescriptionHarnessed
     config: SetupSuccess
+
+
+def lift_harnessed(
+    s: SourceApplication, sys_desc: SystemDescriptionHarnessed,
+) -> HarnessedApplication:
+    """Re-key harness definitions by harnessed contract and fold them into a
+    ``HarnessedApplication`` — each ``SourceExplicitContract`` becomes a
+    ``HarnessedExplicitContract`` carrying the harnesses generated for it.
+
+    Declared beside the models because every consumer of the harnessed view
+    must build it identically — the prover pipeline, and any offline walker
+    re-deriving component cache keys (``composer.meta.run``): the harnessed
+    app is part of the unit's ``cache_material``."""
+    contract_to_harness: dict[SolidityIdentifier, list[HarnessDefinition]] = {}
+    for c in sys_desc.transitive_closure:
+        if not c.harness_definition:
+            continue
+        contract_to_harness.setdefault(c.harness_definition.harness_of, []).append(
+            HarnessDefinition(name=c.solidity_identifier, path=c.path)
+        )
+
+    comp: list[SourceExternalActor | HarnessedExplicitContract] = []
+    for c in s.components:
+        if not isinstance(c, SourceExplicitContract):
+            comp.append(c)
+            continue
+        comp.append(HarnessedExplicitContract(
+            sort=c.sort,
+            name=c.name,
+            solidity_identifier=c.solidity_identifier,
+            components=c.components,
+            description=c.description,
+            path=c.path,
+            harnesses=contract_to_harness.get(c.solidity_identifier, []),
+        ))
+    return HarnessedApplication(
+        application_type=s.application_type, description=s.description, components=comp,
+    )
+
 
 HarnessAnalysis = TypedTemplate[HarnessAnalysisParams]("state_analysis.j2")
 
@@ -230,10 +268,17 @@ class HarnessGenParams(TypedDict):
 
 _HarnessGenerationPrompt = TypedTemplate[HarnessGenParams]("harness_generation_prompt.j2")
 
-def harness_generation_key(
-    instructions: AgentSystemDescription
-) -> CacheKey[SystemDescriptionHarnessed, HarnessResult]:
-    return CacheKey[SystemDescriptionHarnessed, HarnessResult](string_hash(instructions.model_dump_json()))
+def _system_setup_key(s: SourceApplication) -> str:
+    return "system-setup-" + string_hash(s.model_dump_json())
+
+SYSTEM_SETUP_KEY = KeyFamily(ContractSetup, SystemDescriptionHarnessed, _system_setup_key)
+
+def _harness_generation_key(instructions: AgentSystemDescription) -> str:
+    return string_hash(instructions.model_dump_json())
+
+HARNESS_GENERATION_KEY = KeyFamily(
+    SystemDescriptionHarnessed, HarnessResult, _harness_generation_key
+)
 
 async def generate_harnesses(
     context: WorkflowContext[SystemDescriptionHarnessed],
@@ -242,7 +287,7 @@ async def generate_harnesses(
     application: SourceApplication,
     instructions: AgentSystemDescription
 ) -> HarnessResult:
-    child = await context.child(harness_generation_key(instructions), instructions.model_dump())
+    child = await context.child(HARNESS_GENERATION_KEY(instructions), instructions.model_dump())
     if (cached := await child.cache_get(HarnessResult)) is not None:
         return cached
 
@@ -436,7 +481,7 @@ async def run_setup_part1(
     env: ServiceHost,
     application_desc: SourceApplication
 ) -> SystemDescriptionHarnessed:
-    setup_ctx = await context.child(system_setup_key(application_desc), application_desc.model_dump())
+    setup_ctx = await context.child(SYSTEM_SETUP_KEY(application_desc), application_desc.model_dump())
     if (cached := await setup_ctx.cache_get(SystemDescriptionHarnessed)):
         return cached
 
@@ -523,7 +568,7 @@ _logger = getLogger(__name__)
 # Harness creation and AutoSetup are exposed as two separate, independently
 # cached steps so the pipeline can run AutoSetup in parallel with invariant/bug
 # analysis. They share the ``config_key`` parent context, so existing
-# harness-creation caches (keyed by ``system_setup_key``) still hit; the
+# harness-creation caches (keyed by ``SYSTEM_SETUP_KEY``) still hit; the
 # AutoSetup result is cached under its own key.
 # ---------------------------------------------------------------------------
 
@@ -541,18 +586,18 @@ async def run_harness_creation(
     return await run_and_apply_part1(config_ctxt, source, env, application_desc)
 
 
-def autosetup_key(
+def _autosetup_key(
     app: SourceApplication,
     prover_opts: ProverOptions,
-) -> CacheKey[ContractSetup, SetupSuccess]:
-    """Cache key for the AutoSetup phase. Includes ``prover_opts`` so cloud and
-    local configurations never collide (the old composite ``config_key`` omitted
-    them, which could reuse a stale config across modes)."""
-    return CacheKey[ContractSetup, SetupSuccess](
-        "autosetup-" + string_hash(
-            app.model_dump_json() + "\x00" + "\x00".join(prover_opts.extra_args)
-        )
+) -> str:
+    return "autosetup-" + string_hash(
+        app.model_dump_json() + "\x00" + "\x00".join(prover_opts.extra_args)
     )
+
+#: Cache key for the AutoSetup phase. Includes ``prover_opts`` so cloud and
+#: local configurations never collide (the old composite ``config_key`` omitted
+#: them, which could reuse a stale config across modes).
+AUTOSETUP_KEY = KeyFamily(ContractSetup, SetupSuccess, _autosetup_key)
 
 
 async def run_autosetup_phase(
@@ -569,7 +614,7 @@ async def run_autosetup_phase(
     Cache hits are guarded by the on-disk existence of ``summaries_path``."""
     config_ctxt = context.child(config_key)
     cache = await config_ctxt.child(
-        autosetup_key(application_desc, prover_opts),
+        AUTOSETUP_KEY(application_desc, prover_opts),
         application_desc.model_dump(),
     )
     if (cached := await cache.cache_get(SetupSuccess)) is not None:

--- a/composer/spec/source/keys.py
+++ b/composer/spec/source/keys.py
@@ -1,0 +1,61 @@
+"""The prover (CVL) backend's cache sub-chain, declared in one place.
+
+Everything the prover backend adds around the Auto-Prove driver chain
+(``composer.pipeline.keys``), in tree order::
+
+    run root
+    ├── config                              config_key             → ContractSetup
+    │   ├── system-setup-{app digest}       SYSTEM_SETUP_KEY       → SystemDescriptionHarnessed
+    │   │   ├── harness-analysis            HARNESS_ANALYSIS_KEY   → AgentSystemDescription
+    │   │   └── {instructions digest}       HARNESS_GENERATION_KEY → HarnessResult
+    │   └── autosetup-{app+opts digest}     AUTOSETUP_KEY          → SetupSuccess
+    ├── summary-{config digest}             SUMMARY_KEY            → _SummaryCache
+    ├── structural-inv                      STRUCTURAL_INV_KEY     → Invariants
+    │   └── judge                           INV_JUDGE_KEY          → (judge memory)
+    ├── invariant-cvl                       INV_CVL_KEY            → GeneratedCVL
+    │   ├── judge                           CVL_JUDGE_KEY          → (judge memory)
+    │   └── last_attempt                    LAST_ATTEMPT_KEY       → _LastAttemptCache
+    └── ap-properties                       PROPERTIES_KEY(AP_PROPERTIES_KEY_NAME)
+        └── … driver chain …
+            └── {props digest}              FORMALIZATION_KEY      → GeneratedCVL
+                ├── judge                   CVL_JUDGE_KEY
+                └── last_attempt            LAST_ATTEMPT_KEY
+
+Families and constants are declared beside their cache models (harness,
+summarizer, struct_invariant, cvl_generation) and gathered here;
+consumers (the backend pipeline, ``cache-autoprove``) import from this
+registry rather than spelunking the producer modules.
+"""
+
+from composer.spec.context import CacheKey
+from composer.spec.cvl_generation import (
+    CVL_JUDGE_KEY, LAST_ATTEMPT_KEY, GeneratedCVL,
+)
+from composer.spec.source.harness import (
+    AUTOSETUP_KEY, HARNESS_ANALYSIS_KEY, HARNESS_GENERATION_KEY,
+    SYSTEM_SETUP_KEY, config_key,
+)
+from composer.spec.source.struct_invariant import INV_JUDGE_KEY, STRUCTURAL_INV_KEY
+from composer.spec.source.summarizer import SUMMARY_KEY
+
+__all__ = [
+    "AP_PROPERTIES_KEY_NAME",
+    "AUTOSETUP_KEY",
+    "CVL_JUDGE_KEY",
+    "HARNESS_ANALYSIS_KEY",
+    "HARNESS_GENERATION_KEY",
+    "INV_CVL_KEY",
+    "INV_JUDGE_KEY",
+    "LAST_ATTEMPT_KEY",
+    "STRUCTURAL_INV_KEY",
+    "SUMMARY_KEY",
+    "SYSTEM_SETUP_KEY",
+    "config_key",
+]
+
+#: The prover backend's ``SystemAnalysisSpec.properties_key``.
+AP_PROPERTIES_KEY_NAME = "ap-properties"
+
+#: CVL generation for the structural invariants (the per-component peer is
+#: reached via ``FORMALIZATION_KEY``).
+INV_CVL_KEY = CacheKey[None, GeneratedCVL]("invariant-cvl")

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -27,18 +27,17 @@ from typing import override
 from langchain_core.tools import BaseTool
 
 from composer.io.multi_job import TaskInfo
-from composer.spec.context import WorkflowContext, CacheKey, CVLGeneration
+from composer.spec.context import WorkflowContext, CVLGeneration
 from composer.spec.types import PropertyFormulation
 from composer.spec.gen_types import CVLResource, SPECS_DIR, certora_relative_to_project
 from composer.spec.system_model import (
     ContractComponentInstance, ContractInstance, SourceApplication, HarnessedApplication,
-    SourceExplicitContract, HarnessedExplicitContract, SourceExternalActor,
-    HarnessDefinition, SolidityIdentifier,
 )
 from composer.spec.cvl_generation import GeneratedCVL
 from composer.spec.prop_inference import CERTORA_BACKEND_GUIDANCE
 from composer.spec.source.harness import (
     run_harness_creation, run_autosetup_phase, ContractSetup, SystemDescriptionHarnessed,
+    lift_harnessed
 )
 from composer.spec.source.summarizer import setup_summaries
 from composer.spec.source.struct_invariant import get_invariant_formulation
@@ -64,49 +63,15 @@ from composer.ui.autoprove_app import AutoProvePhase
 from composer.pipeline.core import (
     Formalizer, PreparedSystem, PipelineRun, Delivered, GaveUp,
     CorePhases, SystemAnalysisSpec, ComponentOutcome,
-    COMMON_SYSTEM_CACHE_KEY, Curtailed
+    Curtailed
 )
+from composer.pipeline.keys import COMMON_SYSTEM_CACHE_KEY
 from composer.pipeline.ecosystem import main_instance
-
-
-INV_CVL_KEY = CacheKey[None, GeneratedCVL]("invariant-cvl")
+from composer.spec.source.keys import AP_PROPERTIES_KEY_NAME, INV_CVL_KEY
 
 #: The invariant CVL's slot in the report: a real delivery (imported by every component spec)
 #: or the quarantined leftovers of a budget-curtailed generation (appendix only).
 type InvariantResult = Delivered[GeneratedCVL] | Curtailed[Delivered[GeneratedCVL]]
-
-
-def _lift_harnessed(
-    s: SourceApplication, sys_desc: SystemDescriptionHarnessed,
-) -> HarnessedApplication:
-    """Re-key harness definitions by harnessed contract and fold them into a
-    ``HarnessedApplication`` — each ``SourceExplicitContract`` becomes a
-    ``HarnessedExplicitContract`` carrying the harnesses generated for it."""
-    contract_to_harness: dict[SolidityIdentifier, list[HarnessDefinition]] = {}
-    for c in sys_desc.transitive_closure:
-        if not c.harness_definition:
-            continue
-        contract_to_harness.setdefault(c.harness_definition.harness_of, []).append(
-            HarnessDefinition(name=c.solidity_identifier, path=c.path)
-        )
-
-    comp: list[SourceExternalActor | HarnessedExplicitContract] = []
-    for c in s.components:
-        if not isinstance(c, SourceExplicitContract):
-            comp.append(c)
-            continue
-        comp.append(HarnessedExplicitContract(
-            sort=c.sort,
-            name=c.name,
-            solidity_identifier=c.solidity_identifier,
-            components=c.components,
-            description=c.description,
-            path=c.path,
-            harnesses=contract_to_harness.get(c.solidity_identifier, []),
-        ))
-    return HarnessedApplication(
-        application_type=s.application_type, description=s.description, components=comp,
-    )
 
 
 @dataclass
@@ -341,8 +306,6 @@ class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, Con
             lambda: get_invariant_formulation(run.ctx, run.source, run.env, self._harnessed),
         )
 
-AP_PROPERTIES_KEY_NAME = "ap-properties"
-
 @dataclass
 class ProverBackend:
     """PipelineBackend[AutoProvePhase, GeneratedCVL, None, ComponentSpec,
@@ -369,7 +332,7 @@ class ProverBackend:
             TaskInfo(HARNESS_TASK_ID, "Harness Creation", AutoProvePhase.HARNESS),
             lambda: run_harness_creation(run.ctx, run.source, run.env, analyzed),
         )
-        harnessed = _lift_harnessed(analyzed, sys_desc)
+        harnessed = lift_harnessed(analyzed, sys_desc)
         # The materializing strategy covers every phase with one tool: an empty
         # VFS (invariants, or an author that never edited) runs in-situ; a
         # non-empty one runs in a temp materialization of the working copy.

--- a/composer/spec/source/summarizer.py
+++ b/composer/spec/source/summarizer.py
@@ -24,7 +24,8 @@ from graphcore.tools.schemas import WithImplementation, WithInjectedState, WithI
 from composer.spec.graph_builder import bind_standard, run_to_completion
 from composer.cvl.tools import get_cvl, put_cvl, put_cvl_raw, edit_cvl
 from composer.spec.gen_types import CVLResource, SUMMARIES_DIR, under_project
-from composer.spec.context import WorkflowContext, SourceCode, CacheKey
+from composer.spec.context import WorkflowContext, SourceCode
+from composer.spec.key_family import KeyFamily
 from composer.spec.util import temp_certora_file, string_hash, ensure_dir
 from composer.spec.service_host import ServiceHost
 from composer.spec.source.harness import ContractSetup, ExternalInterface, HarnessDef
@@ -287,9 +288,10 @@ class _SummaryCache(BaseModel):
     content: str
 
 
-def _summary_key(d: ContractSetup) -> CacheKey[None, _SummaryCache]:
-    cacher = string_hash(d.model_dump_json())[:16]
-    return CacheKey("summary-" + cacher)
+def _summary_key(d: ContractSetup) -> str:
+    return "summary-" + string_hash(d.model_dump_json())[:16]
+
+SUMMARY_KEY = KeyFamily(type(None), _SummaryCache, _summary_key)
 
 # ---------------------------------------------------------------------------
 # Agent
@@ -319,7 +321,7 @@ async def setup_summaries(
         CVLResource pointing to the generated ``custom_summaries.spec`` file.
     """
 
-    summary_context = ctx.child(_summary_key(config))
+    summary_context = ctx.child(SUMMARY_KEY(config))
     custom_summaries_path = SUMMARIES_DIR / "custom_summaries.spec"  # project-root-relative
     result_path = under_project(source.project_root, custom_summaries_path)
     ensure_dir(result_path.parent)

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -119,7 +119,12 @@ class _Ctx:
 
 
 class _FeatCtx:
-    async def child(self, *_a, **_kw): return _Cache()
+    def child(self, key, tags = None):
+        if tags is None:
+            return _Cache()
+        async def thunk():
+            return _Cache()
+        return thunk()
 
 
 class _Source:


### PR DESCRIPTION
Until now, Cache keys had to be built with loosely defined conventions; this was usually some key construction function (defined as a "private" `_` prefixed module function) that you just kinda had to know was used to define a `CacheKey[Parent, Child]`.

This PR addresses that issue by introducing `KeyFamilies`, which declaratively tie the key generation to the expected types. This is done by declaring `KeyFamily(ParentType, ChildType, key_derivation)`.

`KeyFamily` defines `__call__(**P)`, where `P` is the signature of `key_derivation`. Thus, you are enforced (by the type system) to pass exactly the parameters needed for each key to each derivation step. This should cut down on the proliferation of imported helper functions all over the place.