### PR TITLE
Plugin tool contribution

### DIFF
--- a/composer/core/edit.py
+++ b/composer/core/edit.py
@@ -30,7 +30,7 @@ class EditErr:
     message: str
 
 
-def replace_unique(buffer: str, old: str, new: str) -> EditOk | EditErr:
+def replace_unique(buffer: str, old: str, new: str, replace_all: bool = False) -> EditOk | EditErr:
     """Replace the single occurrence of ``old`` in ``buffer`` with ``new``.
 
     An edit must identify exactly one site. Returns :class:`EditErr` when
@@ -38,16 +38,20 @@ def replace_unique(buffer: str, old: str, new: str) -> EditOk | EditErr:
     surrounding context) rather than risk silently editing the wrong place.
     On success returns :class:`EditOk` with the rewritten buffer.
     """
-    count = buffer.count(old)
-    if count == 0:
-        return EditErr(
-            "`old_string` was not found in the current buffer. It must match an "
-            "exact span of the contents, including whitespace and indentation. "
-            "Read the buffer back and copy the target span verbatim."
-        )
-    if count > 1:
-        return EditErr(
-            f"`old_string` matched {count} locations; it must match exactly one. "
-            "Include more surrounding context so the target span is unique."
-        )
-    return EditOk(buffer.replace(old, new, 1))
+    if not replace_all:
+        count = buffer.count(old)
+        if count == 0:
+            return EditErr(
+                "`old_string` was not found in the current buffer. It must match an "
+                "exact span of the contents, including whitespace and indentation. "
+                "Read the buffer back and copy the target span verbatim."
+            )
+        if count > 1:
+            return EditErr(
+                f"`old_string` matched {count} locations; it must match exactly one. "
+                "Include more surrounding context so the target span is unique."
+            )
+        replace_count = 1
+    else:
+        replace_count = -1
+    return EditOk(buffer.replace(old, new, replace_count))

--- a/composer/cvl/tools.py
+++ b/composer/cvl/tools.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 from typing import Annotated, Literal, overload
 from langchain_core.messages import AIMessage
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, ReadOnly
 
 from langchain_core.tools import tool, InjectedToolCallId, BaseTool
 from langgraph.types import Command
@@ -164,7 +164,7 @@ def put_cvl_raw(
     return maybe_update_cvl(tool_call_id=tool_call_id, pp=cvl_file, reset_read=DEFAULT_READ_KEY, spec_key=DEFAULT_SPEC_KEY)
 
 class WithCurrSpec(TypedDict):
-    curr_spec: str | None
+    curr_spec: ReadOnly[str | None]
 
 class WithCurrSpecAndDidRead(WithCurrSpec):
     did_read: bool

--- a/composer/foundry/author.py
+++ b/composer/foundry/author.py
@@ -21,24 +21,30 @@ Workflow shape:
 * No prover-config editor — foundry projects are assumed pre-configured.
 """
 
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from pathlib import Path
 import asyncio
 from typing import (
-    Awaitable, Callable, Literal, NotRequired, Protocol, override
+    AsyncIterator, Awaitable, Callable, Literal, NotRequired, Protocol,
+    Sequence, override
 )
 from typing_extensions import TypedDict
 
+from langchain_core.tools import BaseTool
 from langgraph.graph import MessagesState
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 
-from graphcore.graph import FlowInput, tool_state_update
+from graphcore.graph import CacheMarker, FlowInput, RawPromptInput, tool_state_update
 from graphcore.summary import SummaryConfig
 from graphcore.tools.schemas import (
     WithAsyncDependencies, WithAsyncImplementation, WithImplementation,
     WithInjectedId, WithInjectedState,
 )
-from composer.pipeline.core import Curtailed, GaveUp
+from composer.pipeline.core import Curtailed, GaveUp, ToolBinder, ToolExtension
+from composer.pipeline.plugin_api import ProvidedTools
+from composer.foundry.plugin import FoundryState, FoundryTools
 from composer.spec.context import FoundryGeneration, FoundryJudge, WorkflowContext
 from composer.spec.cvl_generation import (
     PropertyFeedbackProtocol, RebuttalBase, SkippedProperty,
@@ -59,7 +65,7 @@ from composer.ui.tool_display import (
     suppress_ack, tool_display,
 )
 
-from composer.foundry.runner import get_forge_test_tool
+from composer.foundry.runner import get_forge_test_tool, infer_test_dir
 from composer.foundry.state import (
     FEEDBACK,
     FORGE_TEST_VALIDATION_KEY,
@@ -633,6 +639,13 @@ address, proceed directly with addressing them.
 # Top-level batch entry
 # ---------------------------------------------------------------------------
 
+#: The foundry tool extension: contributions come from plugins deriving
+#: ``FoundryTools``, dispatched via their ``foundry_tools`` hook.
+_FOUNDRY_TOOLS = ToolExtension(
+    provider=FoundryTools, project=lambda p: p.foundry_tools
+)
+
+
 @component_context
 class FoundryPropertyGenParams(TypedDict):
     """Per-batch render variables for ``foundry_property_generation_prompt.j2``.
@@ -675,7 +688,8 @@ async def batch_foundry_test_generation(
     description: str,
     forge_binary: str = "forge",
     forge_timeout_s: int = 600,
-    forge_sem : asyncio.Semaphore
+    forge_sem : asyncio.Semaphore,
+    tool_provider: ToolBinder[ContractComponentInstance],
 ) -> BatchFoundryResult:
     """Author one batch of foundry tests covering ``props``.
 
@@ -694,6 +708,9 @@ async def batch_foundry_test_generation(
       ``composer.foundry.env.build_foundry_env``.
     * ``contract_name`` / ``component`` / ``props`` are bound into the
       initial prompt (``foundry_property_generation_prompt.j2``).
+    * ``tool_provider`` is the driver's tool binder for this batch,
+      dispatched here with the foundry extension and a reader that stages
+      :class:`FoundryState` from the author's live graph state.
 
     ``ctx`` is marked ``FoundryGeneration`` so its cache namespace stays
     distinct from a co-located CVL run's.
@@ -708,6 +725,37 @@ async def batch_foundry_test_generation(
         "contract_name": contract_name,
         "sort": "existing"
     })
+
+    # Stage the foundry analog of the prover's ProverState for contributed tools:
+    # the (in-situ) project root, the configured test dir, and the live draft
+    # buffer. Nothing is materialized — foundry runs against the project as-is —
+    # so the context manager is trivial; the shape leaves the backend free to
+    # stage a copy later without touching the plugin contract.
+    root = Path(project_root).resolve()
+    test_dir = root / infer_test_dir(root)
+
+    @asynccontextmanager
+    async def _staged_state(st: FoundryGenerationState) -> AsyncIterator[FoundryState]:
+        yield FoundryState(
+            working_dir=root,
+            test_dir=test_dir,
+            curr_test=st["curr_test"],
+        )
+
+    tools = await tool_provider(
+        _FOUNDRY_TOOLS, FoundryGenerationState, _staged_state
+    )
+
+    sys_prompt: list[RawPromptInput | type[CacheMarker]] = [
+        lambda load: load("foundry_property_generation_system_prompt.j2"),
+    ]
+    added_tools: list[BaseTool] = []
+    for inj in tools:
+        added_tools.extend(inj.tools)
+        if isinstance(inj.system_prompt_injection, list):
+            sys_prompt.extend(inj.system_prompt_injection)
+        else:
+            sys_prompt.append(inj.system_prompt_injection)
 
     titles = [p.title for p in props]
     judge_ctx = ctx.child(FOUNDRY_JUDGE_KEY)
@@ -736,7 +784,8 @@ async def batch_foundry_test_generation(
             GiveUpTool.as_tool("give_up"),
             ctx.get_memory_tool(),
         ])
-        .with_sys_prompt_template("foundry_property_generation_system_prompt.j2")
+        .with_tools(added_tools)
+        .with_sys_prompt(sys_prompt)
         .inject(lambda b: bound_template.render_to(b.with_initial_prompt_template))
         .with_summary_config(FoundryGenerationSummaryConfig())
         .with_monitor(budget_monitor(

--- a/composer/foundry/pipeline.py
+++ b/composer/foundry/pipeline.py
@@ -22,7 +22,7 @@ import asyncio
 import enum
 import logging
 from dataclasses import dataclass
-from typing import Awaitable, Callable, override
+from typing import Awaitable, Callable, override, Sequence, Any
 
 from composer.foundry.author import (
     GeneratedFoundryTest, batch_foundry_test_generation,
@@ -32,8 +32,9 @@ from composer.foundry.report import _foundry_verdicts
 from composer.pipeline.core import (
     Formalizer, PreparedSystem, PipelineRun,
     GaveUp, SystemAnalysisSpec,
-    CorePhases, CorePipelineResult,
+    CorePhases, CorePipelineResult, ToolBinder,
 )
+from composer.foundry.plugin import FoundryTools
 from composer.pipeline.ptypes import Curtailed
 from composer.pipeline.ecosystem import main_instance
 from composer.pipeline.keys import COMMON_SYSTEM_CACHE_KEY
@@ -109,6 +110,8 @@ class FoundryPhase(enum.Enum):
     REPORT = "report"
 
 class FoundryFormalizer(Formalizer[GeneratedFoundryTest, ContractComponentInstance]):
+    tool_provider_type = FoundryTools
+
     def __init__(self, conf: _ForgeRunConfig):
         super().__init__(GeneratedFoundryTest, "foundry")
         self.conf = conf
@@ -120,7 +123,8 @@ class FoundryFormalizer(Formalizer[GeneratedFoundryTest, ContractComponentInstan
         feat: ContractComponentInstance,
         props: list[PropertyFormulation],
         ctx: WorkflowContext[GeneratedFoundryTest],
-        run: PipelineRun
+        run: PipelineRun,
+        extra_tools: ToolBinder[ContractComponentInstance]
     ) -> GeneratedFoundryTest | Curtailed[GeneratedFoundryTest] | GaveUp:
         return await batch_foundry_test_generation(
             ctx=ctx.abstract(FoundryGeneration),
@@ -132,7 +136,8 @@ class FoundryFormalizer(Formalizer[GeneratedFoundryTest, ContractComponentInstan
             forge_binary=self.conf.forge_binary,
             forge_sem=self.conf.forge_sem,
             forge_timeout_s=self.conf.forge_timeout_s,
-            props=props
+            props=props,
+            tool_provider=extra_tools,
         )
 
     @override

--- a/composer/foundry/plugin.py
+++ b/composer/foundry/plugin.py
@@ -1,0 +1,49 @@
+"""The foundry backend's plugin-extension surface.
+
+What a plugin imports to contribute tools to the foundry test author: the
+:class:`FoundryTools` provider class (deriving it IS the declaration — see
+``composer.pipeline.plugin_api``) and the :class:`FoundryState` view its hooks can
+stage at tool-invocation time. The prover counterpart is
+``composer.spec.source.plugin``.
+"""
+
+import pathlib
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import AsyncContextManager, Callable, Sequence
+
+from composer.pipeline.plugin_api import (
+    FormalizationTool, PipelinePlugin, PluginToolContext, ProvidedTools,
+)
+from composer.spec.system_model import FeatureUnit
+from composer.spec.types import PropertyFormulation
+
+
+@dataclass
+class FoundryState:
+    # The foundry project root the run executes in.
+    working_dir: pathlib.Path
+    # The project's configured test directory (absolute; from foundry.toml's
+    # default profile). May not exist until a draft is first staged into it.
+    test_dir: pathlib.Path
+    # The author's current .t.sol draft buffer; None until a draft is written.
+    curr_test: str | None
+
+type FoundryStateReader[T] = Callable[[T], AsyncContextManager[FoundryState]]
+
+
+class FoundryTools[U: FeatureUnit](PipelinePlugin[U]):
+    """Contributes tools to the foundry test author; the staged view is
+    :class:`FoundryState`. See ``composer.spec.source.plugin.CertoraProverTools``
+    for the reader contract."""
+
+    @abstractmethod
+    async def foundry_tools[T](
+        self,
+        comp: U,
+        prop: Sequence[PropertyFormulation],
+        tool_context: PluginToolContext[FormalizationTool],
+        st: type[T],
+        state_reader: FoundryStateReader[T]
+    ) -> ProvidedTools | None:
+        ...

--- a/composer/io/task_host.py
+++ b/composer/io/task_host.py
@@ -1,0 +1,64 @@
+from typing import Literal, Callable, Awaitable
+from uuid import uuid4
+import asyncio
+from dataclasses import dataclass
+
+@dataclass
+class _TaskHandle[T]:
+    desc: str
+    handle: asyncio.Future[T]
+    event: asyncio.Event
+    ty: type[T]
+
+@dataclass
+class TaskStatus:
+    desc: str
+    status: Literal["running", "complete"]
+
+class NoSuchTaskError(RuntimeError):
+    ...
+
+class TaskHost:
+    def __init__(self):
+        self._task_map : dict[str, _TaskHandle]= {}
+        self._lock = asyncio.Lock()
+
+    async def list_tasks(self) -> dict[str, TaskStatus]:
+        return {
+            k: TaskStatus(
+                desc=j.desc,
+                status="running" if not j.handle.done() else "complete"
+            ) for (k, j) in self._task_map.items()
+        }
+
+    async def launch[T](self, description: str, t: type[T], task: Callable[[], Awaitable[T]]) -> str:
+        # Callable[[], Awaitable[T]] isn't a "coroutine like" for the asyncio typing, so make that explicit
+        async def task_wrap():
+            return await task()
+        async with self._lock:
+            t_id = uuid4().hex
+            compl = asyncio.Event()
+            task_fut = asyncio.create_task(
+                task_wrap()
+            )
+            task_fut.add_done_callback(lambda _: compl.set())
+            self._task_map[t_id] = _TaskHandle(
+                desc=description,
+                handle=task_fut,
+                event=compl,
+                ty=t
+            )
+        return t_id
+
+    async def await_result[T](self, task_id: str, t: type[T]) -> T:
+        async with self._lock:
+            handle = self._task_map.get(task_id)
+        if handle is None:
+            raise NoSuchTaskError()
+        assert handle.ty is t, "Type mismatch"
+        await handle.event.wait()
+        res = handle.handle.result()
+        async with self._lock:
+            if task_id in self._task_map:
+                del self._task_map[task_id]
+        return res

--- a/composer/io/task_tools.py
+++ b/composer/io/task_tools.py
@@ -1,0 +1,59 @@
+"""The author-side surface of the run's :class:`TaskHost`: list the background
+tasks plugin tools have launched, and collect their reports. Task results are
+always strings — the lingua franca of tool results — so ``RetrieveTask`` is
+the single retrieval tool regardless of which plugin launched the task.
+
+Bind both over the host the author owns::
+
+    TaskListTool.bind(host).as_tool(TASK_LIST)
+    RetrieveTask.bind(host).as_tool(RETRIEVE_TASK)
+"""
+
+from typing import override
+
+from pydantic import Field
+
+from graphcore.tools.schemas import WithAsyncDependencies
+
+from .task_host import NoSuchTaskError, TaskHost
+
+TASK_LIST = "task_list"
+RETRIEVE_TASK = "retrieve_task"
+
+
+class TaskListTool(WithAsyncDependencies[str, TaskHost]):
+    """
+    List the background tasks launched in this session: each task's ID, what
+    it is doing, and whether it is still running or has a report ready.
+    """
+
+    @override
+    async def run(self) -> str:
+        with self.tool_deps() as host:
+            tasks = await host.list_tasks()
+        if not tasks:
+            return "No background tasks are outstanding (none launched, or every report already retrieved)."
+        return "\n".join(
+            f"{task_id}: {info.desc} [{info.status}]"
+            for (task_id, info) in tasks.items()
+        )
+
+
+class RetrieveTask(WithAsyncDependencies[str, TaskHost]):
+    """
+    Collect a background task's report by ID, waiting for the task to finish
+    if it is still running. Each report can be retrieved exactly once.
+    """
+    task_id: str = Field(description="The task ID reported when the task was launched")
+
+    @override
+    async def run(self) -> str:
+        with self.tool_deps() as host:
+            try:
+                return await host.await_result(self.task_id, str)
+            except NoSuchTaskError:
+                return (
+                    f"No task with ID {self.task_id}: it never existed, or its "
+                    "report was already retrieved (reports are single-shot); "
+                    f"see `{TASK_LIST}`."
+                )

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -19,10 +19,12 @@ phase objects, and never inspected by the driver.
 
 import asyncio
 import enum
+import functools
 import logging
 from dataclasses import dataclass
-from typing import Protocol, cast, ContextManager, Any
-from collections.abc import Sequence
+from typing import (
+    Protocol, Any, ClassVar, Concatenate, cast, Awaitable, Sequence, Callable, ContextManager, overload
+)
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
 
@@ -35,8 +37,8 @@ from composer.spec.context import (
 from composer.spec.system_model import (
     BaseApplication, FeatureUnit
 )
-from composer.spec.types import PropertyFormulation, ArtifactIdentifier
 from composer.spec.util import combine_digests
+from composer.spec.types import PropertyFormulation, ArtifactIdentifier, VerificationArtifact
 from composer.spec.system_analysis import run_component_analysis
 from composer.spec.prop_inference import (
     run_property_inference, AnyPropertyGenerationInput, CacheablePropertyGenerationInput,
@@ -46,26 +48,97 @@ from composer.input.files import Document
 from composer.spec.source.report.build import build_report
 from composer.spec.source.report.collect import ReportComponentInput, Verdict, EvidenceFetcher, Formalized
 from composer.spec.source.report.schema import (
-    AutoProverReport, RuleName, ReportBackend, SourceEditRecord,
+    AutoProverReport, RuleName, ReportBackend, SourceEditRecord, VerificationArtifactRecord,
 )
 from composer.spec.source.report import build as report_build
 from composer.spec.source.task_ids import SYSTEM_ANALYSIS_TASK_ID, REPORT_TASK_ID
 from composer.pipeline.ecosystem import Ecosystem
-from .ptypes import (
-    BackendJob, BackendResult, ComponentOutcome, CorePhases, CorePipelineResult, Delivered, GaveUp,
-    FinalProperties,
-    PipelineRun, SystemAnalysisSpec, RunBudget, Curtailed
-)
 from .keys import (
-    COMPONENT_KEY, FINAL_PROPERTIES_KEY, FORMALIZATION_KEY,
+    COMPONENT_KEY, FINAL_PROPERTIES_KEY, FORMALIZATION_KEY, PLUGIN_ARTIFACTS_KEY,
     POST_PROPERTY_KEY, PRE_PROPERTY_KEY, PROPERTIES_KEY, SYSTEM_ANALYSIS_KEY,
+    PLUGIN_FORMALIZATION_KEY
 )
 from composer.diagnostics.budget import total_budget, named_budget_or_nop, time_budget
-from .plugin_api import PrePropertyInference, PostPropertyInference
+
+from .ptypes import (
+    BackendJob, BackendResult, ComponentOutcome, CorePhases, CorePipelineResult,
+    Curtailed,  Delivered, RunBudget,
+    FinalProperties, GaveUp, PersistedPluginArtifact, PipelineRun, PluginArtifact,
+    RegisteredArtifacts, SystemAnalysisSpec
+)
+from .plugin_api import (
+    AnyBackendTools, ArtifactRegistrar, FormalizationTool, PipelinePlugin,
+    PluginToolContext, ProvidedTools,
+)
 from .plugins import load_plugins, PluginManager, PluginPhaseManager, PluginPhaseRunner
 
-
 _log = logging.getLogger(__name__)
+
+
+@dataclass
+class ToolExtension[TP: PipelinePlugin[Any], U: FeatureUnit, **P]:
+    """A backend's tool-extension point, handed to the :class:`ToolBinder` at
+    dispatch time: the provider class whose derivers contribute (``provider``) and
+    the selection of their hook method (``project`` — canonically
+    ``lambda p: p.<backend>_tools``, threading the dispatch leg itself, not a
+    wrapper). ``P`` captures the hook's backend-specific tail (its ``st`` /
+    ``state_reader``), which the binder forwards from the dispatch call. The bound
+    ``TP <: PipelinePlugin[U]`` is inexpressible, so unit agreement rides
+    ``project``'s signature statically — and, at runtime, the provider classes
+    deriving ``PipelinePlugin[U]`` plus the load-time scope check."""
+    provider: type[TP]
+    project: Callable[
+        [TP],
+        Callable[
+            Concatenate[U, Sequence[PropertyFormulation], PluginToolContext[FormalizationTool], P],
+            Awaitable[ProvidedTools | None],
+        ],
+    ]
+
+@dataclass
+class InjectingToolExtension[
+    TP: PipelinePlugin[Any],
+    U: FeatureUnit,
+    **P,
+    Ext
+]:
+    """A :class:`ToolExtension` whose hook additionally receives a backend-supplied
+    callable. The backend passes the binder a ``Callable[Concatenate[str, I], R]``;
+    the binder curries in the asking plugin's id, so the hook sees a
+    ``Callable[I, R]`` that already knows who it is serving — attribution is
+    stamped by the driver, never self-reported (the registrar in
+    :class:`_ArtifactCollector` works the same way)."""
+    provider: type[TP]
+    project: Callable[
+        [TP],
+        Callable[
+            Concatenate[U, Sequence[PropertyFormulation], PluginToolContext[FormalizationTool], Ext, P],
+            Awaitable[ProvidedTools | None]
+        ]
+    ]
+
+
+
+class ToolBinder[U: FeatureUnit](Protocol):
+    """What ``formalize`` receives — the core ↔ backend tool seam, naming no
+    backend. The backend calls it exactly once, with its own
+    :class:`ToolExtension` and the extension's tail arguments (its authoring
+    graph's state type and staged-state reader); the binder applies every
+    contributing plugin's hook — always including :class:`AnyBackendTools`
+    derivers — and returns the yielded bundles. Empty when no plugin contributes,
+    so backends need no special-casing."""
+
+    @overload
+    async def __call__[TP: PipelinePlugin[Any], **P](
+        self, ext: ToolExtension[TP, U, P], *args: P.args, **kwargs: P.kwargs
+    ) -> Sequence[ProvidedTools]:
+        ...
+
+    @overload
+    async def __call__[TP: PipelinePlugin[Any], **P, **I, R](
+        self, ext: InjectingToolExtension[TP, U, P, Callable[I, R]], inj: Callable[Concatenate[str, I], R], /, *args: P.args, **kwargs: P.kwargs
+    ) -> Sequence[ProvidedTools]:
+        ...
 
 @dataclass
 class Formalizer[FormT: BackendResult, U: FeatureUnit](ABC):
@@ -80,6 +153,12 @@ class Formalizer[FormT: BackendResult, U: FeatureUnit](ABC):
     formalized_type: type[FormT]
     backend_tag: ReportBackend
 
+    #: The provider class whose derivers contribute tools to this backend — the
+    #: driver matches it for both the dispatch gate and the formalization cache
+    #: key. None (the default) for a backend with no tool extension;
+    #: :class:`AnyBackendTools` derivers count regardless.
+    tool_provider_type: ClassVar[type[PipelinePlugin[Any]] | None] = None
+
     @abstractmethod
     async def formalize(
         self,
@@ -87,10 +166,12 @@ class Formalizer[FormT: BackendResult, U: FeatureUnit](ABC):
         feat: U,
         props: list[PropertyFormulation],
         ctx: WorkflowContext[FormT],
-        run: PipelineRun
+        run: PipelineRun,
+        extra_tools: ToolBinder[U]
     ) -> FormT | Curtailed[FormT] | GaveUp:
-        """A full result, a ``Curtailed`` wrapper when the budget cut the author short (its
-        ``partial`` is whatever was published under the lifted gates), or a ``GaveUp``."""
+        """``extra_tools`` is the run's tool binder: call it exactly once with this
+        backend's :class:`ToolExtension` and the extension's tail (the authoring
+        graph's state type and staged-state reader)."""
         ...
 
     def extra_report_inputs(self) -> list[ReportComponentInput[FormT]]:
@@ -202,6 +283,100 @@ def extract_task_id(idx: int) -> str:
 
 def formalize_task_id(idx: int) -> str:
     return f"formalize-{idx}"
+
+
+# ---- plugin tool contribution -------------------------------------------------
+
+class _ArtifactCollector:
+    """Per-batch sink for the verification artifacts plugin tools register at
+    dispatch time. ``for_plugin`` stamps the attribution, so a plugin never
+    handles its own id; the driver snapshots the collected set into the
+    formalization namespace (cache replays skip the tools) and persists it via
+    the run's artifact store."""
+
+    def __init__(self) -> None:
+        self.items: list[PluginArtifact] = []
+
+    def for_plugin(self, plugin_id: str) -> ArtifactRegistrar:
+        collector = self
+
+        class _Registrar:
+            def register(self, artifact: VerificationArtifact) -> None:
+                collector.items.append(
+                    PluginArtifact(plugin=plugin_id, artifact=artifact)
+                )
+
+        return _Registrar()
+
+
+def _contributes_tools(
+    plugin: PipelinePlugin[Any], provider_type: type[PipelinePlugin[Any]] | None
+) -> bool:
+    """Whether ``plugin`` counts for the running backend's tool dispatch — and so
+    for its ``FORMALIZATION_KEY``: a deriver of the formalizer's declared provider
+    class, or of the always-projected :class:`AnyBackendTools`. One predicate for
+    the gate and the key, so what the binder can reach and what the key says
+    cannot drift."""
+    if isinstance(plugin, AnyBackendTools):
+        return True
+    return provider_type is not None and isinstance(plugin, provider_type)
+
+
+@dataclass
+class _Binder[U: FeatureUnit]:
+    """Core's :class:`ToolBinder` over the batch's contributing plugins, each
+    pre-paired with its id and plugin context. Plugins fire in the deterministic
+    plugin-id order the gate collected them (injection order is prompt content);
+    per plugin, the extension's hook fires before the any-backend hook. Plugin
+    hook code runs only here — at the backend's dispatch — never as a top-level
+    tool-setup task. On an :class:`InjectingToolExtension` dispatch, the
+    backend's injectable gets the asking plugin's id curried in before the hook
+    ever sees it."""
+    _plugins: Sequence[tuple[str, PipelinePlugin[U], PluginToolContext[FormalizationTool]]]
+    _comp: U
+    _props: list[PropertyFormulation]
+
+    @overload
+    async def __call__[TP: PipelinePlugin[Any], **P](
+        self, ext: ToolExtension[TP, U, P], *args: P.args, **kwargs: P.kwargs
+    ) -> Sequence[ProvidedTools]:
+        ...
+
+    @overload
+    async def __call__[TP: PipelinePlugin[Any], **P, **I, R](
+        self, ext: InjectingToolExtension[TP, U, P, Callable[I, R]], inj: Callable[Concatenate[str, I], R], /, *args: P.args, **kwargs: P.kwargs
+    ) -> Sequence[ProvidedTools]:
+        ...
+
+    async def __call__( #type: ignore[trust me bro]
+        self,
+        ext: ToolExtension[Any, U, ...] | InjectingToolExtension[Any, U, ..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Sequence[ProvidedTools]:
+        got: list[ProvidedTools] = []
+        for plugin_id, p, ctxt in self._plugins:
+            if isinstance(p, ext.provider):
+                if isinstance(ext, InjectingToolExtension):
+                    # args[0] is the backend's injectable (positional-only in
+                    # the overload); the hook receives it with this plugin's
+                    # id already bound.
+                    t = await ext.project(p)(
+                        self._comp, self._props, ctxt,
+                        functools.partial(args[0], plugin_id),
+                        *args[1:], **kwargs,
+                    )
+                else:
+                    t = await ext.project(p)(self._comp, self._props, ctxt, *args, **kwargs)
+                if t is not None:
+                    got.append(t)
+            if isinstance(p, AnyBackendTools):
+                t = await p.backend_tools(self._comp, self._props, ctxt)
+                if t is not None:
+                    got.append(t)
+        return got
+
+
 
 def _budget_context(budget: RunBudget | None) -> ContextManager[None]:
     if budget is not None:
@@ -318,7 +493,6 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
         ecosystem,
         plugin_manager.bind_phase(
             phases.get("extraction_plugin") or phases["extraction"],
-            "Property Extraction"
         )
     )
     staged = await staged_task
@@ -338,6 +512,27 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
         result_key = backend.to_artifact_id(batch.feat)
         backend.artifact_store.write_properties(result_key, batch.props)
 
+        # Deriving the backend's declared provider class gates the dispatch AND
+        # keys the cache: whether a hook would actually yield tools is only
+        # knowable inside ``formalize`` (dispatch needs backend state that
+        # doesn't exist yet), so both run off what the plugin derives. A plugin
+        # outside this backend's gate is invisible to its binder, and so must
+        # not perturb its key either. No task machinery: tool hooks are
+        # tool-BINDING hooks, so they get the runner-less context and cannot
+        # run top-level tasks.
+        contributing_plugins : list[str] = []
+        bound_plugins : list[tuple[str, PipelinePlugin[U], PluginToolContext[FormalizationTool]]] = []
+        collected = _ArtifactCollector()
+
+        for plugin_id, plugin in plugin_manager.sorted_plugins():
+            if not _contributes_tools(plugin, formalizer.tool_provider_type):
+                continue
+            k = batch.feat_ctx.child(PLUGIN_FORMALIZATION_KEY(plugin_id))
+            bound_plugins.append((plugin_id, plugin, plugin_manager.tool_context(
+                plugin, k, collected.for_plugin(plugin_id),
+            )))
+            contributing_plugins.append(plugin_id)
+
         # Record the formalization edge's exact derivation inputs — the final
         # (post-plugin) batch and the gated plugin ids — as a first-class cache
         # entry, keyed like the bug analysis (the component namespace is shared
@@ -349,12 +544,13 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                 interactive,
                 combine_digests([d.to_digest() for d in extra_context]),
             )
-        ).cache_put(FinalProperties(items=batch.props))
+        ).cache_put(FinalProperties(items=batch.props, tool_plugins=contributing_plugins))
 
         child : WorkflowContext[FormT] = await batch.feat_ctx.child(
-            FORMALIZATION_KEY(formalizer.formalized_type, batch.props),
+            FORMALIZATION_KEY(formalizer.formalized_type, batch.props, contributing_plugins),
             {"properties": [p.model_dump() for p in batch.props]},
         )
+        artifacts_ctx = child.child(PLUGIN_ARTIFACTS_KEY)
         cached_result: FormT | None = await child.cache_get(formalizer.formalized_type)
         result : FormT | Curtailed[FormT] | GaveUp
         if cached_result is None:
@@ -366,19 +562,27 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                         label,
                         phases["formalization"]
                     ),
-                    lambda: formalizer.formalize(label, batch.feat, batch.props, child, run),
+                    lambda: formalizer.formalize(
+                        label, batch.feat, batch.props, child, run,
+                        _Binder(bound_plugins, batch.feat, batch.props)
+                    ),
                 )
             # Snapshot what the tools registered: a cache replay of this
             # formalization never runs the tools, so the artifacts must ride
             # the cache alongside the result they accompany.
             if not isinstance(result, GaveUp):
-                # A curtailed partial is never the
+                await artifacts_ctx.cache_put(RegisteredArtifacts(items=collected.items))
+                # Envelope before result: a crash between the two puts replays
+                # as a miss (re-run, envelope rewritten) rather than a hit with
+                # silently absent artifacts. A curtailed partial is never the
                 # component's cached result — a later run redoes the
                 # formalization under a fresh budget.
                 if not isinstance(result, Curtailed):
                     await child.cache_put(result)
         else:
             result = cached_result
+            restored = await artifacts_ctx.cache_get(RegisteredArtifacts)
+            collected.items = restored.items if restored is not None else []
 
         outcome: Delivered[FormT] | Curtailed[Delivered[FormT]] | GaveUp
         if isinstance(result, GaveUp):
@@ -395,7 +599,22 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
             )
         else:
             outcome = Delivered(result, backend.artifact_store.write_artifact(result_key, result))
-        return ComponentOutcome(batch.feat, batch.props, outcome)
+
+        # Persist registered artifacts on every path (fresh run or cache
+        # replay), like ``write_artifact`` above — deliverables are rebuilt
+        # from cache content, never assumed to survive on disk. A gave-up
+        # component keeps whatever its tools registered before the surrender.
+        persisted = [
+            PersistedPluginArtifact(
+                plugin=pa.plugin,
+                artifact=pa.artifact,
+                path=backend.artifact_store.write_plugin_artifact(
+                    result_key, pa.plugin, pa.artifact
+                ),
+            )
+            for pa in collected.items
+        ]
+        return ComponentOutcome(batch.feat, batch.props, outcome, persisted)
 
     settled = await asyncio.gather(*[_run(b) for b in batches], return_exceptions=True)
     outcomes = [o if isinstance(o, ComponentOutcome)
@@ -415,6 +634,18 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
         )
         for o in outcomes
     ] + formalizer.extra_report_inputs()
+    artifact_records = [
+        VerificationArtifactRecord(
+            component=o.feat.display_name,
+            plugin=pa.plugin,
+            name=pa.artifact.name,
+            kind=pa.artifact.kind,
+            description=pa.artifact.description,
+            path=str(pa.path),
+        )
+        for o in outcomes
+        for pa in o.artifacts
+    ]
     findings_evidence = formalizer.findings_evidence()
     try:
         async def _report() -> AutoProverReport:
@@ -422,6 +653,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                 contract_name=source.contract_name, backend=formalizer.backend_tag,
                 components=inputs, llm=run.env.llm_lite(), fetch_verdicts=formalizer.fetch_verdicts,
                 source_edits=await formalizer.source_edits(outcomes, run),
+                verification_artifacts=artifact_records,
                 # Findings only when the backend supplies evidence — skip the heavy model otherwise.
                 findings_llm=run.env.llm_heavy() if findings_evidence else None,
                 fetch_evidence=findings_evidence,

--- a/composer/pipeline/keys.py
+++ b/composer/pipeline/keys.py
@@ -27,8 +27,8 @@ registry: ``composer.spec.source.keys``.
 
 from typing import Any
 
-from composer.pipeline.ptypes import FinalProperties
-from composer.spec.context import ComponentGroup, Properties
+from composer.pipeline.ptypes import FinalProperties, RegisteredArtifacts
+from composer.spec.context import CacheKey, ComponentGroup, Properties
 from composer.spec.key_family import KeyFamily, PolyKeyFamily
 from composer.spec.prop_inference import (
     AGENT_RESULT_KEY, AGENT_ROUND_KEY, BUG_ANALYSIS_KEY,
@@ -37,7 +37,7 @@ from composer.spec.system_model import FeatureUnit
 from composer.spec.types import PropertyFormulation
 from composer.spec.util import string_hash
 
-from .plugin_api import PostPropertyInference, PrePropertyInference
+from .plugin_api import PostPropertyInference, PrePropertyInference, FormalizationTool
 
 __all__ = [
     "AGENT_RESULT_KEY",
@@ -47,6 +47,7 @@ __all__ = [
     "COMPONENT_KEY",
     "FINAL_PROPERTIES_KEY",
     "FORMALIZATION_KEY",
+    "PLUGIN_ARTIFACTS_KEY",
     "POST_PROPERTY_KEY",
     "PRE_PROPERTY_KEY",
     "PROPERTIES_KEY",
@@ -118,10 +119,27 @@ def _final_properties_key(
 #: read by offline walkers (``composer.meta.run``) to reconstruct that edge.
 FINAL_PROPERTIES_KEY = KeyFamily(ComponentGroup, FinalProperties, _final_properties_key)
 
+
+def _props_and_plugins(props: list[PropertyFormulation], plugins: list[str] | None = None) -> str:
+    if not plugins:
+        return _props_digest(props)
+    return _props_digest(props) + "-" + string_hash("|".join(plugins))
+
 #: One unit's formalization result, keyed by the exact property batch. The
 #: child is the backend's result type — pass ``formalizer.formalized_type``.
-FORMALIZATION_KEY = PolyKeyFamily(ComponentGroup, _props_digest)
+FORMALIZATION_KEY = PolyKeyFamily(ComponentGroup, _props_and_plugins)
 
+#: The verification artifacts a batch's plugin tools registered, cached under
+#: the formalization child so cache replays (where the tools never run) still
+#: carry them into the report. Parent is the backend's result-typed namespace,
+#: which no static declaration can name — hence ``Any``.
+PLUGIN_ARTIFACTS_KEY = CacheKey[Any, RegisteredArtifacts]("plugin-artifacts")
+
+
+def _plugin_formalization_key(plugin: str):
+    return f"formalization-plugin-{plugin}"
+
+PLUGIN_FORMALIZATION_KEY = KeyFamily(ComponentGroup, FormalizationTool, _plugin_formalization_key)
 
 def _pre_property_key(feat: FeatureUnit, plugin: str) -> str:
     return f"{component_digest(feat)}-{string_hash(plugin)}-pre"

--- a/composer/pipeline/plugin_api.py
+++ b/composer/pipeline/plugin_api.py
@@ -1,23 +1,30 @@
-from typing import AsyncContextManager, Protocol, Callable, Awaitable, Any
+from typing import AsyncContextManager, Protocol, Callable, Awaitable, Any, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from abc import ABC, abstractmethod
-from graphcore.graph import TemplateLoader
+
+from langchain_core.tools import BaseTool
+
+from graphcore.graph import TemplateLoader, PromptInput
 from jinja2.loaders import BaseLoader, PackageLoader, ChoiceLoader, PrefixLoader
 
 from composer.templates.loader import base_loader, load_jinja_template, _autoescape
 from composer.spec.system_model import FeatureUnit
-from composer.pipeline.ptypes import PipelineRun
 from composer.spec.context import WorkflowContext, SourceCode
 from composer.spec.service_host import ServiceHost
-from composer.spec.types import PropertyFormulation
+from composer.spec.types import PropertyFormulation, VerificationArtifact
 from composer.spec.prop_inference import AnyPropertyGenerationInput
 
-class PluginContext[C](Protocol):
+class PluginRunContext[C](Protocol):
+    """The run's services, without the task runner: what a tool-binding hook gets.
+    Tool hooks bind tools into the backend's authoring graph — they don't run
+    top-level tasks, so the runner capability lives only on :class:`PluginContext`,
+    the task-hook context."""
+
     @property
     def ctx(self) -> WorkflowContext[C]:
         ...
-    
+
     @property
     def env(self) -> ServiceHost:
         ...
@@ -26,6 +33,7 @@ class PluginContext[C](Protocol):
     def source(self) -> SourceCode:
         ...
 
+class PluginContext[C](PluginRunContext[C], Protocol):
     async def runner[T](
         self,
         label: str,
@@ -33,10 +41,35 @@ class PluginContext[C](Protocol):
     ) -> T:
         ...
 
+
+class ArtifactRegistrar(Protocol):
+    """How a plugin's contributed tool reports a verification artifact it
+    produced (a Lean proof, an auxiliary certificate, …). Registration is
+    in-memory and synchronous — the driver persists registered artifacts via
+    the run's artifact store and records them in the report, attributed to the
+    registering plugin. Call it from tool bodies as they produce results; the
+    driver collects per formalization batch."""
+
+    def register(self, artifact: VerificationArtifact) -> None:
+        ...
+
+
+class PluginToolContext[C](PluginRunContext[C], Protocol):
+    """What a tool-binding hook receives: the run's services plus the artifact
+    registrar for the batch being formalized. Still no task runner — tool hooks
+    bind tools, they don't run top-level tasks."""
+
+    @property
+    def artifacts(self) -> ArtifactRegistrar:
+        ...
+
 class PrePropertyInference:
     pass
 
 class PostPropertyInference:
+    pass
+
+class FormalizationTool:
     pass
 
 import jinja2
@@ -68,8 +101,43 @@ class _PluginEnvironment(Environment):
             return prefix + template
         return template
 
+@dataclass
+class ProvidedTools:
+    tools: Sequence[BaseTool]
+    system_prompt_injection: PromptInput
+
+def plugin_jinja_loader(
+    loader: BaseLoader | None | type
+) -> TemplateLoader:
+    if loader is None:
+        return load_jinja_template
+
+    if isinstance(loader, type):
+        try:
+            loader = PackageLoader(loader.__module__)
+        except ValueError:
+            return load_jinja_template
+    
+    new_jinja_loader = ChoiceLoader([
+        loader,
+        _NonStrippingPrefixLoader({
+            "autoprover": base_loader
+        })
+    ])
+    compilation_env = _PluginEnvironment(loader=new_jinja_loader, autoescape=_autoescape)
+    def _load_jinja_template(template_name: str, **kwargs: Any) -> str:
+        """Load and render a Jinja template from the script directory"""
+        template = compilation_env.get_template(template_name)
+        return template.render(**kwargs)
+    return _load_jinja_template
+
+
 class PipelinePlugin[U: FeatureUnit](ABC):
-    """A pipeline plugin, parameterized by the unit type its hooks accept."""
+    """A pipeline plugin, parameterized by the unit type its hooks accept. Tool
+    contribution is not declared here: a plugin opts in by deriving from a
+    tool-provider subclass instead of this base directly — a backend's own
+    (``composer.spec.source.plugin.CertoraProverTools``,
+    ``composer.foundry.plugin.FoundryTools``) or :class:`AnyBackendTools` below."""
 
     NAME: str
 
@@ -79,27 +147,11 @@ class PipelinePlugin[U: FeatureUnit](ABC):
             return PackageLoader(t)
         except ValueError:
             return None
-    
+
     @cached_property
     def load_jinja_template(self) -> TemplateLoader:
         loader = self.plugin_loader()
-        if loader is None:
-            return load_jinja_template
-        
-    
-        new_jinja_loader = ChoiceLoader([
-            loader,
-            _NonStrippingPrefixLoader({
-                "autoprover": base_loader
-            })
-        ])
-        compilation_env = _PluginEnvironment(loader=new_jinja_loader, autoescape=_autoescape)
-        def _load_jinja_template(template_name: str, **kwargs: Any) -> str:
-            """Load and render a Jinja template from the script directory"""
-            template = compilation_env.get_template(template_name)
-            return template.render(**kwargs)
-        return _load_jinja_template
-
+        return plugin_jinja_loader(loader)
 
     async def property_inference_input_hook(
         self,
@@ -116,6 +168,41 @@ class PipelinePlugin[U: FeatureUnit](ABC):
     ) -> list[PropertyFormulation]:
         return props
 
+
+# ---------------------------------------------------------------------------
+# Tool contribution — deriving a tool-provider subclass IS the declaration
+# ---------------------------------------------------------------------------
+#
+# A plugin contributes formalization tools by deriving from a tool-provider
+# subclass of PipelinePlugin: each backend defines its own in its own package
+# (the prover's ``composer.spec.source.plugin.CertoraProverTools``, foundry's
+# ``composer.foundry.plugin.FoundryTools``) and hands it to the driver as a
+# ``ToolExtension`` (see ``composer.pipeline.core``) — this module stays
+# backend-agnostic. The driver dispatches — and perturbs the formalization
+# cache key for — exactly the plugins deriving the running backend's provider
+# class, so declaration and implementation cannot drift, and a plugin that
+# derives none (property-inference-only plugins) leaves every formalization
+# key plugin-free. Each hook returns one tool bundle, or None when it has
+# nothing for this particular unit/batch (None keeps the plugin in the cache
+# key: whether it yields is only knowable at dispatch time).
+
+
+class AnyBackendTools[U: FeatureUnit](PipelinePlugin[U]):
+    """The one backend-agnostic tool provider: the same tools for every backend,
+    present and future — so no staged backend state, since none is common across
+    backends. Always projected by the driver's binder, so it perturbs every
+    backend's formalization keys; prefer a backend's own provider class when the
+    tools are backend-specific. Composes with those: on a backend whose provider
+    class the plugin also derives, both hooks fire and both bundles are injected."""
+
+    @abstractmethod
+    async def backend_tools(
+        self,
+        comp: U,
+        prop: Sequence[PropertyFormulation],
+        tool_context: PluginToolContext[FormalizationTool],
+    ) -> ProvidedTools | None:
+        ...
 
 # ---------------------------------------------------------------------------
 # Scope — which runs a plugin applies to

--- a/composer/pipeline/plugins.py
+++ b/composer/pipeline/plugins.py
@@ -16,18 +16,37 @@ from composer.spec.system_model import FeatureUnit
 from composer.spec.util import combine_digests, string_hash
 from .ptypes import PipelineRun
 from .plugin_api import (
-    AnyEcosystem, ForEcosystem, PipelinePluginLoader, PipelinePlugin, PluginContext, PluginScope,
+    AnyEcosystem, ArtifactRegistrar, ForEcosystem, PipelinePluginLoader, PipelinePlugin,
+    PluginContext, PluginRunContext, PluginScope, PluginToolContext,
 )
 
 class _RunnerFun(Protocol):
     async def __call__[T](self, label: str, job: Callable[[], Awaitable[T]]) -> T: ...
 
+
+def _with_plugin_loader(env: ServiceHost, plugin: PipelinePlugin[Any]) -> ServiceHost:
+    """The run's services with the plugin's own template loader swapped in, so the
+    plugin's prompts resolve against its package (falling back to the autoprover
+    namespace — see ``plugin_api.plugin_jinja_loader``)."""
+    return replace(env, models=replace(env.models, _loader=plugin.load_jinja_template))
+
+
 @dataclass
-class PluginRunner[C]:
+class _PluginServices[C]:
+    """The runner-less :class:`PluginRunContext` implementation."""
     ctx: WorkflowContext[C]
     env: ServiceHost
     source: SourceCode
 
+
+@dataclass
+class _PluginToolServices[C](_PluginServices[C]):
+    """The :class:`PluginToolContext` implementation — what tool-binding hooks
+    receive: run services plus the batch's artifact registrar."""
+    artifacts: ArtifactRegistrar
+
+@dataclass
+class PluginRunner[C](_PluginServices[C]):
     runner: _RunnerFun
 
 class DisplayStrings(tuple[str, str]):
@@ -50,7 +69,7 @@ class DisplayStrings(tuple[str, str]):
 class PluginPhaseRunner[P: enum.Enum, U: FeatureUnit]:
     plugin: PipelinePlugin[U]
     _run: PipelineRun[P, Any]
-    _phase: tuple[P, str]
+    _phase: P
     _sub_phase: DisplayStrings
     plugin_id: str
 
@@ -59,21 +78,18 @@ class PluginPhaseRunner[P: enum.Enum, U: FeatureUnit]:
         uid: str,
         ctxt: WorkflowContext[C]
     ) -> PluginContext[C]:
-        new_loader = self.plugin.load_jinja_template
-        env = self._run.env
-        env = replace(env, models=replace(env.models, _loader=new_loader))
         async def run[T](
             label: str,
             job: Callable[[], Awaitable[T]]
         ) -> T:
             label = f"(Plugin {self._sub_phase.display_str}) {self.plugin.NAME}: {label}"
             return await self._run.runner(
-                TaskInfo(f"{self._phase[0].name}-{self._sub_phase.id_str}-{self.plugin_id}-{uid}", label, self._phase[0]),
+                TaskInfo(f"{self._phase.name}-{self._sub_phase.id_str}-{self.plugin_id}-{uid}", label, self._phase),
                 job,
             )
         return PluginRunner(
             ctxt,
-            env,
+            _with_plugin_loader(self._run.env, self.plugin),
             self._run.source,
             run
         )
@@ -139,16 +155,34 @@ class PluginManager[P: enum.Enum, U: FeatureUnit]:
     def plugin_manifest(self) -> list[str]:
         return sorted(self._plugins.keys())
 
+    def sorted_plugins(self) -> Iterable[tuple[str, PipelinePlugin[U]]]:
+        """Deterministic ``(plugin id, plugin)`` iteration — the order tool
+        contributions are bound in (injection order is prompt content)."""
+        return sorted(self._plugins.items(), key=lambda r: r[0])
+
+    def tool_context[C](
+        self,
+        plugin: PipelinePlugin[U],
+        ctxt: WorkflowContext[C],
+        artifacts: ArtifactRegistrar,
+    ) -> PluginToolContext[C]:
+        """The context a tool-binding hook receives: the run's services under the
+        plugin's template loader, the batch's artifact registrar, and deliberately
+        NO task runner — tool hooks bind tools, they don't run top-level tasks."""
+        return _PluginToolServices(
+            ctxt, _with_plugin_loader(self._run.env, plugin), self._run.source, artifacts
+        )
+
     def bind_phase(
-        self, phase: P, label: str
+        self, phase: P
     ) -> "PluginPhaseManager[P, U]":
         return PluginPhaseManager(
-            self._plugins, self._run, (phase, label)
+            self._plugins, self._run, phase
         )
 
 @dataclass
 class PluginPhaseManager[P: enum.Enum, U: FeatureUnit](PluginManager[P, U]):
-    _phase: tuple[P, str]
+    _phase: P
 
     def runners(self, *, sub_phase_id: str, sub_phase_label: str, sorted_run: bool = False) -> Iterable[PluginPhaseRunner[P, U]]:
         to_iter : Iterable[tuple[str, PipelinePlugin[U]]] = sorted(

--- a/composer/pipeline/ptypes.py
+++ b/composer/pipeline/ptypes.py
@@ -15,7 +15,9 @@ from composer.spec.service_host import ServiceHost
 from composer.spec.system_model import (
     FeatureUnit,
 )
-from composer.spec.types import Curtailed, PropertyFormulation, FormalResult
+from composer.spec.types import (
+    Curtailed, PropertyFormulation, FormalResult, VerificationArtifact,
+)
 from composer.spec.source.report.collect import ReportableResult
 
 
@@ -80,14 +82,39 @@ class BackendJob[U: FeatureUnit]:
     feat: U
     props: list[PropertyFormulation]
 
+
 class FinalProperties(BaseModel):
     """A component's property batch as it left the property pipeline — after
-    every post-inference plugin rewrite. This is exactly the input
+    every post-inference plugin rewrite — plus the tool-contributing plugin
+    ids the driver gated in. Together these are exactly the inputs
     ``FORMALIZATION_KEY`` is derived from, so an offline walker
-    can reconstruct the formalization edge without
+    (``composer.meta.run``) can reconstruct the formalization edge without
     sniffing the store. Written by the driver at formalization time; the
     pre-rewrite batch remains ``_BugAnalysisCache``."""
     items: list[PropertyFormulation]
+    tool_plugins: list[str]
+
+class PluginArtifact(BaseModel):
+    """One registered verification artifact with its contributing plugin's id —
+    the driver stamps the attribution, so plugins never handle their own id."""
+    plugin: str
+    artifact: VerificationArtifact
+
+
+class RegisteredArtifacts(BaseModel):
+    """The artifacts a batch's plugin tools registered during formalization,
+    cached under the formalization namespace so cache replays (where the tools
+    never run) still carry them into the report."""
+    items: list[PluginArtifact]
+
+
+@dataclass(frozen=True)
+class PersistedPluginArtifact:
+    """A registered artifact after the store wrote it: the registration plus
+    the project-relative path the report records."""
+    plugin: str
+    artifact: VerificationArtifact
+    path: Path
 
 
 @dataclass(frozen=True)
@@ -113,6 +140,10 @@ class Delivered[FormT: BackendResult]:
 @dataclass
 class ComponentOutcome[FormT: BackendResult, U: FeatureUnit](BackendJob[U]):
     result: Delivered[FormT] | GaveUp | BaseException | Curtailed[Delivered[FormT]]
+    #: Verification artifacts the batch's plugin tools registered, already
+    #: persisted by the artifact store. Independent of ``result``: a component
+    #: that gave up may still have produced artifacts worth reporting.
+    artifacts: list[PersistedPluginArtifact] = field(default_factory=list)
 
 @dataclass
 class CorePipelineResult[FormT: BackendResult]:

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -117,11 +117,17 @@ class ProverReport:
     them through the return value.
 
     ``link`` is the prover run's URL (cloud) or local results directory.
+
+    ``certora_run_stdout`` is the captured stdout of the ``certoraRun``
+    invocation. It carries diagnostic signal that never reaches the rule
+    results — e.g. internal function summarization silently failing on
+    stack-too-deep — so it rides along even on successful runs.
     """
     raw_rule_status: dict[RulePath, StatusCodes]
 
     result_str: str
     link: str
+    certora_run_stdout: str
 
     @property
     def rule_status(self) -> dict[str, bool]:
@@ -565,4 +571,5 @@ async def run_prover(
         raw_rule_status=raw_rule_results,
         result_str=result_str,
         link=run_result["link"],
+        certora_run_stdout=stdout,
     )

--- a/composer/prover/ptypes.py
+++ b/composer/prover/ptypes.py
@@ -64,10 +64,12 @@ class RuleResult:
     If status == ERROR, error_msg is non-none
     """
     path: RulePath
-    cex_dump: Optional[str]
+    cex_dump: str | None
     status: StatusCodes
 
     error_messages: list[str] = field(default_factory=list)
+
+    live_check_info : str | None = field(default=None)
 
     @property
     def name(self) -> str:

--- a/composer/prover/results.py
+++ b/composer/prover/results.py
@@ -100,9 +100,9 @@ def flatten_tree_view(context: Path, r: RuleNodeModel, path: RulePath, parent_ty
         if all(
             "timed-out" in err or ("did not run: BlockingCoroutine was cancelled") in err for err in messages
         ):
+            # time out masquerading as an error...    
             stat = "TIMEOUT"
         else:
-            # time out masquerading as an error...    
             return [RuleResult(
                 path=effective_path,
                 cex_dump=None,
@@ -133,7 +133,7 @@ def flatten_tree_view(context: Path, r: RuleNodeModel, path: RulePath, parent_ty
             )]
 
     if stat == "TIMEOUT":
-        if all(r.nodeType == "SANITY" for r in r.children):
+        if all(tc.nodeType == "SANITY" for tc in r.children):
             return [RuleResult(path=effective_path, cex_dump=None,status=stat, live_check_info=r.LiveCheckInfo)]
     assert stat == "TIMEOUT" or stat == "VIOLATED" or stat == "SANITY_FAILED"
     violated_assert_children = any([ c.nodeType == "VIOLATED_ASSERT" for c in r.children])

--- a/composer/prover/results.py
+++ b/composer/prover/results.py
@@ -22,6 +22,7 @@ class RuleNodeModel(BaseModel):
     status: Optional[str] = Field(description="The smt status")
     nodeType: str
     errors: list[RuleNotificationMessages]
+    LiveCheckInfo: str | None = Field(default=None)
 
 
 class TreeViewStatus(BaseModel):
@@ -96,12 +97,18 @@ def flatten_tree_view(context: Path, r: RuleNodeModel, path: RulePath, parent_ty
     if stat == "ERROR":
         messages : set[str] = set()
         _collect_child_errors(r, messages, lambda sev: sev == "error")
-        return [RuleResult(
-            path=effective_path,
-            cex_dump=None,
-            status=stat,
-            error_messages=list(messages)
-        )]
+        if all(
+            "timed-out" in err or ("did not run: BlockingCoroutine was cancelled") in err for err in messages
+        ):
+            stat = "TIMEOUT"
+        else:
+            # time out masquerading as an error...    
+            return [RuleResult(
+                path=effective_path,
+                cex_dump=None,
+                status=stat,
+                error_messages=list(messages)
+            )]
     elif stat == "SKIPPED":
         warning_message = [
             i.message for i in r.errors if i.severity == "error" or i.severity == "warning"
@@ -126,8 +133,8 @@ def flatten_tree_view(context: Path, r: RuleNodeModel, path: RulePath, parent_ty
             )]
 
     if stat == "TIMEOUT":
-        if len(r.children) == 0:
-            return [RuleResult(path=effective_path, cex_dump=None,status=stat)]
+        if all(r.nodeType == "SANITY" for r in r.children):
+            return [RuleResult(path=effective_path, cex_dump=None,status=stat, live_check_info=r.LiveCheckInfo)]
     assert stat == "TIMEOUT" or stat == "VIOLATED" or stat == "SANITY_FAILED"
     violated_assert_children = any([ c.nodeType == "VIOLATED_ASSERT" for c in r.children])
     if violated_assert_children:

--- a/composer/spec/artifacts.py
+++ b/composer/spec/artifacts.py
@@ -18,7 +18,7 @@ from typing import TypedDict, Unpack
 
 from composer.diagnostics.timing import RunSummary
 from composer.spec.gen_types import PROPERTIES_SUBDIR, under_project
-from composer.spec.types import PropertyFormulation
+from composer.spec.types import PropertyFormulation, VerificationArtifact
 from composer.spec.util import ensure_dir
 from .types import ArtifactIdentifier, FormalResult
 from composer.spec.source.report.schema import AutoProverReport
@@ -78,6 +78,21 @@ class ArtifactStore[I: ArtifactIdentifier, FormT: FormalResult](ABC):
         target_dir = ensure_dir(self._artifact_dir())
         target_path = target_dir / (i.artifact_file + QUARANTINE_SUFFIX)
         target_path.write_text(artifact.artifact_text)
+        return target_path.relative_to(self._project_root)
+
+    def write_plugin_artifact(
+        self, i: I, plugin: str, artifact: VerificationArtifact
+    ) -> Path:
+        """A verification-supporting artifact a plugin's tool registered for unit
+        ``i`` → ``{artifact_dir}/certificates/{stem}/{plugin}/{name}``. The name is
+        reduced to its basename and namespaced per unit and plugin, so tools cannot
+        traverse or collide. Returns the project-relative path (what the report
+        records)."""
+        target_dir = ensure_dir(
+            self._artifact_dir() / "certificates" / i.stem / plugin
+        )
+        target_path = target_dir / Path(artifact.name).name
+        target_path.write_text(artifact.content)
         return target_path.relative_to(self._project_root)
 
     def _deliverable_dir(self) -> Path:

--- a/composer/spec/solana/null_backend.py
+++ b/composer/spec/solana/null_backend.py
@@ -14,7 +14,7 @@ import enum
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import override
+from typing import override, Sequence, Any
 
 from pydantic import BaseModel, Field
 
@@ -25,6 +25,7 @@ from composer.pipeline.core import (
     PipelineRun,
     PreparedSystem,
     SystemAnalysisSpec,
+    ToolBinder,
 )
 from composer.spec.artifacts import ArtifactStore
 from composer.spec.context import WorkflowContext
@@ -121,6 +122,7 @@ class NullSolanaFormalizer(Formalizer[NullResult, SolanaComponentInstance]):
         props: list[PropertyFormulation],
         ctx: WorkflowContext[NullResult],
         run: PipelineRun,
+        extra_tools: ToolBinder[SolanaComponentInstance]
     ) -> NullResult | GaveUp:
         return NullResult(
             commentary=f"Null formalization of instruction {feat.display_name} "

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -1,6 +1,9 @@
-from typing import Callable, NotRequired, Sequence, override, Literal, Annotated
+from typing import AsyncIterator, NotRequired, override, Literal, Annotated, Sequence, Protocol, Callable
+
 from typing_extensions import TypedDict
+from contextlib import asynccontextmanager
 import json
+import pathlib
 
 from dataclasses import dataclass
 
@@ -11,9 +14,8 @@ from graphcore.tools.schemas import (
     WithAsyncImplementation, WithImplementation, WithInjectedId, WithInjectedState,
     WithAsyncDependencies
 )
+from graphcore.graph import tool_state_update, RawPromptInput, CacheMarker, SummaryConfig
 from graphcore.tools.vfs import VFSAccessor, VFSState
-from graphcore.graph import tool_state_update
-from graphcore.summary import SummaryConfig
 
 from composer.spec.cvl_generation import (
     static_tools, property_tools, skip_tools, CVLGenerationExtra, FEEDBACK_VALIDATION_KEY,
@@ -21,13 +23,18 @@ from composer.spec.cvl_generation import (
     GeneratedCVL, PropertyRuleMapping, AppliedEdit, FeedbackToolBase, SkippedProperty,
     PropertyFeedbackProtocol,
 )
+from composer.prover.core import run_prover, CexHandler, ProverCallbacks, ProverReport
 from composer.spec.source.live_explorer import VersionedHistory, LiveEditTools, WIPE_HISTORY
+from composer.spec.source.prover import setup_prover_config_in
 from composer.spec.context import WorkflowContext, CVLGeneration, CacheKey, SourceCode
 from composer.spec.types import PropertyFormulation
-from composer.pipeline.core import Curtailed, GaveUp
+from composer.pipeline.core import GaveUp, ToolBinder, InjectingToolExtension, Curtailed
+from composer.pipeline.plugin_api import ProvidedTools
+from composer.spec.source.plugin import CertoraProverTools, CVLAuthorState
 from composer.spec.system_model import ContractComponentInstance, SolidityIdentifier, component_context
 from composer.spec.source.prover import (
     OVERLAY_OWNED_KEYS, ProverStateExtra, DELETE_SKIP, VALIDATION_KEY as PROVER_VALIDATION_KEY,
+    materializing_project,
 )
 from langgraph.graph import MessagesState
 from pathlib import Path
@@ -37,6 +44,8 @@ from composer.llm.provider import CacheLevel
 from composer.kb.kb_context import with_cvl_context
 
 from composer.pipeline.ptypes import GaveUp
+
+from composer.prover.core import ProverOptions
 
 from langgraph.types import Command
 from graphcore.graph import Builder
@@ -53,7 +62,7 @@ from .monitor import monitor
 from composer.spec.source.conf_maps import (
     CompilerSettings, MapViolations, extend_compiler_maps, map_violation_message,
 )
-from composer.spec.source.munge.edit_store import EditStore
+from composer.spec.source.munge.edit_store import EditStore, PluginEditor
 from composer.spec.source.munge.munge_agent import editor_tool
 from composer.spec.source.munge.tool_names import (
     COMMIT_EDIT, CONFIG_EDIT, EDIT_HISTORY_LOG, REVERT_TO_EDIT,
@@ -61,6 +70,9 @@ from composer.spec.source.munge.tool_names import (
 from composer.spec.source.munge.vfs_diff import summarize_changes
 
 from graphcore.graph import FlowInput, MonitorReturn
+
+from composer.io.task_host import TaskHost
+from composer.io.task_tools import RETRIEVE_TASK, TASK_LIST, RetrieveTask, TaskListTool
 
 class SourceAuthorExtra(TypedDict):
     failed: bool | None
@@ -540,6 +552,18 @@ class SourceEditing:
     store: EditStore
 
 
+@dataclass(frozen=True)
+class EditingTools:
+    """Source editing and plugin tool contribution, fused: a contributed tool's
+    staged :class:`CVLAuthorState` proposes edits into the editing kit's store
+    and materializes against its working copy, so a binder without an editing
+    kit is unusable. Fusing them makes "tools provided ⟺ editing enabled" a
+    fact of the type rather than an assert (the structural-invariant phase
+    passes None: neither)."""
+    editing: SourceEditing
+    tool_provider: ToolBinder[ContractComponentInstance]
+
+
 class _LastAttemptEdits(BaseModel):
     """Sibling of cvl_generation's last-attempt draft cache: the applied-edit
     history at snapshot time. The working copy itself is deliberately not
@@ -616,6 +640,59 @@ class EditorAwareFeedbackTool(
 
 _PropertyGenTemplate = TypedTemplate[PropertyGenParams]("property_generation_prompt.j2")
 
+class PropertyGenSystemParams(TypedDict):
+    source_editing: bool
+
+_PropertyGenSysTemplate = TypedTemplate[PropertyGenSystemParams]("property_generation_system_prompt.j2")
+
+#: The prover's tool extension: contributions come from plugins deriving
+#: ``CertoraProverTools``, dispatched via their ``certora_prover_tools`` hook.
+_PROVER_TOOLS = InjectingToolExtension(
+    provider=CertoraProverTools, project=lambda p: p.certora_prover_tools
+)
+
+@dataclass
+class ProverTool:
+    lg_tool: BaseTool
+    options: ProverOptions
+
+@dataclass
+class WrappedProverRunner:
+    config: dict
+    prover_options: ProverOptions
+    main_contract: str
+
+    async def run(
+        self,
+        *,
+        curr_spec: str,
+        working_dir: str,
+        cex_handler: CexHandler,
+        callbacks: ProverCallbacks,
+        tool_call_id: str,
+        rules: list[str] | None = None,
+        **config,
+    ) -> ProverReport | str:
+        # The spec/conf staging only has to outlive the run itself, so one call
+        # stages, runs, and cleans up (the CVLAuthorState.prover_runner contract).
+        with setup_prover_config_in(
+            working_dir=working_dir,
+            spec_stem="adhoc_run",
+            main_contract=self.main_contract,
+            spec_contents=curr_spec,
+            config=self.config,
+            rule=rules,
+            **config
+        ) as (conf_path, _):
+            return await run_prover(
+                pathlib.Path(working_dir),
+                [conf_path],
+                tool_call_id,
+                self.prover_options,
+                callbacks, cex_handler
+            )
+
+
 _BUDGET_WRAPUP_MESSAGE = """
 <system-alert>
 You have almost exceeded the {resource} budget for this task. Wrap up IMMEDIATELY;
@@ -657,19 +734,20 @@ async def batch_cvl_generation(
     props: list[PropertyFormulation],
     component: ContractComponentInstance | None,
     resources: list[CVLResource],
-    prover_tool: BaseTool,
+    prover_tool: ProverTool,
     env: ServiceHost,
     description: str,
     source: SourceCode,
     spec_dir: Path,
     spec_stem: str,
-    editing: SourceEditing | None,
+    editing_tools: EditingTools | None,
 ) -> BatchGeneratedCVLResult:
     # *spec_dir* (project-root-relative) is where the caller will persist the spec
     # authored here. The prover resolves the spec's CVL imports relative to its own
     # directory, so resource imports are expressed relative to *spec_dir*.
     # *spec_stem* is the basename it is persisted under; the prover materializes its
     # transient spec/conf under the same stem so on-disk names match the dump.
+    editing = editing_tools.editing if editing_tools is not None else None
     resource_views: list[ResourceView] = [
         {
             "description": r.description,
@@ -685,6 +763,73 @@ async def batch_cvl_generation(
         "contract_name": source.contract_name,
         "sort": "existing"
     })
+
+    sys_prompt : list[RawPromptInput | type[CacheMarker]] = [
+        _PropertyGenSysTemplate.bind({"source_editing": editing is not None}).render_to
+    ]
+
+    added_tools : list[BaseTool] = []
+    if editing_tools is not None:
+        task_host = TaskHost()
+        kit = editing_tools.editing
+        # The same run-root strategy verify_spec uses (see ProjectDirectory): an
+        # empty working copy is read in-situ, a non-empty one against a temporary
+        # materialization whose lifetime is the contributed tool's invocation.
+        project_directory = materializing_project(source.project_root, kit.live.mat)
+
+        @asynccontextmanager
+        async def yield_state(
+            plugin_id: str,
+            st: SourceCVLGenerationState
+        ) -> AsyncIterator[CVLAuthorState]:
+            class _PluginStore:
+                async def propose(
+                    self, vfs: dict[str, str], *, executive_summary: str, why_sound: str
+                ) -> str:
+                    # Snapshot completion (the EditProposer contract): the
+                    # proposer's overlay is relative to the working copy this
+                    # read staged, but ApplyEditTool snapshots are wholesale —
+                    # so fold the author's own overlay back in, or applying
+                    # the proposal would silently revert prior edits.
+                    return await kit.store.commit(
+                        {**(st.get("vfs") or {}), **vfs},
+                        executive_summary=executive_summary,
+                        why_sound=why_sound,
+                        attribution=PluginEditor(plugin_id)
+                    )
+            async with project_directory(st.get("vfs") or {}) as run_root:
+                yield CVLAuthorState(
+                    working_dir=pathlib.Path(run_root),
+                    curr_spec=st["curr_spec"],
+                    prover_runner=WrappedProverRunner(
+                        st["config"],
+                        prover_tool.options,
+                        source.contract_name
+                    ).run,
+                    host=task_host,
+                    edit_store=_PluginStore()
+                )
+
+        tools = await editing_tools.tool_provider(
+            _PROVER_TOOLS, yield_state, SourceCVLGenerationState
+        )
+        if tools:
+            # The retrieval surface for whatever the contributed tools launch;
+            # dead prompt weight when no plugin contributed, so gated on a
+            # non-empty contribution.
+            added_tools.extend([
+                TaskListTool.bind(task_host).as_tool(TASK_LIST),
+                RetrieveTask.bind(task_host).as_tool(RETRIEVE_TASK),
+            ])
+    else:
+        tools = []
+
+    for inj in tools:
+        added_tools.extend(inj.tools)
+        if isinstance(inj.system_prompt_injection, list):
+            sys_prompt.extend(inj.system_prompt_injection)
+        else:
+            sys_prompt.append(inj.system_prompt_injection)
 
     titles = [p.title for p in props]
     judge_ctx = ctx.child(CVL_JUDGE_KEY)
@@ -728,7 +873,7 @@ async def batch_cvl_generation(
     ).with_tools(
         feedback_suite
     ).with_tools(
-        [prover_tool,
+        [prover_tool.lg_tool,
          ExpectRulePassage.as_tool("expect_rule_passage"),
          ExpectRuleFailure.as_tool("expect_rule_failure"),
          GiveUpTool.as_tool("give_up"),
@@ -742,10 +887,12 @@ async def batch_cvl_generation(
         "result"
     ).with_input(
         SourceCVLGenerationInput
-    ).with_sys_prompt_template(
-        "property_generation_system_prompt.j2", source_editing=editing is not None
+    ).with_sys_prompt(
+        [*sys_prompt]
     ).with_initial_prompt(
         with_cvl_context(bound_template.render_to)
+    ).with_tools(
+        added_tools
     ).with_summary_config(
         PropertyGenerationConfig(source_editing=editing is not None)
     ).compile_async()

--- a/composer/spec/source/autoprove_common.py
+++ b/composer/spec/source/autoprove_common.py
@@ -134,7 +134,6 @@ async def autoprove_executor(args: AutoProveArgs, summary: RunSummary) -> AsyncI
                 thread_id=thread_id,
                 task_handler=handler,
                 at_exit=exit_logger,
-
                 workflow="autoprove"
             ) as (staged, cont),
             PostgreSQLRAGDatabase.rag_context(staged.embed_model, args.rag_db) as rag_db

--- a/composer/spec/source/munge/edit_store.py
+++ b/composer/spec/source/munge/edit_store.py
@@ -5,14 +5,52 @@ from langgraph.store.base import BaseStore
 
 
 @dataclass(frozen=True)
+class MungeEditor:
+    """The munge editor sub-agent, commissioned through the author's
+    edit-request tool. Every record written before attribution existed has
+    this provenance — it was the only committer."""
+
+
+@dataclass(frozen=True)
+class PluginEditor:
+    """A pipeline plugin proposed this edit through the edit store staged into
+    its contributed tools; the CVL author still decides whether to apply it."""
+    plugin: str
+
+
+type EditAttribution = MungeEditor | PluginEditor
+
+
+def _attribution_payload(a: EditAttribution) -> dict:
+    match a:
+        case MungeEditor():
+            return {"kind": "munge-editor"}
+        case PluginEditor(plugin=plugin):
+            return {"kind": "plugin", "plugin": plugin}
+
+
+def _attribution_of(v: object) -> EditAttribution:
+    match v:
+        case None:
+            return MungeEditor()
+        case {"kind": "munge-editor"}:
+            return MungeEditor()
+        case {"kind": "plugin", "plugin": str(plugin)}:
+            return PluginEditor(plugin=plugin)
+        case _:
+            raise ValueError(f"Unrecognized edit attribution payload: {v!r}")
+
+
+@dataclass(frozen=True)
 class StoredEdit:
-    """A committed edit: the full VFS snapshot plus the editor's account of it.
-    The description fields ride into the edit-history log and the final
-    deliverable, so a reader can tell why the source was changed without
-    reconstructing the diff."""
+    """A committed edit: the full VFS snapshot, the committer's account of it,
+    and who committed it. The description fields ride into the edit-history log
+    and the final deliverable, so a reader can tell why the source was changed
+    without reconstructing the diff; ``attribution`` says on whose authority."""
     vfs: dict[str, str]
     executive_summary: str
     why_sound: str
+    attribution: EditAttribution
 
 
 @dataclass
@@ -29,6 +67,7 @@ class EditStore:
             vfs=cast(dict[str, str], v["vfs"]),
             executive_summary=cast(str, v["executive_summary"]),
             why_sound=cast(str, v["why_sound"]),
+            attribution=_attribution_of(v.get("attribution")),
         )
 
     @classmethod
@@ -41,12 +80,14 @@ class EditStore:
         return hasher.hexdigest()
 
     async def commit(
-        self, vfs: dict[str, str], *, executive_summary: str, why_sound: str
+        self, vfs: dict[str, str], *, executive_summary: str, why_sound: str,
+        attribution: EditAttribution,
     ) -> str:
         id = self._deterministic_hash(vfs)
         await self._store.aput(self._target_ns, id, {
             "vfs": {**vfs},
             "executive_summary": executive_summary,
             "why_sound": why_sound,
+            "attribution": _attribution_payload(attribution),
         })
         return id

--- a/composer/spec/source/munge/munge_agent.py
+++ b/composer/spec/source/munge/munge_agent.py
@@ -10,7 +10,7 @@ from langgraph.types import Command
 from langchain_core.tools import BaseTool
 from langchain_core.messages import ToolMessage
 
-from .edit_store import EditStore
+from .edit_store import EditStore, MungeEditor
 from .vfs_diff import summarize_changes
 from composer.spec.source.conf_maps import (
     CompilerSettings, MapViolations, extend_compiler_maps, map_violation_message,
@@ -146,6 +146,7 @@ class EditMungeTool(WithAsyncDependencies[str, MungeToolDeps], WithInjectedId, W
                 res["vfs"],
                 executive_summary=d.executive_summary,
                 why_sound=d.why_sound,
+                attribution=MungeEditor(),
             )
             diff = summarize_changes(
                 res, deps.accessor, self.state["vfs"]

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -22,7 +22,7 @@ context and hands them to ``run_pipeline``.
 import asyncio
 from dataclasses import dataclass
 from pathlib import Path
-from typing import override
+from typing import override, Sequence
 
 from langchain_core.tools import BaseTool
 
@@ -32,18 +32,21 @@ from composer.spec.types import PropertyFormulation
 from composer.spec.gen_types import CVLResource, SPECS_DIR, certora_relative_to_project
 from composer.spec.system_model import (
     ContractComponentInstance, ContractInstance, SourceApplication, HarnessedApplication,
+    SourceExplicitContract, HarnessedExplicitContract, SourceExternalActor,
+    HarnessDefinition, SolidityIdentifier,
 )
 from composer.spec.cvl_generation import GeneratedCVL
 from composer.spec.prop_inference import CERTORA_BACKEND_GUIDANCE
 from composer.spec.source.harness import (
     run_harness_creation, run_autosetup_phase, ContractSetup, SystemDescriptionHarnessed,
-    lift_harnessed
+    lift_harnessed,
 )
 from composer.spec.source.summarizer import setup_summaries
 from composer.spec.source.struct_invariant import get_invariant_formulation
 from composer.spec.source.autosetup import SetupSuccess
 from composer.spec.source.prover import get_prover_tool, materializing_project
-from composer.spec.source.author import batch_cvl_generation, SourceEditing
+from composer.spec.source.plugin import CertoraProverTools
+from composer.spec.source.author import batch_cvl_generation, EditingTools, SourceEditing, ProverTool
 from composer.spec.source.artifacts import ProverArtifactStore, ComponentSpec, InvariantSpec
 from composer.spec.source.report_prover import make_prover_fetcher
 from composer.spec.source.report.collect import (
@@ -62,12 +65,22 @@ from composer.prover.core import ProverOptions
 from composer.ui.autoprove_app import AutoProvePhase
 from composer.pipeline.core import (
     Formalizer, PreparedSystem, PipelineRun, Delivered, GaveUp,
-    CorePhases, SystemAnalysisSpec, ComponentOutcome,
+    CorePhases, SystemAnalysisSpec, ComponentOutcome, ToolBinder,
     Curtailed
 )
-from composer.pipeline.keys import COMMON_SYSTEM_CACHE_KEY
 from composer.pipeline.ecosystem import main_instance
+from composer.pipeline.keys import COMMON_SYSTEM_CACHE_KEY
 from composer.spec.source.keys import AP_PROPERTIES_KEY_NAME, INV_CVL_KEY
+
+@dataclass
+class _ProverPipelineDeps:
+    prover_options: ProverOptions
+    store: ProverArtifactStore
+    analysis_store: CexAnalysisStore
+    editing: SourceEditing
+
+    def to_prover_tool(self, tool: BaseTool) -> ProverTool:
+        return ProverTool(lg_tool=tool, options=self.prover_options)
 
 #: The invariant CVL's slot in the report: a real delivery (imported by every component spec)
 #: or the quarantined leftovers of a budget-curtailed generation (appendix only).
@@ -79,14 +92,18 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
     """Immutable formalizer: per-batch CVL generation against a fixed prover
     config + resource set (already including ``invariants.spec`` when there are
     structural invariants), plus the in-memory invariant result for the report."""
-    _store: ProverArtifactStore
+    # _store: ProverArtifactStore
     _prover_tool: BaseTool
     _prover_config: dict
     _resources: list[CVLResource]
     _invariant: tuple[list[PropertyFormulation], InvariantResult] | None
     _fetch: VerdictFetcher[GeneratedCVL]
-    _editing: SourceEditing
-    _analysis_store: CexAnalysisStore
+    # _editing: SourceEditing
+    # _analysis_store: CexAnalysisStore
+    # _prover_options: ProverOptions
+    _deps: _ProverPipelineDeps
+
+    tool_provider_type = CertoraProverTools
 
     @override
     async def formalize(
@@ -96,6 +113,7 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
         props: list[PropertyFormulation],
         ctx: WorkflowContext[GeneratedCVL],
         run: PipelineRun,
+        extra_tools: ToolBinder[ContractComponentInstance]
     ) -> GeneratedCVL | Curtailed[GeneratedCVL] | GaveUp:
         return await batch_cvl_generation(
             ctx=ctx.abstract(CVLGeneration),
@@ -103,13 +121,15 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
             props=props,
             component=feat,
             resources=self._resources,
-            prover_tool=self._prover_tool,
+            prover_tool=self._deps.to_prover_tool(self._prover_tool),
             env=run.env,
             description=label,
             source=run.source,
             spec_dir=SPECS_DIR,
             spec_stem=ComponentSpec(feat.slugified_name).stem,
-            editing=self._editing,
+            editing_tools=EditingTools(
+                editing=self._deps.editing, tool_provider=extra_tools
+            ),
         )
 
     @override
@@ -158,7 +178,7 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
         # per binding while the report shows a single row for the whole rule.
         return [
             RuleEvidence(label=r.label, analysis=r.analysis, counterexample=r.counterexample)
-            for r in await self._analysis_store.for_rule(rule_name)
+            for r in await self._deps.analysis_store.for_rule(rule_name)
         ]
 
     @override
@@ -174,21 +194,19 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
             inv = self._invariant[1]
             if isinstance(inv, Delivered) and inv.run_link:
                 runs[InvariantSpec().run_key] = inv.run_link
-        self._store.write_component_runs(runs)
+        self._deps.store.write_component_runs(runs)
 
 
 @dataclass
 class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, ContractInstance]):
     """Post-harness system: holds the harnessed app + prover tool, and runs the
     prover-only pre-formalization fan-out in ``prepare_formalization``."""
-    _store: ProverArtifactStore
     _sys_desc: SystemDescriptionHarnessed
     _harnessed: HarnessedApplication
     _prover_tool: BaseTool
-    _prover_opts: ProverOptions
     _analyzed: SourceApplication
-    _editing: SourceEditing
-    _analysis_store: CexAnalysisStore
+
+    _deps: _ProverPipelineDeps
 
     @override
     async def prepare_formalization(self, run: PipelineRun) -> Formalizer[GeneratedCVL, ContractComponentInstance]:
@@ -204,7 +222,7 @@ class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, Con
                 PropertyFormulation(title=inv.name, description=inv.description, sort="invariant")
                 for inv in invariants.inv
             ]
-            self._store.write_properties(InvariantSpec(), inv_props)
+            self._deps.store.write_properties(InvariantSpec(), inv_props)
 
             inv_cvl_ctx = run.ctx.child(INV_CVL_KEY)
             cached = await inv_cvl_ctx.cache_get(GeneratedCVL)
@@ -220,7 +238,7 @@ class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, Con
                         props=inv_props,
                         component=None,
                         resources=resources,
-                        prover_tool=self._prover_tool,
+                        prover_tool=self._deps.to_prover_tool(self._prover_tool),
                         env=run.env,
                         description="Structural invariant CVL",
                         source=run.source,
@@ -229,8 +247,9 @@ class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, Con
                         # Invariants are assumed as preconditions by every
                         # downstream spec, so they must hold against the
                         # unedited source: no editor, frozen source tools,
-                        # immutable-source judge.
-                        editing=None,
+                        # immutable-source judge — and, since the two travel
+                        # together, no plugin tool contribution either.
+                        editing_tools=None,
                     ),
                 )
                 if isinstance(inv_result, GaveUp):
@@ -249,14 +268,14 @@ class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, Con
                 partial = (
                     Delivered(
                         inv_cvl.partial,
-                        self._store.write_quarantined(InvariantSpec(), inv_cvl.partial),
+                        self._deps.store.write_quarantined(InvariantSpec(), inv_cvl.partial),
                     )
                     if inv_cvl.partial is not None else None
                 )
                 invariant = (inv_props, Curtailed(partial, inv_cvl.detail))
             else:
                 # Writes invariants.spec + bundle, returns its project-root-relative path.
-                inv_path = self._store.write_artifact(InvariantSpec(), inv_cvl)
+                inv_path = self._deps.store.write_artifact(InvariantSpec(), inv_cvl)
                 # All pre-formalization work has joined, so appending here is race-free;
                 # the per-component CVLs (run after this returns) will see invariants.spec.
                 resources = [*resources, CVLResource(
@@ -269,15 +288,15 @@ class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, Con
 
         return ProverRunner(
             GeneratedCVL, "prover",
-            self._store, self._prover_tool, setup_config.prover_config, resources, invariant,
-            make_prover_fetcher(), self._editing, self._analysis_store,
+            self._prover_tool, setup_config.prover_config, resources, invariant,
+            make_prover_fetcher(), self._deps
         )
 
     async def _autosetup(self, run: PipelineRun) -> tuple[SetupSuccess, list[CVLResource]]:
         setup_config = await run.runner(
             TaskInfo(AUTOSETUP_TASK_ID, "AutoSetup", AutoProvePhase.AUTOSETUP),
             lambda: run_autosetup_phase(
-                run.ctx, run.source, self._sys_desc, self._analyzed, self._prover_opts,
+                run.ctx, run.source, self._sys_desc, self._analyzed, self._deps.prover_options,
             ),
         )
         resources: list[CVLResource] = [CVLResource(
@@ -341,9 +360,10 @@ class ProverBackend:
             prover_opts=self._prover_opts, analysis_store=self.analysis_store,
         )
         return ProverPrepared(
-            main_instance(harnessed, run.source),
-            self.artifact_store, sys_desc, harnessed, prover_tool,
-            self._prover_opts, analyzed, self.editing, self.analysis_store,
+            main=main_instance(harnessed, run.source),
+            _sys_desc=sys_desc, _harnessed=harnessed, _prover_tool=prover_tool,
+            _analyzed=analyzed,
+            _deps=_ProverPipelineDeps(self._prover_opts, self.artifact_store, self.analysis_store, self.editing)
         )
 
     def to_artifact_id(self, c: ContractComponentInstance) -> ComponentSpec:

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -92,15 +92,11 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
     """Immutable formalizer: per-batch CVL generation against a fixed prover
     config + resource set (already including ``invariants.spec`` when there are
     structural invariants), plus the in-memory invariant result for the report."""
-    # _store: ProverArtifactStore
     _prover_tool: BaseTool
     _prover_config: dict
     _resources: list[CVLResource]
     _invariant: tuple[list[PropertyFormulation], InvariantResult] | None
     _fetch: VerdictFetcher[GeneratedCVL]
-    # _editing: SourceEditing
-    # _analysis_store: CexAnalysisStore
-    # _prover_options: ProverOptions
     _deps: _ProverPipelineDeps
 
     tool_provider_type = CertoraProverTools

--- a/composer/spec/source/plugin.py
+++ b/composer/spec/source/plugin.py
@@ -1,0 +1,91 @@
+"""The prover backend's plugin-extension surface.
+
+What a plugin imports to contribute tools to the prover's CVL author: the
+:class:`CertoraProverTools` provider class (deriving it IS the declaration — see
+``composer.pipeline.plugin_api``) and the :class:`ProverState` view its hooks can
+stage at tool-invocation time. Lives here rather than in the plugin API so the
+core/plugin layers stay backend-agnostic; the author hands the provider class to
+the driver's binder as a ``ToolExtension`` (``composer.pipeline.core``).
+"""
+
+import pathlib
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import AsyncContextManager, Callable, Sequence, Protocol
+
+from composer.pipeline.plugin_api import (
+    FormalizationTool, PipelinePlugin, PluginToolContext, ProvidedTools,
+)
+from composer.spec.system_model import FeatureUnit
+from composer.spec.types import PropertyFormulation
+from composer.prover.core import ProverReport, ProverCallbacks, CexHandler
+from composer.io.task_host import TaskHost
+
+class ProverRunner(Protocol):
+    """One ad-hoc prover run: stages the spec/conf into ``working_dir`` for the
+    duration of the call and forwards to ``run_prover``. ``config`` entries
+    override the author's current prover config for this run only."""
+    async def __call__(
+        self,
+        *,
+        curr_spec: str,
+        working_dir: str,
+        cex_handler: CexHandler,
+        callbacks: ProverCallbacks,
+        tool_call_id: str,
+        rules: list[str] | None = None,
+        **config,
+    ) -> ProverReport | str:
+        ...
+
+class EditProposer(Protocol):
+    """A plugin's narrowed window onto the run's edit store: stage a source
+    edit for the CVL author to consider. Proposing only records the edit and
+    returns its id — nothing changes until the author applies that id through
+    its edit-management tools. The implementation stamps the proposing
+    plugin's identity onto the record; attribution is not the proposer's to
+    choose.
+
+    ``vfs`` is the proposer's overlay *relative to the staged working copy*
+    its :class:`CVLAuthorState` was read with (the only view a plugin has).
+    The implementation completes it into the edit store's full-snapshot form —
+    merging the overlay the staged copy was materialized from — before
+    committing."""
+
+    async def propose(
+        self, vfs: dict[str, str], *, executive_summary: str, why_sound: str
+    ) -> str:
+        ...
+
+
+@dataclass
+class CVLAuthorState:
+    # The run root the prover would execute in: the project itself, or a temporary
+    # materialization of the author's working copy (lifetime = the read).
+    working_dir: pathlib.Path
+    curr_spec: str | None
+    prover_runner: ProverRunner
+    host: TaskHost
+    # Propose source edits for the author to apply; records carry the
+    # proposing plugin's attribution.
+    edit_store: EditProposer
+
+type ProverStateReader[T] = Callable[[T], AsyncContextManager[CVLAuthorState]]
+
+
+class CertoraProverTools[U: FeatureUnit](PipelinePlugin[U]):
+    """Contributes tools to the prover's CVL author. ``st``/``state_reader`` let a
+    contributed tool stage the author's live dependencies (:class:`ProverState`) at
+    invocation time: bind the reader into the tool, and open it against the injected
+    graph state of type ``st``."""
+
+    @abstractmethod
+    async def certora_prover_tools[T](
+        self,
+        comp: U,
+        prop: Sequence[PropertyFormulation],
+        tool_context: PluginToolContext[FormalizationTool],
+        state_reader: ProverStateReader[T],
+        st: type[T],
+    ) -> ProvidedTools | None:
+        ...

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -393,6 +393,39 @@ def materializing_project(
             await asyncio.to_thread(stack.close)
     return provide
 
+@contextmanager
+def setup_prover_config_in(
+    *,
+    working_dir: str,
+    config: dict,
+    spec_contents: str,
+    spec_stem: str | None = None,
+    main_contract: str,
+    rule: list[str] | None,
+    conf_dir: Path = CERTORA_DIR,
+    **config_extra
+):
+    with tmp_spec(
+        root=working_dir,
+        content=spec_contents,
+        name=spec_stem
+    ) as generated_path:
+        config = prover_config_overlay(
+            config, main_contract=main_contract, verify_target=f"{main_contract}:{generated_path}"
+        )
+        config.update(config_extra)
+        if rule is not None:
+            config["rule"] = rule
+        with temp_certora_file(
+            root=working_dir,
+            content=json.dumps(config, indent=2),
+            ext="conf",
+            name=spec_stem,
+            prefix="verify",
+            dest_dir=conf_dir,
+        ) as conf_path:
+            yield (conf_path, config)
+
 def get_prover_tool(
     llm: LLM,
     main_contract: str,
@@ -444,39 +477,34 @@ def get_prover_tool(
         conf_dir = (CERTORA_DIR / "confs") if spec_stem is not None else CERTORA_DIR
         lock = spec_locks.setdefault(spec_stem, asyncio.Lock()) if spec_stem is not None else nullcontext()
 
+        summary = get_run_summary()
+
+        component = (spec_stem or main_contract).removeprefix("autospec_")
+        iteration = len(state["prover_history"]) + 1
+        prover_msg = f"{component} iteration number {iteration}"
+
+
         async def run_in(run_root: str) -> str | Command:
-            with tmp_spec(root=run_root, content=spec, name=spec_stem) as generated:
-                config = prover_config_overlay(
-                    conf, main_contract=main_contract, verify_target=f"{main_contract}:{generated}"
-                )
-
-                if rules:
-                    config["rule"] = rules
-
-                summary = get_run_summary()
-
-                component = (spec_stem or main_contract).removeprefix("autospec_")
-                iteration = len(state["prover_history"]) + 1
-                config["msg"] = f"{component} iteration number {iteration}"
-
-                with temp_certora_file(
-                    root=run_root,
-                    content=json.dumps(config, indent=2),
-                    ext="conf",
-                    name=spec_stem,
-                    prefix="verify",
-                    dest_dir=conf_dir,
-                ) as config_path:
-                    async with sem:
-                        result = await run_prover(
-                            Path(run_root),
-                            [config_path],
-                            tool_call_id,
-                            prover_opts,
-                            _SpecCallbacks(get_stream_writer(), tool_call_id, summary, config,
-                                           analysis_store=analysis_store),
-                            DefaultCexHandler(llm, state, summarization_threshold=10)
-                        )
+            with setup_prover_config_in(
+                working_dir=run_root,
+                main_contract=main_contract,
+                spec_stem=spec_stem,
+                spec_contents=spec,
+                conf_dir=conf_dir,
+                config=conf,
+                rule=rules,
+                msg=prover_msg
+            ) as (config_path, config):
+                async with sem:
+                    result = await run_prover(
+                        Path(run_root),
+                        [config_path],
+                        tool_call_id,
+                        prover_opts,
+                        _SpecCallbacks(get_stream_writer(), tool_call_id, summary, config,
+                                        analysis_store=analysis_store),
+                        DefaultCexHandler(llm, state, summarization_threshold=10)
+                    )
 
             if isinstance(result, str):
                 return result

--- a/composer/spec/source/report/build.py
+++ b/composer/spec/source/report/build.py
@@ -22,7 +22,8 @@ from composer.spec.source.report.grouping import (
     build_fallback_grouping, build_groups, call_grouping_llm, PropertyGroup
 )
 from composer.spec.source.report.schema import (
-    AutoProverReport, Finding, Outcome, PropertyKey, ReportBackend, RuleRef, SourceEditRecord
+    AutoProverReport, Finding, Outcome, PropertyKey, ReportBackend, RuleRef, SourceEditRecord,
+    VerificationArtifactRecord,
 )
 
 _log = logging.getLogger(__name__)
@@ -45,6 +46,7 @@ async def build_report[R: ReportableResult](
     llm: BaseChatModel,
     fetch_verdicts: VerdictFetcher[R],
     source_edits: list[SourceEditRecord] | None = None,
+    verification_artifacts: list[VerificationArtifactRecord] | None = None,
     findings_llm: BaseChatModel | None = None,
     fetch_evidence: EvidenceFetcher | None = None,
 ) -> AutoProverReport:
@@ -138,6 +140,7 @@ async def build_report[R: ReportableResult](
         gave_up_components=gave_up,
         curtailed_components=curtailed,
         source_edits=source_edits or [],
+        verification_artifacts=verification_artifacts or [],
         coverage=coverage,
         findings=findings,
     )

--- a/composer/spec/source/report/schema.py
+++ b/composer/spec/source/report/schema.py
@@ -208,6 +208,23 @@ class SourceEditRecord(BaseModel):
     cumulative_diff: str
 
 
+class VerificationArtifactRecord(BaseModel):
+    """A verification-supporting file a plugin's tool produced during one component's
+    formalization — a Lean proof discharging instrumented lemmas, an auxiliary
+    certificate, etc. The content lives on disk at ``path`` (project-relative, written
+    by the artifact store); the record carries provenance and a description for the
+    deliverable. Deliberately its own model: report.json is a persisted contract."""
+    component: ComponentName
+    #: The contributing plugin's id (its entry-point name).
+    plugin: str
+    #: File basename as registered by the tool.
+    name: str
+    #: Open vocabulary, e.g. "lean-proof".
+    kind: str
+    description: str
+    path: str
+
+
 type ReportBackend = Literal["prover", "foundry"]
 """Which pipeline produced this report. Provenance only — every backend fills the same fields;
 this tag just lets the renderer pick the right outcome labels ("Verified" vs "Successful test")
@@ -295,6 +312,9 @@ class AutoProverReport(BaseModel):
     #: Source modifications each component's verification ran against; empty when every
     #: component was verified against the on-disk source.
     source_edits: list[SourceEditRecord] = Field(default_factory=list)
+    #: Verification-supporting artifacts registered by plugin tools during
+    #: formalization (Lean proofs et al.), written to disk by the artifact store.
+    verification_artifacts: list[VerificationArtifactRecord] = Field(default_factory=list)
     coverage: CoverageReport
     #: Violated rules surfaced as audit issues (one per BAD rule; empty
     #: when nothing is violated, when synthesis was unavailable, or for a non-prover backend). Prose

--- a/composer/spec/types.py
+++ b/composer/spec/types.py
@@ -101,5 +101,20 @@ class PropertyFormulation(UntitledPropertyFormulation):
     A property or invariant that must hold for the component
     """
     title: str = Field(description="A short, descriptive snake_case identifier for the property (e.g. 'total_supply_preserved'). Must be unique within the batch of properties.")
+
+
+class VerificationArtifact(BaseModel):
+    """A verification-supporting file produced by a plugin's contributed tool — a
+    Lean proof discharging instrumented lemmas, an auxiliary certificate, etc.
+    Registered with its *content*, not a path: the artifact store owns the
+    deliverable layout and decides where it lands on disk."""
+    #: File basename (the store sanitizes to a basename and namespaces by
+    #: unit and plugin, so collisions across tools are impossible).
+    name: str
+    #: Open vocabulary tag, e.g. "lean-proof".
+    kind: str
+    #: One-or-two-line blurb for the report deliverable.
+    description: str
+    content: str
     
 

--- a/composer/templates/task_protocol.j2
+++ b/composer/templates/task_protocol.j2
@@ -1,0 +1,7 @@
+You can retrieve the list of currently running background tasks
+with the "task_list" tool. The result is a list of task IDs, a description
+of the task, and the current state.
+
+`retrieve_task` will retrieve the result of the task by its ID. Each
+task can only be retrieved once. If the task with the given ID is not yet
+complete, the `retrieve_task` tool will block until it is ready.

--- a/template_manifest.json
+++ b/template_manifest.json
@@ -113,6 +113,12 @@
     "template_name": "property_generation_prompt.j2",
     "ty_sort": "TypedTemplate"
   },
+  "composer.spec.source.author:_PropertyGenSysTemplate": {
+    "module": "composer.spec.source.author",
+    "qualname": "_PropertyGenSysTemplate",
+    "template_name": "property_generation_system_prompt.j2",
+    "ty_sort": "TypedTemplate"
+  },
   "composer.spec.source.design_doc_finder:_FINDER_PROMPT": {
     "module": "composer.spec.source.design_doc_finder",
     "qualname": "_FINDER_PROMPT",

--- a/tests/test_migration_oracle.py
+++ b/tests/test_migration_oracle.py
@@ -29,7 +29,7 @@ from langgraph.store.memory import InMemoryStore
 from composer.rag.models import DefaultEmbedder
 from composer.spec.agent_index import AgentIndex, AgentIndexConfig
 from composer.spec.source.munge.edit_oracle import mk_oracle
-from composer.spec.source.munge.edit_store import StoredEdit
+from composer.spec.source.munge.edit_store import MungeEditor, StoredEdit
 from composer.spec.source.versioned_index import (
     VersionedAgentIndex, AnswerPortability, Stale, UpToDate,
 )
@@ -61,7 +61,10 @@ def _sc(project_root) -> Any:
 
 
 def _stored(vfs: dict[str, str]) -> StoredEdit:
-    return StoredEdit(vfs=vfs, executive_summary="summary", why_sound="sound")
+    return StoredEdit(
+        vfs=vfs, executive_summary="summary", why_sound="sound",
+        attribution=MungeEditor(),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_null_solana_backend.py
+++ b/tests/test_null_solana_backend.py
@@ -85,7 +85,7 @@ async def test_formalize_echoes_properties_into_result():
     props = _props()
 
     result = await NullSolanaFormalizer().formalize(
-        "batch", feat, props, cast(Any, None), cast(Any, None)
+        "batch", feat, props, cast(Any, None), cast(Any, None), cast(Any, None)
     )
 
     assert isinstance(result, NullResult)
@@ -109,7 +109,7 @@ async def test_formalize_echoes_properties_into_result():
 @pytest.mark.asyncio
 async def test_formalize_with_no_properties_records_empty():
     result = await NullSolanaFormalizer().formalize(
-        "batch", _unit(), [], cast(Any, None), cast(Any, None)
+        "batch", _unit(), [], cast(Any, None), cast(Any, None), cast(Any, None)
     )
     assert isinstance(result, NullResult)
     assert result.property_units() == []

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -59,7 +59,7 @@ class _Formalizer:
     def __init__(self, calls: list[tuple[str, list[str]]] | None = None):
         self.calls = [] if calls is None else calls
 
-    async def formalize(self, _label, feat, props, _ctx, _run):
+    async def formalize(self, _label, feat, props, _ctx, _run, _extra_tools):
         # A yield point, so a driver that started the fan-out before `begin` finished would
         # interleave here and be caught by the ordering assertion.
         await asyncio.sleep(0)
@@ -109,13 +109,19 @@ class _Cache:
     async def cache_get(self, _ty): return None
     async def cache_put(self, _v): return None
 
+    def child(self, key, tags = None):
+        if tags is None:
+            return _Cache()
+        async def thunk():
+            return _Cache()
+        return thunk()
+
+
 
 class _Ctx:
     recursion_limit = 10
 
     def child(self, *_a, **_kw): return self
-
-    async def achild(self, *_a, **_kw): return _Cache()
 
 
 class _FeatCtx:
@@ -137,7 +143,7 @@ class _Run:
     env = None
     ctx = _Ctx()
 
-    async def runner(self, _task_info, job):
+    async def runner(self, task_info, job):
         return await job()
 
 

--- a/tests/test_prover_nag_integration.py
+++ b/tests/test_prover_nag_integration.py
@@ -95,6 +95,7 @@ async def _fake_run_prover(
         raw_rule_status=statuses,
         result_str="\n".join(f"{p.rule}: {s}" for p, s in statuses.items()),
         link="https://prover.example/fake-run",
+        certora_run_stdout=""
     )
 
 

--- a/tests/test_rule_skips.py
+++ b/tests/test_rule_skips.py
@@ -65,9 +65,10 @@ def _result(commentary: str) -> ToolCallDict:
 
 def _raw_report(**rule_status: bool) -> ProverReport:
     return ProverReport(result_str="Prover report output", link="local://test-run", raw_rule_status={
-        RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k,v) in rule_status.items(),
+            RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k,v) in rule_status.items()
+        },
         certora_run_stdout="certoraRun output"
-    })
+    )
 
 
 def _summarized_report(todo: str, **rule_status: bool) -> ProverReport:

--- a/tests/test_rule_skips.py
+++ b/tests/test_rule_skips.py
@@ -65,15 +65,18 @@ def _result(commentary: str) -> ToolCallDict:
 
 def _raw_report(**rule_status: bool) -> ProverReport:
     return ProverReport(result_str="Prover report output", link="local://test-run", raw_rule_status={
-        RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k,v) in rule_status.items()
+        RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k,v) in rule_status.items(),
+        certora_run_stdout="certoraRun output"
     })
 
 
 def _summarized_report(todo: str, **rule_status: bool) -> ProverReport:
     return ProverReport(
         result_str=todo, link="local://test-run", raw_rule_status={
-        RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k,v) in rule_status.items()
-    })
+            RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k,v) in rule_status.items()
+        },
+        certora_run_stdout="certoraRun output"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rustapp_validate_target.py
+++ b/tests/test_rustapp_validate_target.py
@@ -295,7 +295,7 @@ async def test_the_result_carries_the_targets_the_gating_run_covered(monkeypatch
     ]
     result = await formalizer.formalize(
         "Farms", cast(Any, _Feat()), props, cast(Any, _Ctx()),
-        cast(Any, _Run(_Source(str(tmp_path)), _Ctx())),
+        cast(Any, _Run(_Source(str(tmp_path)), _Ctx())), cast(Any, None)
     )
 
     assert isinstance(result, adapter.RustFormalResult)


### PR DESCRIPTION
Allows plugins to contribute tools to the formalizers of individual backends.

This accomplished in two places. First, the *formalizers* (not the backend) declares a `tool_provider_type` field. This field names a particular subclass of `PipelinePlugin` which provide tools for the formalizer to use. This information is used by the pipeline to construct a formalization cache key that includes the plugins that contributed to that formalization.

The actual binding of tools is accomplished by pushing a `ToolBinder` object through to the formalizer. The `ToolBinder` takes `ToolExtension` type and the "injected parameters" and returns a sequence of `ProvidedTools`. Each `ProvidedTools` object encapsulates the Langchain tools that may be bound directly on the graph plus the system prompt blurb describing to the agent how to use said tool.

## Tool Discovery Details

The ToolBinder type is a polymorphic function with (roughly) the following signature:

```
(ToolExtension[TP, U, P], **P) -> Sequence[ProvidedTool]
```

where `U` is the usual `FeatureUnit` bound type parameter for the backend. `**P` is a param spec type parameter; it defines the protocol for how the formalizer communicates with its plugins in a way that is opaque to the pipeline core. `ToolExtension` itself is defined as a class with two fields:
```
provider: type[TP]
project: (TP) -> ((U, list[PropertyFormulation], PluginToolContext, **P) -> Sequence[ProvidedTools])
```

`project` takes an instance of `TP` (the tool provider) and projects out a member function which takes, as arguments: the feature unit being formalized (represented by `U`), the list of properties being formalized, the "plugin tool context" (see below), and "whatever arguments are represented by P". The fixed argument prefix (`U`, `list[PropertyFormulation]`, and `PluginToolContext`) are all injected automatically by the tool binder implementation; all the arguments represented by `P` are passed through from the call to the `ToolBinder`. [1]

Behind the scenes, the `ToolBinder` constructed by the pipeline core iterates all of the plugins loaded for a run, and finds those that are subclasses of `provider`, it injects the fixed prefix arguments alongside the formalization specific arguments represented by `P`. In addition, a special class `AnyBackend` allows a plugin to define tools used by anybackend; it only has the fixed prefix injected, formalization specific parameters are never passed through.

The `PluginToolContext` type is the existing `PluginContext` type without the `runner` field; the plugin is expected to provide its functionality through tools, which should not be spawned as top-level multi-job tasks. In addition, we provide a `register` field of type `ArtifactRegistrar`. This lets plugins communicate unstructured "verification artifacts" back to the main pipeline. These artifacts are included in the main report as side information.

## Tool Usage

In practice, the expected shape of communication between a plugin and the formalizer are two parameters, the actual runtime representation of the author's state type, and a projector function, which takes an instance of the state and yields a slice of the state used by the author.

For example, the `CertoraProverTool` api provides the plugin tools with `type[SourceCVLGenerationState]` and `(SourceCVLGenerationState) -> AsyncContextManager[CVLAuthorState]`. `CVLAuthorState` contains, among other things:
1. The current configuration
2. A materialized copy of the VFS state of the author
3. An edit store for proposing edits to the author's VFS
4. A "prover runner" which handles provisioning and running the prover

It is strongly recommended (but not enforced) that formalizers handle provisioning of abstractions for accessing the utilities they themselves access through tools (e.g., running the prover) instead of passing through the raw building blocks to access those utilities themselves. For example, in the prover runner case above, passing through the data necessary for the plugin to run the prover "from scratch" would require passing the `ProverOptions` the "config overlay" (the basic config elaboration performed by the author's prover tool), the current configuration (already passed), *and* require the plugin to know how to piece all that together. All of this together would create a far greater API surface with which to maintain BC for the plugins (e.g., don't rename the `prover_config_overlay` function because some random plugin might need it). In other words, use this projector function pattern to *push* functionality to the plugins, instead of making them pull in random pieces of code from the rest of the AP codebase.

## Parallelization

To support long running tools, we've added a `TaskHost` abstraction, which can be used to launch background tasks that run in parallel with the main agent. It is expected this will be used to allow plugins to doe their work as background tasks. The main formalization agent can use the task management tools to query background task state and to wait for/retrieve results.

## Prover Tools

The other "big" piece of this PR is enabling plugins for the Certora Prover tool to propose edits to the source code under verification. This could be useful to, e.g., write a plugin that addresses PTA failures due to inline assembly, or to use Concord to make verified large scale rewrites beyond what the code editor agent is empowered to do. These edits are proposed and committed using the existing edit store infrastructure. However, we extend the edit store to record the provenance of edits; the existing editor is called "MungeAgent", edits from plugins are tagged with their id (this tagging is handled automatically; the plugins cannot lie about their id).

## On Testing

I have proven this code correct, but I haven't yet tested it [2]. I am sharing it here because its in its mostly final state; I plan to do a big test run in parallel with the review process.

[1] There is a second form which takes an `InjectedToolExtension`, which allows the `P` part of the plugin to know about the plugin id it is requesting. Don't think too hard about it, it makes your head hurt.

[2] I haven't actually proved it correct either