### PR TITLE
Hot fixes

### DIFF
--- a/composer/cvl/tools.py
+++ b/composer/cvl/tools.py
@@ -10,6 +10,7 @@ import logging
 import subprocess
 import tempfile
 from typing import Annotated, Literal, overload
+from langchain_core.messages import AIMessage
 from typing_extensions import TypedDict
 
 from langchain_core.tools import tool, InjectedToolCallId, BaseTool
@@ -242,6 +243,9 @@ re-sending the entire file.
 
 The edited spec is run through the CVL parser exactly like `put_cvl_raw`. If the result
 fails to parse, the edit is rejected with the parser errors and the buffer is unchanged.
+
+IMPORTANT: You cannot call this tool multiple times in the same turn. If you need to make
+multiple edits, you must spread them across distinct turns.
 """
 
 
@@ -270,6 +274,9 @@ def edit_cvl[S: WithCurrSpec](ty: type[S]) -> BaseTool:
         st = args["state"]
         if st["curr_spec"] is None:
             return "No spec file written yet — use put_cvl or put_cvl_raw first."
+        last = st["messages"][-1]
+        if isinstance(last, AIMessage) and len([ t for t in last.tool_calls if t["name"] == "edit_cvl"]) > 1:
+            return "`edit_cvl` tool cannot be called in parallel within the same turn."
         match replace_unique(st["curr_spec"], args["old_string"], args["new_string"]):
             case EditErr(message=msg):
                 return msg

--- a/composer/spec/source/monitor.py
+++ b/composer/spec/source/monitor.py
@@ -16,5 +16,5 @@ def monitor(
         return None, None
     
     return [HumanMessage(f"<system-reminder>{'\n'.join(curr_state["reminders_channel"])}</system-reminder>")], {
-        "reminders_channel": None
+        "reminders_channel": []
     }

--- a/composer/testing/ui_harness_autoprove_Counter.py
+++ b/composer/testing/ui_harness_autoprove_Counter.py
@@ -67,6 +67,7 @@ from typing import Any
 import uuid
 
 from composer.testing.harness_tape import HarnessFakeLLM, install_fake_llm
+from composer.spec.source.prover import STUCK_RULE_NAG_THRESHOLD
 from composer.spec.source.task_ids import (
     DESIGN_DOC_DISCOVERY_TASK_ID,
     SYSTEM_ANALYSIS_TASK_ID, HARNESS_TASK_ID, INVARIANTS_TASK_ID,
@@ -277,13 +278,14 @@ _APP_RESULT = {
 #
 # Shape must satisfy pydantic validation of
 # ``composer.spec.source.harness.AgentSystemDescription`` AND the
-# ``classifier_agent`` validator: every ``transitive_closure[*].name`` must
-# map to a known SourceExplicitContract, every ``external_interfaces[*].name``
+# ``classifier_agent`` validator: every ``transitive_closure[*].solidity_identifier``
+# must map to a known SourceExplicitContract, every ``external_interfaces[*].name``
 # must map to a known SourceExternalActor (with a path).
 #
-# We use ``num_instances=None`` so ``needs_harnessing()`` returns False and
-# the harness-generation sub-agent is skipped. ``erc20_contracts=[]`` and
-# ``external_interfaces=[]`` so the summaries sub-agent is skipped.
+# We use ``harness_determination=None`` (→ ``num_instances`` None) so
+# ``needs_harnessing()`` returns False and the harness-generation sub-agent is
+# skipped. ``erc20_contracts=[]`` and ``external_interfaces=[]`` so the
+# summaries sub-agent is skipped.
 
 _CLASSIFIER_RESULT = {
     "non_trivial_state": (
@@ -1455,6 +1457,256 @@ _CURTAILED_CVL_TAPE: list[BaseMessage] = [
 ]
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# Stuck-rule nag variant lanes
+# ───────────────────────────────────────────────────────────────────────────
+# Alternate authoring lanes for the prover-nag integration test
+# (``tests/test_prover_nag_integration.py``). That test mocks ``run_prover``
+# and assigns statuses by rule name (every declared rule VERIFIED except
+# NAG_STUCK_RULE → SANITY_FAILED), so no prover jobs run; the spec is kept
+# live-prover-honest anyway: the third rule's contradictory ``require``s make
+# its body unreachable, so it typechecks (put_cvl_raw's real Typechecker gate
+# still runs) and a real run would report the same SANITY_FAILED via
+# ``rule_sanity: basic`` (forced by ``prover_config_overlay``) — with no
+# counterexample, so no CEX-analysis entries are consumed either way.
+# The author runs the spec ``STUCK_RULE_NAG_THRESHOLD`` times, nudging it with
+# a trailing comment between runs: the streak detector keys on (rule, status),
+# not spec digest, so the nudge doesn't reset it — while keeping every run's
+# digest distinct, clear of the identical-spec re-run gate in ``verify_spec``
+# (today it only fires on TIMEOUT results, but it is expected to broaden to
+# the other stuck statuses). The last run trips the stuck-rule detector, which appends a
+# NagMarker to ``prover_history`` and queues the reminder the author monitor
+# injects as a ``<system-reminder>`` HumanMessage. The author then reacts as
+# the reminder suggests — marks the rule expected-to-fail — and re-verifies
+# (the skipped rule no longer blocks ``all_verified``, and must NOT be
+# re-nagged). The judge round comes AFTER the streak: every put invalidates
+# the feedback stamp, so it is earned once, on the final spec text.
+
+#: The rule the nag tape gets stuck on (and then marks expected-to-fail).
+NAG_STUCK_RULE = "incrementOther_credits_target_when_distinct"
+
+# Same two passing increment() rules as COMPONENT_CVL; the third rule's
+# contradictory requires make it permanently vacuous → SANITY_FAILED.
+NAG_COMPONENT_CVL = """\
+methods {
+    function count() external returns (uint256) envfree;
+    function increments(address) external returns (uint256) envfree;
+    function increment() external;
+    function incrementOther(address) external;
+}
+
+rule increment_increases_count {
+    env e;
+    mathint before = count();
+    increment(e);
+    assert to_mathint(count()) == before + 1,
+        "increment() must increase count by exactly 1";
+}
+
+rule increment_increases_sender_tally {
+    env e;
+    address s = e.msg.sender;
+    mathint before = increments(s);
+    increment(e);
+    assert to_mathint(increments(s)) == before + 1,
+        "increment() must increase increments[msg.sender] by exactly 1";
+}
+
+rule incrementOther_credits_target_when_distinct {
+    env e;
+    address other;
+    require other != e.msg.sender;
+    require other == e.msg.sender;
+    mathint before_other = increments(other);
+    incrementOther(e, other);
+    assert to_mathint(increments(other)) == before_other + 1,
+        "incrementOther(other) must increase increments[other] by exactly 1 when other != msg.sender";
+}
+"""
+
+
+# Minimal happy-path invariant lane: the nag test doesn't re-pay the
+# broken-parse / bad-draft / CEX detours the main tape covers — one judge
+# round, one (passing) prover run, publish.
+_NAG_INVARIANT_CVL_TAPE: list[BaseMessage] = [
+    _ai(
+        "Drafting the structural invariants.",
+        _tc("put_cvl_raw", cvl_file=GOOD_INV_CVL),
+    ),
+    _ai(
+        "Requesting judge feedback.",
+        _tc("feedback_tool"),
+    ),
+    _ai(
+        "Judge: inspecting the spec.",
+        _tc("get_cvl"),
+        _tc(
+            "write_rough_draft",
+            rough_draft=(
+                "Both approved invariants (increments_sum_is_count, "
+                "zero_address_is_zero) are faithfully encoded, with the ghost "
+                "seeded by an init_state axiom. Verdict: GOOD."
+            ),
+        ),
+    ),
+    _ai(
+        "Judge: reading the draft.",
+        _tc("read_rough_draft"),
+    ),
+    _ai(
+        "Judge: approving the spec.",
+        _tc("result", good=True, feedback=""),
+    ),
+    _ai(
+        "Running the prover on the invariants.",
+        _tc("verify_spec", rules=None),
+    ),
+    _ai(
+        "Finalizing the invariant CVL.",
+        _tc(
+            "result",
+            commentary=(
+                "Formalized the two structural invariants "
+                "(increments_sum_is_count, zero_address_is_zero)."
+            ),
+            property_rules=[
+                {"property_title": "increments_sum_is_count", "rules": ["increments_sum_is_count"]},
+                {"property_title": "zero_address_is_zero", "rules": ["zero_address_is_zero"]},
+            ],
+        ),
+    ),
+]
+
+
+def _nag_attempt_spec(i: int) -> str:
+    """The spec for streak attempt ``i`` (0-based). Attempts differ only by a
+    trailing comment: the streak detector keys on (rule, status), so the nudge
+    doesn't reset it, while every run's spec digest stays distinct — clear of
+    the identical-spec re-run gate in ``verify_spec``."""
+    if i == 0:
+        return NAG_COMPONENT_CVL
+    return (
+        f"{NAG_COMPONENT_CVL}\n"
+        f"// Attempt {i + 1}: nudging the spec to retry the sanity failure.\n"
+    )
+
+
+def _nag_streak_turns() -> list[BaseMessage]:
+    """The stuck streak: threshold-many put/verify rounds. Each run: two rules
+    VERIFIED, the vacuous rule SANITY_FAILED (never VIOLATED → no CEX
+    entries). The final run reaches the threshold and fires the nag; the
+    author monitor injects the <system-reminder> before the next turn."""
+    turns: list[BaseMessage] = [
+        _ai(
+            "Writing the component spec covering all three properties.",
+            _tc("put_cvl_raw", cvl_file=_nag_attempt_spec(0)),
+        ),
+        _ai(
+            "Running the prover on the component spec.",
+            _tc("verify_spec", rules=None),
+        ),
+    ]
+    for i in range(1, STUCK_RULE_NAG_THRESHOLD):
+        turns.append(_ai(
+            f"The sanity failure could be transient — nudging the spec and "
+            f"trying again (attempt {i + 1}).",
+            _tc("put_cvl_raw", cvl_file=_nag_attempt_spec(i)),
+        ))
+        turns.append(_ai(
+            f"Re-running the prover (attempt {i + 1}).",
+            _tc("verify_spec", rules=None),
+        ))
+    return turns
+
+
+_NAG_CVL_TAPE: list[BaseMessage] = [
+
+    # NG1..NG{2×threshold} — put the component spec with the permanently-
+    # vacuous third rule, then the nudge/verify streak up to the threshold.
+    *_nag_streak_turns(),
+
+    # NG-react — the turn after the nag reminder landed. React as it suggests:
+    # take the stuck rule out of the verification obligation. rule_skips is
+    # not part of the validation digest, so the feedback stamp survives.
+    _ai(
+        "The reminder is right — the rule has failed sanity identically on "
+        "every run; its requires are unsatisfiable as written. Marking it "
+        "expected-to-fail and moving on rather than burning more prover runs.",
+        _tc(
+            "expect_rule_failure",
+            rule_name=NAG_STUCK_RULE,
+            reason=(
+                "Stuck in SANITY_FAILED across repeated identical runs (the "
+                "rule body is vacuous — the requires are contradictory). "
+                "Flagged by the stuck-rule reminder; excluded from the "
+                "verification obligation instead of re-running."
+            ),
+        ),
+    ),
+
+    # NG-verify — re-verify. The skipped rule is excluded from all_verified
+    # AND from the stuck-rule tally (no re-nag); the two increment() rules
+    # pass, so rules=None + all_verified stamps validations["prover"] at the
+    # digest of the final (attempt-nudged) spec.
+    _ai(
+        "Re-running the prover with the stuck rule excluded.",
+        _tc("verify_spec", rules=None),
+    ),
+
+    # NG-judge — the feedback round runs AFTER the streak: every nudge put
+    # invalidated any earlier feedback stamp, so it is earned once here, on
+    # the final spec text (matching the prover stamp above). The judge
+    # approves on property coverage — it doesn't run the prover, so the
+    # vacuity goes unnoticed, deliberately.
+    _ai(
+        "Requesting judge feedback on the component spec.",
+        _tc("feedback_tool"),
+    ),
+    _ai(
+        "Judge: inspecting the component spec.",
+        _tc("get_cvl"),
+        _tc(
+            "write_rough_draft",
+            rough_draft=(
+                "Three rules, one per extracted property, each asserting the "
+                "exact post-condition. The incrementOther rule is recorded as "
+                "expected-to-fail with a documented reason. Coverage is "
+                "complete. Verdict: GOOD."
+            ),
+        ),
+    ),
+    _ai(
+        "Judge: reading the draft.",
+        _tc("read_rough_draft"),
+    ),
+    _ai(
+        "Judge: approving the component spec.",
+        _tc("result", good=True, feedback=""),
+    ),
+
+    # NG-publish — coverage maps the third property onto the vacuous rule
+    # (allowed for expected-to-fail rules, mirroring the main tape's R6).
+    _ai(
+        "Finalizing the component CVL.",
+        _tc(
+            "result",
+            commentary=(
+                "Formalized all three extracted safety properties. The two "
+                "increment() rules verify. The incrementOther rule is stuck "
+                "in a sanity failure (vacuous body) and was marked "
+                "expected-to-fail after the stuck-rule reminder fired; it "
+                "needs a human rewrite."
+            ),
+            property_rules=[
+                {"property_title": "count_increments_by_one", "rules": ["increment_increases_count"]},
+                {"property_title": "sender_increments_by_one", "rules": ["increment_increases_sender_tally"]},
+                {"property_title": "other_increments_by_one", "rules": [NAG_STUCK_RULE]},
+            ],
+        ),
+    ),
+]
+
+
 # Design-doc discovery lane. Only consumed when the run omits the design doc
 # (system_doc=None); the finder lists the project, reads the design doc, and selects
 # it. Counter's design doc is ``system.md`` at the scenario root. A single flat lane:
@@ -1510,6 +1762,21 @@ _AUTOPROVE_CURTAILED_TAPE: dict[str, list[BaseMessage]] = {
 }
 
 
+# The stuck-rule nag variant: identical up-front phases, minimal invariant
+# authoring, and the nag-exercising formalize lane. The report lane is the
+# main tape's verbatim — this variant formalizes the same five properties.
+_AUTOPROVE_NAG_TAPE: dict[str, list[BaseMessage]] = {
+    DESIGN_DOC_DISCOVERY_TASK_ID: _DESIGN_DOC_TAPE,
+    SYSTEM_ANALYSIS_TASK_ID: _SYSTEM_ANALYSIS_TAPE,
+    HARNESS_TASK_ID: _HARNESS_TAPE,
+    INVARIANTS_TASK_ID: _INVARIANTS_TAPE,
+    INVARIANT_CVL_TASK_ID: _NAG_INVARIANT_CVL_TAPE,
+    extract_task_id(0): _BUG_TAPE,
+    formalize_task_id(0): _NAG_CVL_TAPE,
+    REPORT_TASK_ID: _REPORT_TAPE,
+}
+
+
 # ---------------------------------------------------------------------------
 # Install / configuration API
 # ---------------------------------------------------------------------------
@@ -1560,16 +1827,38 @@ def install_curtailment_tape(with_delay: bool = True) -> HarnessFakeLLM:
     return _install(get_autoprove_Counter_curtailment_llm(with_delay))
 
 
+def autoprove_nag_lanes() -> dict[str, list[BaseMessage]]:
+    """The nag-variant lane map, for callers that construct their own
+    ``HarnessFakeLLM`` (e.g. the nag test's reminder-sniffing subclass)."""
+    return dict(_AUTOPROVE_NAG_TAPE)
+
+
+def install_nag_tape(
+    with_delay: bool = True, *, fake: HarnessFakeLLM | None = None
+) -> HarnessFakeLLM:
+    """``install_harness_tape``, but with the stuck-rule nag tape. Pass ``fake``
+    (built over ``autoprove_nag_lanes()``) to install a custom subclass instead
+    of the default; ``with_delay`` only applies to the default construction."""
+    return _install(
+        fake if fake is not None
+        else HarnessFakeLLM(lanes=_AUTOPROVE_NAG_TAPE, with_human_delay=with_delay)
+    )
+
+
 __all__ = [
     "BAD_INV_CVL",
     "BROKEN_PARSE_CVL",
     "COMPONENT_CVL",
     "GOOD_INV_CVL",
+    "NAG_COMPONENT_CVL",
+    "NAG_STUCK_RULE",
     "SUBTLE_INV_CVL",
+    "autoprove_nag_lanes",
     "get_autoprove_Counter_llm",
     "get_autoprove_Counter_curtailment_llm",
     "install_harness_tape",
     "install_curtailment_tape",
+    "install_nag_tape",
 ]
 
 

--- a/tests/test_autoprove_integration.py
+++ b/tests/test_autoprove_integration.py
@@ -15,7 +15,7 @@ and skipped without testcontainers. Run with ``-m expensive``.
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Callable, cast
 
 import pytest
 
@@ -106,12 +106,18 @@ def _make_args(rag_conn: str, scenario_dir: Path, system_doc: str | None) -> Aut
     ))
 
 
-def _install_mocks(monkeypatch, scenario_dir: Path) -> None:
+def _install_mocks(
+    monkeypatch,
+    scenario_dir: Path,
+    tape_installer: Callable[[], object] = lambda: install_harness_tape(with_delay=False),
+) -> None:
     """LLM / AutoSetup / embedding mocks (undone per test by ``monkeypatch``). The
     databases themselves — and the host/port connection redirection — are handled once
-    per session by the ``langgraph_db`` fixture."""
-    # Mock only the LLM (Counter tape) + disable the agent-index cache.
-    install_harness_tape(with_delay=False)
+    per session by the ``langgraph_db`` fixture. ``tape_installer`` selects which
+    tape backs the fake LLM (default: the main Counter tape); the sibling
+    integration tests pass their variant installers through it."""
+    # Mock only the LLM (the selected tape) + disable the agent-index cache.
+    tape_installer()
     # pipeline.cli imported `get_provider_for` by name, so install_harness_tape's
     # patch of registry.get_provider_for doesn't reach that binding — rebind it here.
     import composer.llm.registry as registry

--- a/tests/test_edit_cvl.py
+++ b/tests/test_edit_cvl.py
@@ -1,0 +1,74 @@
+"""Tests for ``edit_cvl``'s parallel-call guard, wired through a mocked ReAct
+graph (``graphcore.testing.Scenario``).
+
+An AI turn carrying more than one ``edit_cvl`` call must be refused: parallel
+edits against the same buffer would race through the state reducer. The guard
+is per-tool, not per-turn — a single ``edit_cvl`` alongside a *different* tool
+call is allowed (unlike ``verify_spec``'s solo-turn rule).
+
+Both tests stay on paths that return before ``maybe_update_cvl``, so the real
+CVL parser (Typechecker jar) is never launched — this is a fast unit test.
+"""
+import pytest
+
+from langgraph.graph import MessagesState
+
+from composer.cvl.tools import WithCurrSpec, edit_cvl, get_cvl
+
+from graphcore.testing import Scenario, tool_call_raw
+
+pytestmark = pytest.mark.asyncio
+
+
+class EditTestState(MessagesState, WithCurrSpec):
+    pass
+
+
+EDIT_TOOL = edit_cvl(EditTestState)
+GET_TOOL = get_cvl(EditTestState)
+
+# The exact refusal edit_cvl returns for a parallel-edit turn.
+_REFUSAL = "`edit_cvl` tool cannot be called in parallel within the same turn."
+
+_SPEC = """\
+rule foo {
+    assert true;
+}
+"""
+
+
+def _edit(old: str, new: str):
+    return tool_call_raw("edit_cvl", old_string=old, new_string=new)
+
+
+def _scenario():
+    return Scenario(EditTestState, EDIT_TOOL, GET_TOOL).init(curr_spec=_SPEC)
+
+
+async def test_parallel_edits_both_refused():
+    st = await _scenario().turn(
+        _edit("assert true", "assert false"),
+        _edit("rule foo", "rule bar"),
+    ).run()
+    responses = [p["resp"] for p in Scenario.get_last_tool_result(st)["edit_cvl"]]
+    assert len(responses) == 2
+    assert all(r == _REFUSAL for r in responses)
+    # Neither edit landed: the buffer is untouched.
+    assert st["curr_spec"] == _SPEC
+
+
+async def test_single_edit_alongside_other_tool_not_refused():
+    """One edit_cvl next to a different tool is not a parallel-edit turn. The
+    edit targets a span absent from the buffer, so it fails in replace_unique
+    — deterministically past the guard, without reaching the CVL parser."""
+    st = await _scenario().turn(
+        _edit("does not appear in the buffer", "irrelevant"),
+        tool_call_raw("get_cvl"),
+    ).run()
+    results = Scenario.get_last_tool_result(st)
+    (edit_pair,) = results["edit_cvl"]
+    assert edit_pair["resp"] != _REFUSAL
+    assert "`old_string` was not found" in edit_pair["resp"]
+    # The sibling call was serviced normally (responses are harness-stripped).
+    (get_pair,) = results["get_cvl"]
+    assert get_pair["resp"] == _SPEC.strip()

--- a/tests/test_prover_nag_integration.py
+++ b/tests/test_prover_nag_integration.py
@@ -1,0 +1,156 @@
+"""End-to-end integration test for the stuck-rule nag ("prover nagging")
+behavior of ``verify_spec``.
+
+Runs the full autoprove pipeline on the Counter scenario with the nag-variant
+tape (``install_nag_tape``). The prover core itself is mocked — the nag
+machinery under test lives entirely in ``verify_spec``'s post-processing,
+above the ``run_prover`` seam — so no cloud (or local) prover jobs run:
+``_fake_run_prover`` reads the spec each call targets and reports every
+declared rule VERIFIED except the permanently-stuck one, which reports
+SANITY_FAILED (the status the real ``rule_sanity`` check would produce for
+its vacuous body).
+
+The taped author runs the spec ``STUCK_RULE_NAG_THRESHOLD`` times, nudging it
+with a trailing comment between runs (the streak keys on (rule, status), not
+spec digest — and the distinct digests stay clear of verify_spec's
+identical-spec re-run gate); the last run must append a ``NagMarker`` to
+``prover_history`` and queue the stuck-rule reminder, which the author monitor
+injects into the conversation as a ``<system-reminder>`` HumanMessage. The
+tape then reacts as the reminder suggests (marks the rule expected-to-fail),
+re-verifies, and publishes.
+
+Pass/fail: the pipeline completes without raising, AND the reminder actually
+reached the author's prompt. The fake LLM is the only observer of the real
+conversation, so delivery is asserted by a ``HarnessFakeLLM`` subclass that
+sniffs every prompt it is asked to answer for ``<system-reminder>`` blocks —
+exactly once per prompt (a re-fired nag or a non-draining reminders channel
+would stack duplicates).
+
+Still marked ``expensive``: no prover money is spent, but the run needs the
+testcontainer Postgres and the real local CVL toolchain (``put_cvl_raw``'s
+Typechecker gate), which puts it well outside the routine fast pass. Run with
+``-m expensive``.
+"""
+import json
+import re
+from pathlib import Path
+from typing import Any, override
+
+import pytest
+from pydantic import Field
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.prompt_values import PromptValue
+
+from composer.diagnostics.timing import RunSummary, get_current_task_id
+from composer.pipeline.core import formalize_task_id
+from composer.prover.core import ProverReport
+from composer.prover.ptypes import RulePath, StatusCodes
+from composer.spec.source.autoprove_common import autoprove_executor
+from composer.testing.harness_tape import HarnessFakeLLM
+from composer.testing.ui_harness_autoprove_Counter import (
+    NAG_STUCK_RULE,
+    autoprove_nag_lanes,
+    install_nag_tape,
+)
+from composer.ui.autoprove_console import AutoProveConsoleHandler
+
+from tests.conftest import needs_postgres
+from tests.test_autoprove_integration import _install_mocks, _make_args
+
+pytestmark = [pytest.mark.expensive, needs_postgres, pytest.mark.asyncio]
+
+_SCENARIO_NAME = "autoprove_counter"
+
+# Stable prefix of the reminder verify_spec queues when the stuck-rule
+# detector fires (the "3" is spelled by the message itself, so match short of it).
+_NAG_SNIPPET = "identical failures on the last"
+
+_DECL_RE = re.compile(r"^\s*(?:rule|invariant)\s+([A-Za-z_]\w*)", re.MULTILINE)
+
+
+async def _fake_run_prover(
+    folder: Path, args: list[str], tool_call_id: str,
+    prover_opts: Any, callbacks: Any, cex: Any,
+) -> ProverReport:
+    """Stand-in for ``run_prover``, patched over the binding ``verify_spec``
+    calls through (the same seam the ``certora_prover`` conftest fixture
+    patches). Parses the conf the tool just wrote, reads the spec it verifies,
+    and reports every declared rule/invariant VERIFIED except the permanently
+    stuck ``NAG_STUCK_RULE`` → SANITY_FAILED. Content-derived, so both
+    authoring lanes are served without ordering assumptions."""
+    conf_path = Path(args[0])
+    if not conf_path.is_absolute():
+        conf_path = folder / conf_path
+    conf = json.loads(conf_path.read_text())
+    spec_path = Path(conf["verify"].split(":", 1)[1])
+    if not spec_path.is_absolute():
+        spec_path = folder / spec_path
+    statuses: dict[RulePath, StatusCodes] = {
+        RulePath(rule=name): ("SANITY_FAILED" if name == NAG_STUCK_RULE else "VERIFIED")
+        for name in _DECL_RE.findall(spec_path.read_text())
+    }
+    assert statuses, f"fake prover: no rule/invariant declarations in {spec_path}"
+    return ProverReport(
+        raw_rule_status=statuses,
+        result_str="\n".join(f"{p.rule}: {s}" for p, s in statuses.items()),
+        link="https://prover.example/fake-run",
+    )
+
+
+class _ReminderSniffingLLM(HarnessFakeLLM):
+    """Records, per LLM call, the ``<system-reminder>`` human messages present
+    in the prompt (keyed by tape lane). The monitor-injected nag reminder lives
+    in the author's message history, and the fake LLM is the only place the
+    real conversation can be observed."""
+
+    sniffed: list[tuple[str, list[str]]] = Field(default_factory=list, exclude=True)
+
+    @override
+    async def ainvoke(self, input: Any, config: Any = None, *, stop: Any = None, **kwargs: Any) -> AIMessage:
+        msgs = list(input.to_messages()) if isinstance(input, PromptValue) else list(input)
+        reminders : list[str] = [
+            m.text for m in msgs
+            if isinstance(m, HumanMessage) and "<system-reminder>" in m.text
+        ]
+        if reminders:
+            self.sniffed.append((get_current_task_id() or "<no lane>", reminders))
+        return await super().ainvoke(input, config, stop=stop, **kwargs)
+
+
+async def test_prover_nag_fires_and_run_survives(scenario_provider, langgraph_db, monkeypatch):
+    scenario_dir = scenario_provider.by_name(_SCENARIO_NAME)
+    fake = _ReminderSniffingLLM(lanes=autoprove_nag_lanes(), with_human_delay=False)
+    _install_mocks(
+        monkeypatch, scenario_dir, tape_installer=lambda: install_nag_tape(fake=fake)
+    )
+    # This test is about verify_spec's monitoring behavior, not proving — swap
+    # the prover core for the canned status reports.
+    monkeypatch.setattr("composer.spec.source.prover.run_prover", _fake_run_prover)
+
+    # Run the whole pipeline. The first requirement is simply that the nag
+    # path doesn't kill (or corrupt) the run: this raises if any phase dies.
+    summary = RunSummary()
+    async with autoprove_executor(
+        _make_args(langgraph_db.rag_db, scenario_dir, str(scenario_dir / "system.md")),
+        summary,
+    ) as run:
+        await run(AutoProveConsoleHandler().make_handler)
+
+    # The nag reminder reached the author's conversation...
+    nag_prompts = [
+        (lane, [t for t in texts if _NAG_SNIPPET in t])
+        for lane, texts in fake.sniffed
+    ]
+    nag_prompts = [(lane, ts) for lane, ts in nag_prompts if ts]
+    assert nag_prompts, (
+        "the stuck-rule nag never reached any prompt; system-reminders seen: "
+        f"{fake.sniffed}"
+    )
+    # ...in the component-formalization lane, naming the stuck rule...
+    assert all(lane == formalize_task_id(0) for lane, _ in nag_prompts)
+    assert all(NAG_STUCK_RULE in t for _, ts in nag_prompts for t in ts)
+    # ...and exactly once per prompt: the post-skip verify run must not re-nag,
+    # and the reminders channel must drain on injection — either failure would
+    # stack a second copy of the reminder into later prompts.
+    assert all(len(ts) == 1 for _, ts in nag_prompts)


### PR DESCRIPTION
Monitor state update broke validators (cleared channel via [], not None you dummy).

Disable parallel edit tool calling for now, this has killed so many runs :(

WITH TESTS THIS TIME OKAY