### PR TITLE
autosetup: express remapping contexts against the run root

### DIFF
--- a/certora_autosetup/build_systems/foundry.py
+++ b/certora_autosetup/build_systems/foundry.py
@@ -182,7 +182,10 @@ class FoundryManager(BuildSystemManager):
             # Build the packages list from forge remappings + foundry.toml + remappings.txt
             # + package.json for the resolved profile.
             packages = build_packages_from_remapping_sources(
-                base_dir=config_file.parent, log_fn=self.log, profile=profile
+                base_dir=config_file.parent,
+                log_fn=self.log,
+                profile=profile,
+                run_root=self.project_root,
             )
             if packages:
                 config.packages = packages

--- a/certora_autosetup/build_systems/truffle.py
+++ b/certora_autosetup/build_systems/truffle.py
@@ -126,7 +126,9 @@ class TruffleManager(BuildSystemManager):
 
         # Independent of whether the config itself evaluated: the packages list comes from
         # package.json/node_modules, which is what Truffle's own resolver uses.
-        packages = build_packages_from_remapping_sources(base_dir=config_file.parent, log_fn=self.log)
+        packages = build_packages_from_remapping_sources(
+            base_dir=config_file.parent, log_fn=self.log, run_root=self.project_root
+        )
         if packages:
             config.packages = packages
 

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -1626,5 +1626,8 @@ class CompilationWorkaroundManager:
         """
         # Read from the directory that owns the build config (the run root unless the
         # contract lives in a monorepo sub-project); the helper resolves every relative
-        # target absolute against it, so the emitted paths are valid from the run CWD.
-        return build_packages_from_remapping_sources(base_dir=self.build_config_dir, log_fn=self.log)
+        # target absolute against it, so the emitted paths are valid from the run CWD, and
+        # re-expresses remapping contexts against the run root, where solc matches them.
+        return build_packages_from_remapping_sources(
+            base_dir=self.build_config_dir, log_fn=self.log, run_root=self.project_root
+        )

--- a/certora_autosetup/utils/remappings.py
+++ b/certora_autosetup/utils/remappings.py
@@ -182,8 +182,9 @@ def _rebase_context(context: str, base_dir: Path, run_root: Optional[Path], log_
 
     A context is rebased only when ``base_dir/context`` is a real directory, which is what tells
     a project-relative context apart from one that is already run-root-relative. Anything else
-    (no ``run_root``, a context that resolves outside ``run_root``, a context naming no directory)
-    is returned untouched: those are shapes this cannot improve on, so leave them alone.
+    (no ``run_root``, a context naming no directory, a context resolving to the run root itself
+    or outside it) is returned untouched: those are shapes this cannot improve on, so leave them
+    alone. Only the outside-the-run-root case warns — it is the one that cannot work at all.
     """
     if run_root is None or not context:
         return context
@@ -193,7 +194,13 @@ def _rebase_context(context: str, base_dir: Path, run_root: Optional[Path], log_
         return context
 
     rebased = os.path.relpath(resolved, run_root)
-    if rebased == os.curdir or rebased.startswith(os.pardir):
+    if rebased == os.curdir:
+        # The context IS the run root, so it already covers every source unit name. Its faithful
+        # translation is a global, context-free remapping — but promoting a scoped remapping to
+        # global would let it shadow correct global mappings (solc ranks longest matching context
+        # first), so keep it as authored. Nothing is wrong here, hence no warning.
+        return context
+    if rebased.startswith(os.pardir):
         log_fn(
             f"Remapping context '{context}' resolves outside the run root {run_root} "
             f"— leaving it as is",

--- a/certora_autosetup/utils/remappings.py
+++ b/certora_autosetup/utils/remappings.py
@@ -11,7 +11,7 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 import tomllib
 
@@ -23,7 +23,12 @@ LogFn = Callable[[str, str], None]
 _SOURCE_SUFFIXES = (".sol", ".vy", ".yul")
 
 
-def build_packages_from_remapping_sources(base_dir: Path, log_fn: LogFn, profile: str = "default") -> List[str]:
+def build_packages_from_remapping_sources(
+    base_dir: Path,
+    log_fn: LogFn,
+    profile: str = "default",
+    run_root: Optional[Path] = None,
+) -> List[str]:
     """Build a merged packages list from forge remappings, foundry.toml, remappings.txt, package.json.
 
     All sources are read relative to ``base_dir`` (the Foundry project dir), and ``forge remappings``
@@ -31,6 +36,11 @@ def build_packages_from_remapping_sources(base_dir: Path, log_fn: LogFn, profile
     project dir (nested/walked-up ``foundry.toml``). ``profile`` is passed to forge via
     ``FOUNDRY_PROFILE`` and selects the ``[profile.<profile>]`` remappings read from foundry.toml
     when forge is unavailable, so a non-default profile's remappings are honored.
+
+    ``run_root`` is the directory certoraRun is invoked from (the autosetup run root). It is what
+    the *context* half of a context-scoped remapping must be expressed against — see
+    ``_rebase_context``. It equals ``base_dir`` for a project whose build config sits at the run
+    root, in which case every context comes out unchanged; pass it whenever the caller knows it.
 
     Priority on key conflict (highest wins, with a warning on path mismatch):
     1. ``forge remappings`` — recursively walks nested foundry.toml files (e.g. lib/*/foundry.toml)
@@ -74,6 +84,7 @@ def build_packages_from_remapping_sources(base_dir: Path, log_fn: LogFn, profile
                 remapping_key_to_source=remapping_key_to_source,
                 warn_on_mismatch=False,
                 base_dir=base_dir,
+                run_root=run_root,
                 log_fn=log_fn,
             )
     elif result is not None:
@@ -111,6 +122,7 @@ def build_packages_from_remapping_sources(base_dir: Path, log_fn: LogFn, profile
                 remapping_key_to_source=remapping_key_to_source,
                 warn_on_mismatch=False,
                 base_dir=base_dir,
+                run_root=run_root,
                 log_fn=log_fn,
             )
 
@@ -128,6 +140,7 @@ def build_packages_from_remapping_sources(base_dir: Path, log_fn: LogFn, profile
                 remapping_key_to_source=remapping_key_to_source,
                 warn_on_mismatch=True,
                 base_dir=base_dir,
+                run_root=run_root,
                 log_fn=log_fn,
             )
 
@@ -148,10 +161,49 @@ def build_packages_from_remapping_sources(base_dir: Path, log_fn: LogFn, profile
                     remapping_key_to_source=remapping_key_to_source,
                     warn_on_mismatch=True,
                     base_dir=base_dir,
+                    run_root=run_root,
                     log_fn=log_fn,
                 )
 
     return [f"{key}={path}" for key, path in remapping_key_to_path.items()]
+
+
+def _rebase_context(context: str, base_dir: Path, run_root: Optional[Path], log_fn: LogFn) -> str:
+    """Re-express a remapping *context* against ``run_root``.
+
+    A remapping's two halves are matched against different things. The target is a filesystem
+    path, so any spelling that reaches the directory works. The context is matched by solc
+    against the **source unit name** of the importing file — i.e. the path as it appears in the
+    conf's ``files``, which is relative to the directory certoraRun runs from. ``forge
+    remappings`` reports contexts relative to the Foundry project dir instead, so for a project
+    nested under the run root (``<repo>/chains/ethereum-1/foundry.toml``) a context like
+    ``src/Widget_1234/`` never prefixes the source unit name ``chains/ethereum-1/src/Widget_1234/…``,
+    no remapping applies, and every import of that sub-project fails to resolve.
+
+    A context is rebased only when ``base_dir/context`` is a real directory, which is what tells
+    a project-relative context apart from one that is already run-root-relative. Anything else
+    (no ``run_root``, a context that resolves outside ``run_root``, a context naming no directory)
+    is returned untouched: those are shapes this cannot improve on, so leave them alone.
+    """
+    if run_root is None or not context:
+        return context
+
+    resolved = Path(context) if Path(context).is_absolute() else base_dir / context
+    if not resolved.is_dir():
+        return context
+
+    rebased = os.path.relpath(resolved, run_root)
+    if rebased == os.curdir or rebased.startswith(os.pardir):
+        log_fn(
+            f"Remapping context '{context}' resolves outside the run root {run_root} "
+            f"— leaving it as is",
+            "WARNING",
+        )
+        return context
+
+    # relpath drops the trailing slash; the context is a path *prefix*, so put it back exactly
+    # when the source had one (see `_merge_remapping_entry` on why the boundary slash matters).
+    return rebased + "/" if context.endswith("/") else rebased
 
 
 def _merge_remapping_entry(
@@ -162,6 +214,7 @@ def _merge_remapping_entry(
     remapping_key_to_source: Dict[str, str],
     warn_on_mismatch: bool,
     base_dir: Path,
+    run_root: Optional[Path] = None,
     log_fn: LogFn,
 ) -> None:
     """Record a single `key=path` remapping entry into the running key->path/source maps.
@@ -180,7 +233,9 @@ def _merge_remapping_entry(
     ``@oz/contracts/`` from different sources onto one key, so the dedup below stays correct.)
 
     Relative target paths are resolved to absolute against ``base_dir`` so the packages list is
-    valid even when the process CWD differs from the project dir.
+    valid even when the process CWD differs from the project dir. The *context* half of a
+    context-scoped key gets the opposite treatment — ``_rebase_context`` re-expresses it against
+    ``run_root``, because solc matches it against source unit names rather than the filesystem.
 
     On a key conflict (already populated by an earlier-priority source):
     - if ``warn_on_mismatch`` and the stored path differs from the new one, log a warning naming
@@ -192,6 +247,12 @@ def _merge_remapping_entry(
     raw_key, raw_path = entry.split("=", 1)
     key = raw_key.strip()
     path = raw_path.strip()
+
+    # A context-scoped key is `context:prefix`; solc reads the context as a source-unit-name
+    # prefix, so it belongs to the run root while the prefix is opaque text (see `_rebase_context`).
+    if ":" in key:
+        context, prefix = key.split(":", 1)
+        key = f"{_rebase_context(context, base_dir, run_root, log_fn)}:{prefix}"
 
     # Resolve a relative target against base_dir first (Path() drops any trailing slash).
     if not Path(path).is_absolute():

--- a/tests/test_remappings.py
+++ b/tests/test_remappings.py
@@ -320,3 +320,20 @@ def test_parse_config_rebases_contexts_against_the_project_root(tmp_path: Path, 
 
     keys = {p.split("=", 1)[0] for p in (config.packages or [])}
     assert "chains/somechain/src/Widget_1234/:@oz/" in keys
+
+
+def test_context_that_is_the_run_root_is_left_alone_without_a_warning(tmp_path: Path, monkeypatch) -> None:
+    # A context resolving to the run root itself already covers every source unit name, so
+    # nothing is wrong with it — unlike a context resolving outside the run root, it must not
+    # be reported as a problem.
+    project = _nested_project(tmp_path)
+    _no_forge(monkeypatch)
+    (project / "remappings.txt").write_text("../../:@oz/=lib/forge-std/src/\n")
+    logged: list[tuple[str, str]] = []
+
+    packages = build_packages_from_remapping_sources(
+        base_dir=project, log_fn=lambda msg, level: logged.append((msg, level)), run_root=tmp_path
+    )
+
+    assert "../../:@oz/" in _keys(packages)
+    assert not [m for m, level in logged if level == "WARNING" and "run root" in m]

--- a/tests/test_remappings.py
+++ b/tests/test_remappings.py
@@ -213,3 +213,110 @@ def test_forge_run_with_foundry_profile_env(tmp_path: Path, monkeypatch) -> None
     build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None, profile="ci")
 
     assert captured["env"]["FOUNDRY_PROFILE"] == "ci"
+
+
+def _nested_project(tmp_path: Path) -> Path:
+    """A repo whose Foundry project sits at <repo>/chains/somechain, with a sub-project tree."""
+    project = tmp_path / "chains" / "somechain"
+    (project / "src" / "Widget_1234" / "dependencies" / "oz-5.4.0" / "contracts").mkdir(parents=True)
+    (project / "lib" / "forge-std" / "src").mkdir(parents=True)
+    return project
+
+
+def test_context_is_rebased_onto_the_run_root(tmp_path: Path, monkeypatch) -> None:
+    # `forge remappings` reports contexts relative to the project dir, but solc matches them
+    # against source unit names, which are relative to the run root. For a project nested under
+    # the run root the reported context `src/Widget_1234/` never prefixes the source unit name
+    # `chains/somechain/src/Widget_1234/...`, so the remapping silently never applies and every
+    # import of that sub-project fails to resolve.
+    project = _nested_project(tmp_path)
+    _forge_returning(
+        monkeypatch,
+        "src/Widget_1234/:@openzeppelin/contracts/=src/Widget_1234/dependencies/oz-5.4.0/contracts/\n"
+        "forge-std/=lib/forge-std/src/\n",
+    )
+
+    packages = build_packages_from_remapping_sources(
+        base_dir=project, log_fn=lambda *_: None, run_root=tmp_path
+    )
+
+    keys = _keys(packages)
+    assert "chains/somechain/src/Widget_1234/:@openzeppelin/contracts/" in keys
+    assert "src/Widget_1234/:@openzeppelin/contracts/" not in keys
+    # the target half is untouched by the rebasing — still absolute, still pointing at the tree
+    assert _path_of(packages, "chains/somechain/src/Widget_1234/:@openzeppelin/contracts/") == \
+        str(project / "src/Widget_1234/dependencies/oz-5.4.0/contracts") + "/"
+    # an unscoped key has no context to rebase
+    assert "forge-std/" in keys
+
+
+def test_context_unchanged_when_the_project_is_the_run_root(tmp_path: Path, monkeypatch) -> None:
+    # The flat case (the overwhelming majority): base_dir == run_root, so contexts are already
+    # expressed against the run root and must come out byte-identical.
+    (tmp_path / "lib" / "some-dependency").mkdir(parents=True)
+    _no_forge(monkeypatch)
+    (tmp_path / "remappings.txt").write_text(
+        "lib/some-dependency/:@openzeppelin/contracts/=lib/openzeppelin-contracts-v4/contracts/\n"
+    )
+
+    with_root = build_packages_from_remapping_sources(
+        base_dir=tmp_path, log_fn=lambda *_: None, run_root=tmp_path
+    )
+    without_root = build_packages_from_remapping_sources(base_dir=tmp_path, log_fn=lambda *_: None)
+
+    assert with_root == without_root
+    assert "lib/some-dependency/:@openzeppelin/contracts/" in _keys(with_root)
+
+
+def test_context_naming_no_directory_is_left_alone(tmp_path: Path, monkeypatch) -> None:
+    # Only a context that names a real directory under the project is project-relative. Anything
+    # else — including a context already written against the run root — is left as authored.
+    project = _nested_project(tmp_path)
+    _no_forge(monkeypatch)
+    (project / "remappings.txt").write_text(
+        "chains/somechain/src/Widget_1234/:@oz/=src/Widget_1234/dependencies/oz-5.4.0/contracts/\n"
+    )
+
+    packages = build_packages_from_remapping_sources(
+        base_dir=project, log_fn=lambda *_: None, run_root=tmp_path
+    )
+
+    assert "chains/somechain/src/Widget_1234/:@oz/" in _keys(packages)
+
+
+def test_context_outside_the_run_root_is_left_alone_with_a_warning(tmp_path: Path, monkeypatch) -> None:
+    # A context resolving outside the run root cannot be named by any source unit name; keep the
+    # authored form and say so rather than emitting a `../`-prefixed context.
+    project = _nested_project(tmp_path)
+    outside = tmp_path.parent / f"{tmp_path.name}-vendor"
+    outside.mkdir(exist_ok=True)
+    _no_forge(monkeypatch)
+    (project / "remappings.txt").write_text(f"{outside}/:@oz/=lib/forge-std/src/\n")
+    warnings: list[tuple[str, str]] = []
+
+    packages = build_packages_from_remapping_sources(
+        base_dir=project,
+        log_fn=lambda msg, level: warnings.append((msg, level)),
+        run_root=tmp_path,
+    )
+
+    assert f"{outside}/:@oz/" in _keys(packages)
+    assert any(level == "WARNING" and "outside the run root" in msg for msg, level in warnings)
+
+
+def test_parse_config_rebases_contexts_against_the_project_root(tmp_path: Path, monkeypatch) -> None:
+    # End-to-end at the bug site: the manager knows the run root, so parse_config's packages
+    # come out with run-root-relative contexts.
+    project = _nested_project(tmp_path)
+    foundry_toml = project / "foundry.toml"
+    foundry_toml.write_text(
+        '[profile.default]\nsrc = "src"\n'
+        'remappings = ["src/Widget_1234/:@oz/=src/Widget_1234/dependencies/oz-5.4.0/contracts/"]\n'
+    )
+    _no_forge(monkeypatch)
+
+    manager = FoundryManager(project_root=tmp_path, scope=None)
+    config = manager.parse_config(foundry_toml)
+
+    keys = {p.split("=", 1)[0] for p in (config.packages or [])}
+    assert "chains/somechain/src/Widget_1234/:@oz/" in keys


### PR DESCRIPTION
## The bug

A remapping's two halves are matched against different things:

- the **target** is a filesystem path — absolute or cwd-relative, both resolve;
- the **context** is a prefix solc matches against the *source unit name* of the importing
  file, i.e. the path as it appears in the conf's `files`, relative to the directory
  certoraRun runs from.

`build_packages_from_remapping_sources` resolved the target against `base_dir` but copied the
key verbatim, and `forge remappings` reports contexts relative to the Foundry project dir. When
the project is a subdirectory of the run root (`<repo>/<chain-dir>/foundry.toml`, one bundle per
subdirectory under it), a reported context `src/Widget_1234/` never prefixes the source unit name
`<chain-dir>/src/Widget_1234/…`, so **no context ever matches and every package for that
sub-project is inert**. The failure is confusing because the conf plainly contains the right
mapping and the target directory really exists:

```
ParserError: Source "@openzeppelin/contracts/utils/ReentrancyGuard.sol" not found:
File not found. Searched the following locations: "".
```

The empty search-location list is the tell — solc had no applicable remapping at all.

`source_not_found_packages` cannot rescue it either: since the builder was unified it recomputes
the identical list and stops with *"Workarounds applied … but the conf and command are unchanged
— retrying would fail identically, giving up"*.

## The fix

`_rebase_context` re-expresses the context against the run root, which the three call sites
(`foundry.py`, `truffle.py`, `compilation_workarounds.py`) already hold as `self.project_root`.

A context is rebased only when `base_dir/context` is a real directory — that is what separates a
project-relative context from one already written against the run root, and it avoids inventing a
doubled prefix. A context resolving outside the run root cannot be named by any source unit name,
so it is kept as authored with a WARNING.

**When the build config sits at the run root — every flat project — the rebasing is the
identity**, so nothing changes for the vast majority of runs.

## Tests

Five new cases in `tests/test_remappings.py`: nested project rebases, flat project is
byte-identical with and without `run_root`, a context naming no directory is left alone, a
context outside the run root warns and is left alone, and `parse_config` end-to-end.

`pytest -m "not expensive"`: 700 passed, 9 skipped. `pyright`: 0 errors.

Fleet: a new corpus entry reproducing this layout is queued through the mass-test rig — a
before/after on it plus a full-corpus regression run. Results will be posted here before merge.