### PR TITLE
Isolate a failing CEX analysis from the run that produced it

### DIFF
--- a/composer/prover/agentic_analyzer.py
+++ b/composer/prover/agentic_analyzer.py
@@ -29,6 +29,7 @@ and the actual source compiled into the verification problem.
 
 import asyncio
 from dataclasses import dataclass
+import logging
 from pathlib import Path
 from typing import Annotated, Literal, NotRequired, Union, override
 import uuid
@@ -56,6 +57,8 @@ from composer.templates.loader import load_jinja_template
 from composer.diagnostics.timing import set_current_task_id
 from composer.prover.cex_task_ids import cex_rule_task_id, cex_aggregator_task_id
 from composer.tools.thinking import RoughDraftState, get_rough_draft_tools
+
+_logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -490,12 +493,28 @@ class AgenticCexHandler(CexHandler):
             with set_current_task_id(cex_rule_task_id(tool_call_id, rule_group.rule_name)):
                 return await _process_rule(rule_group)
 
+        # A rule whose analysis raises forfeits its own root causes only; the
+        # remaining rules still report, and the caller still gets a rendered
+        # report rather than losing the prover run.
         per_rule = await asyncio.gather(
-            *(_process_rule_addressed(rg) for rg in failing_rules)
+            *(_process_rule_addressed(rg) for rg in failing_rules),
+            return_exceptions=True,
         )
+        for rule_group, outcome in zip(failing_rules, per_rule):
+            if isinstance(outcome, asyncio.CancelledError):
+                raise outcome
+            if isinstance(outcome, BaseException):
+                _logger.warning(
+                    "CEX analysis failed for rule %s, continuing without its root causes: %r",
+                    rule_group.rule_name,
+                    outcome,
+                )
         # Flatten preserving rule order (gather preserves input order).
         all_causes: list[_PerRuleRootCause] = [
-            c for rule_results in per_rule for c in rule_results
+            c
+            for rule_results in per_rule
+            if not isinstance(rule_results, BaseException)
+            for c in rule_results
         ]
 
         if not all_causes:

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -309,8 +309,25 @@ class TrivialFanoutCexHandler(CexHandler):
                 await callbacks.on_analysis_complete(instance, analysis)
             return (instance, analysis)
 
-        jobs = [_one(r) for r in all_results if r.status == "VIOLATED"]
-        results = await asyncio.gather(*jobs)
+        violated = [r for r in all_results if r.status == "VIOLATED"]
+        # One counterexample's analysis failing is not a reason to lose the
+        # prover run that produced it: the rule keeps its status and only its
+        # explanation goes missing, so the report renders without it.
+        settled = await asyncio.gather(
+            *(_one(r) for r in violated), return_exceptions=True
+        )
+        results: list[tuple[RuleResult, str | None]] = []
+        for rule, outcome in zip(violated, settled):
+            if isinstance(outcome, asyncio.CancelledError):
+                raise outcome
+            if isinstance(outcome, BaseException):
+                _logger.warning(
+                    "CEX analysis failed for rule %s, continuing without its explanation: %r",
+                    rule.name,
+                    outcome,
+                )
+                continue
+            results.append(outcome)
 
         to_cex_explanation = {
             r.name: stat for (r, stat) in results if stat is not None
@@ -331,8 +348,10 @@ class TrivialFanoutCexHandler(CexHandler):
             results=results_for_template,
         )
 
+        # Counted over every violated rule, not just the analyzed ones, so a
+        # failed analysis cannot move the summarization threshold.
         failed_count = sum(
-            1 for instance, _ in results
+            1 for instance in violated
             if instance.status != "VERIFIED"
         )
         if failed_count > self.summarization_threshold:

--- a/tests/test_cex_analysis_failure_isolation.py
+++ b/tests/test_cex_analysis_failure_isolation.py
@@ -1,0 +1,93 @@
+"""A failing per-CEX analysis must cost only that counterexample's explanation.
+
+``TrivialFanoutCexHandler.analyze`` fans the violated rules out concurrently. The
+fan-out used to be a bare ``asyncio.gather``, so the first analysis to raise
+propagated out of ``analyze`` → ``run_prover`` → the pipeline and ended the run —
+after the prover had already done its work. A transient API error on one
+counterexample was enough to discard hours of verification.
+
+These tests pin the isolation: the surviving rules keep their explanations, the
+report still renders, and the summarization threshold is unmoved by whether an
+analysis succeeded or blew up.
+"""
+
+import asyncio
+
+import pytest
+
+from composer.prover import core
+from composer.prover.core import TrivialFanoutCexHandler
+from composer.prover.ptypes import RulePath, RuleResult
+
+
+def _violated(rule: str) -> RuleResult:
+    return RuleResult(path=RulePath(rule=rule), cex_dump=f"<cex {rule}/>", status="VIOLATED")
+
+
+class _RecordingCallbacks:
+    def __init__(self) -> None:
+        self.started: list[str] = []
+        self.completed: dict[str, str] = {}
+
+    async def on_analysis_start(self, rule: RuleResult) -> None:
+        self.started.append(rule.name)
+
+    async def on_analysis_complete(self, rule: RuleResult, explanation: str) -> None:
+        self.completed[rule.name] = explanation
+
+
+def handler_for() -> TrivialFanoutCexHandler:
+    # ``llm`` is only reached through the patched ``analyze_cex_raw`` (and by
+    # ``_report_to_todo_list``, which these cases stay under the threshold of).
+    return TrivialFanoutCexHandler(llm=None, state={"messages": []})  # type: ignore[arg-type]
+
+
+async def _analyze(handler: TrivialFanoutCexHandler, rules: list[RuleResult], tmp_path):
+    callbacks = _RecordingCallbacks()
+    report = await handler.analyze(rules, "tool-call-1", callbacks, tmp_path)  # type: ignore[arg-type]
+    return report, callbacks
+
+
+@pytest.mark.asyncio
+async def test_one_failed_analysis_does_not_sink_the_others(monkeypatch, tmp_path) -> None:
+    async def fake_analyze(llm, messages, rule: RuleResult, tool_call_id: str) -> str:
+        if rule.name == "boom":
+            raise RuntimeError("api blew up")
+        return f"explanation for {rule.name}"
+
+    monkeypatch.setattr(core, "analyze_cex_raw", fake_analyze)
+
+    rules = [_violated("first"), _violated("boom"), _violated("second")]
+    report, callbacks = await _analyze(handler_for(), rules, tmp_path)
+
+    assert "explanation for first" in report
+    assert "explanation for second" in report
+    assert set(callbacks.completed) == {"first", "second"}
+
+
+@pytest.mark.asyncio
+async def test_every_analysis_failing_still_renders_a_report(monkeypatch, tmp_path) -> None:
+    async def fake_analyze(llm, messages, rule: RuleResult, tool_call_id: str) -> str:
+        raise RuntimeError("api blew up")
+
+    monkeypatch.setattr(core, "analyze_cex_raw", fake_analyze)
+
+    rules = [_violated("first"), _violated("second")]
+    report, callbacks = await _analyze(handler_for(), rules, tmp_path)
+
+    # The rules' statuses come from the prover, not from their analyses, so the
+    # report still has something to say about them.
+    assert "first" in report
+    assert "second" in report
+    assert callbacks.completed == {}
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_not_swallowed(monkeypatch, tmp_path) -> None:
+    async def fake_analyze(llm, messages, rule: RuleResult, tool_call_id: str) -> str:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(core, "analyze_cex_raw", fake_analyze)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _analyze(handler_for(), [_violated("first")], tmp_path)


### PR DESCRIPTION
## What happened

A long dev run died at its very last stage. The prover had finished; CEX analysis
called the LLM for one counterexample, got a `500`, and the exception propagated
out of `analyze` → `run_prover` → the pipeline. Hours of verification work were
discarded for one transient server error.

```
composer/prover/analysis.py:37   analyze_cex_raw → ainvoke
anthropic.InternalServerError: Error code: 500
```

## Why one bad response is fatal

Both handlers fan their per-rule analyses out under a bare `asyncio.gather`:

- `composer/prover/core.py:313` — `TrivialFanoutCexHandler`
- `composer/prover/agentic_analyzer.py:493` — `AgenticCexHandler`

Without `return_exceptions`, the first exception aborts the gather and orphans
its siblings, and nothing above catches it. Every rule's result is lost because
one rule's *explanation* could not be produced.

## The fix

Gather with `return_exceptions=True` in both handlers and drop only the failed
rule's contribution. It keeps its prover-assigned status and loses its
explanation (trivial handler) or its root causes (agentic handler); every other
rule reports as before, and the caller still gets a rendered report.
`CancelledError` is re-raised rather than logged, so cancellation still unwinds.

One adjacent correction: the trivial handler's `failed_count` was summed over
the analyzed results, so dropping a failed analysis would quietly lower it and
change the summarization-threshold decision. It now counts violated rules.

## On retrying the 5xx

Deliberately not added. `composer/llm/anthropic.py:284` already builds
`ChatAnthropic(..., max_retries=8)`, and the SDK retries `>=500` by default — so
that `500` had already been retried eight times before it surfaced. A second
retry layer would be redundant, and would not have saved this run. The blast
radius was the problem, not the frequency.

## Testing

`tests/test_cex_analysis_failure_isolation.py` — one rule's analysis raising
still yields the others' explanations; all of them raising still renders a
report; `CancelledError` still propagates. The first two fail against `master`
and pass here.

Full pass: `693 passed, 9 skipped, 9 deselected`, `pyright` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)