### PR TITLE
automatic graph retries

### DIFF
--- a/composer/io/context.py
+++ b/composer/io/context.py
@@ -23,16 +23,18 @@ parent_id=outer_tid)`` before pushing to the queue.  The drainer
 peels these layers to reconstruct the full execution path.
 """
 
-from contextvars import ContextVar
+from abc import ABC, abstractmethod
+from contextvars import ContextVar, Token
 from contextlib import asynccontextmanager
 
 import asyncio
+
 
 from composer.io.protocol import IOHandler
 from composer.io.stream import EventQueue
 from composer.io.event_handler import EventHandler
 
-from typing import Any, Mapping
+from typing import Any, Awaitable, Callable, Mapping, Protocol, cast, override
 
 from composer.io.events import (
     AllEvents, InnerEvent, Nested, NextCheckpoint,
@@ -46,7 +48,7 @@ from langgraph.graph.state import CompiledStateGraph
 from langchain_core.runnables import RunnableConfig
 
 from composer.io.graph_runner import SinkProtocol, run_graph as _run_graph
-
+from langgraph._internal._typing import StateLike
 
 _io_handler : ContextVar[None | tuple[EventQueue, IOHandler[Any], EventHandler]] = ContextVar("_io_handler", default=None)
 
@@ -145,6 +147,7 @@ async def run_graph[S: StateLike, C: StateLike | None, I: StateLike](
     run_conf: RunnableConfig,
     description: str,
     within_tool: str | None = None,
+    retry: "RetryPolicy | FreshRetryPolicy[S, I] | None" = None,
 ) -> S:
     """Execute a graph within the current ``with_handler`` scope.
 
@@ -154,6 +157,15 @@ async def run_graph[S: StateLike, C: StateLike | None, I: StateLike](
     the drainer can reconstruct the execution path.
 
     HITL interrupts are bridged to ``IOHandler.human_interaction()``.
+
+    Retry is first-class: the floor policy (``retry`` when it is a
+    :class:`RetryPolicy`, else the ambient :func:`install_retry_policy` one)
+    re-runs transient failures from the last checkpoint this run streamed; a
+    :class:`FreshRetryPolicy` (``retry`` when it is one) escalates wedged
+    failures by rebuilding the input on a fresh thread. Checkpoints are
+    tracked by wrapping THIS run's sink — children's checkpoints arrive
+    ``Nested``-wrapped and don't register — so retry works for nested
+    (sub-agent) runs, each tracking only its own thread.
     """
     curr_io = _io_handler.get()
     if curr_io is None:
@@ -162,7 +174,8 @@ async def run_graph[S: StateLike, C: StateLike | None, I: StateLike](
     (ev, handle, _) = curr_io
 
     # Determine thread_id from config
-    tid = run_conf.get("configurable", {}).get("thread_id")
+    configurable = run_conf.get("configurable", {})
+    tid = configurable.get("thread_id")
     if tid is None:
         raise ValueError("thread_id required in run config")
 
@@ -174,7 +187,20 @@ async def run_graph[S: StateLike, C: StateLike | None, I: StateLike](
         (parent_sink, parent_tid) = parent
         sink = lambda event: parent_sink(Nested(event, parent_id=parent_tid))
 
-    tok = _current_sink.set((sink, tid))
+    # The most recent checkpoint THIS run committed (seeded from an explicit
+    # resume point when the caller passed one) — the resume anchor for floor
+    # retries. Recorded by wrapping this run's own sink rather than the
+    # scope's queue, so concurrent and nested runs never cross-talk.
+    last_checkpoint: str | None = configurable.get("checkpoint_id")
+
+    def tracking_sink(event: GraphEvents) -> None:
+        nonlocal last_checkpoint
+        if isinstance(event, NextCheckpoint):
+            last_checkpoint = event.checkpoint_id
+        sink(event)
+
+    floor = retry if isinstance(retry, RetryPolicy) else _run_retry_policy.get()
+    fresh = retry if isinstance(retry, FreshRetryPolicy) else None
 
     async def handle_human(
         h: Any,
@@ -182,16 +208,201 @@ async def run_graph[S: StateLike, C: StateLike | None, I: StateLike](
     ) -> str:
         return await handle.human_interaction(h, lambda: None)
 
-    try:
-        return await _run_graph(
-            event_sink=sink,
-            graph=graph,
-            ctxt=ctxt,
-            input=input,
-            run_conf=run_conf,
-            description=description,
-            human_handler=handle_human,
-            within_tool=within_tool,
-        )
-    finally:
-        _current_sink.reset(tok)
+    async def _attempt(inp: I, tid_: str, desc: str) -> S:
+        conf = run_conf.copy()
+        merged: dict[str, Any] = {**configurable, "thread_id": tid_}
+        # ``configurable`` may carry the caller's original resume point; the
+        # tracked checkpoint (None after a fresh restart) is authoritative.
+        merged.pop("checkpoint_id", None)
+        if last_checkpoint is not None:
+            merged["checkpoint_id"] = last_checkpoint
+        conf["configurable"] = merged
+        tok = _current_sink.set((tracking_sink, tid_))
+        try:
+            return await _run_graph(
+                event_sink=tracking_sink,
+                graph=graph,
+                ctxt=ctxt,
+                input=inp,
+                run_conf=conf,
+                description=desc,
+                human_handler=handle_human,
+                within_tool=within_tool,
+            )
+        finally:
+            _current_sink.reset(tok)
+
+    async def _with_floor(inp: I, tid_: str, desc_base: str) -> S:
+        attempts = floor.max_retries if floor is not None else 1
+        for i in range(attempts):
+            desc = desc_base if i == 0 else f"{desc_base} (Retry {i})"
+            try:
+                return await _attempt(inp, tid_, desc)
+            except Exception as e:
+                # Non-retryable, or that was the last attempt: propagate as-is
+                # (no parting backoff — there is no next attempt to wait for).
+                if floor is None or not floor.should_retry(e) or i + 1 >= attempts:
+                    raise e
+                if last_checkpoint is None:
+                    raise ValueError("Got retryable error but no checkpoint to resume from") from e
+                await floor.try_backoff(i)
+        assert False  # unreachable: the last iteration either returns or raises
+
+    if fresh is None:
+        return await _with_floor(input, tid, description)
+
+    curr_input = input
+    curr_tid = tid
+    for j in range(fresh.max_fresh_retries):
+        if j > 0:
+            last_checkpoint = None
+        desc = description if j == 0 else f"{description} (Attempt {j})"
+        try:
+            return await _with_floor(curr_input, curr_tid, desc)
+        except Exception as e:
+            # Not fresh-retryable, or that was the last fresh attempt:
+            # propagate as-is (no pointless rebuild of an input that will
+            # never run).
+            if not fresh.should_retry_fresh(e) or j + 1 >= fresh.max_fresh_retries:
+                raise e
+            if last_checkpoint is None:
+                raise ValueError("Have retryable error but no checkpoint from which to recover") from e
+            last_state = await graph.aget_state({"configurable": {
+                "thread_id": curr_tid,
+                "checkpoint_id": last_checkpoint
+            }})
+            if not last_state.values:
+                raise ValueError(f"No state at the last checkpoint {last_checkpoint} in {curr_tid}") from e
+            (curr_input, curr_tid) = await fresh.rebuild_input(
+                last_state=cast(S, last_state.values),
+                last_input=curr_input
+            )
+    assert False  # unreachable: the last iteration either returns or raises
+
+
+async def run_to_completion[I: StateLike, S: StateLike, C: StateLike | None](
+    graph: CompiledStateGraph[S, C, I, Any],
+    input: I,
+    thread_id: str,
+    context: C = None,
+    *,
+    checkpoint_id: str | None = None,
+    recursion_limit: int,
+    description: str,
+    within_tool: str | None = None,
+    retry: "RetryPolicy | FreshRetryPolicy[S, I] | None" = None,
+) -> S:
+    """Run a compiled state graph to completion.
+
+    Delegates to :func:`run_graph`, which handles event nesting automatically
+    via context vars and applies the ambient (or ``retry``-overridden) retry
+    policy. Requires ``with_handler()`` to be active.
+
+    ``within_tool`` is the calling tool's ``tool_call_id`` when this graph is
+    being run as a sub-agent from inside a tool. It anchors the sub-graph's
+    UI panel under the tool-call widget so the renderer can mount nested
+    output in the right place. Pass ``self.tool_call_id`` from a tool that
+    mixes in ``WithInjectedId``; leave ``None`` for top-level / pipeline-
+    phase invocations.
+    """
+    run_conf: RunnableConfig = {
+        "configurable": {"thread_id": thread_id},
+        "recursion_limit": recursion_limit,
+    }
+    if checkpoint_id is not None:
+        run_conf["configurable"]["checkpoint_id"] = checkpoint_id
+
+    return await run_graph(
+        graph=graph,
+        ctxt=context,
+        input=input,
+        run_conf=run_conf,
+        description=description,
+        within_tool=within_tool,
+        retry=retry,
+    )
+
+class RetryPolicy(ABC):
+    """The transient-failure ("floor") retry contract: which exceptions are
+    worth re-running from the last checkpoint, and how long to back off
+    between attempts. Installed run-wide via :func:`install_retry_policy`,
+    or passed per-run through ``run_graph`` / ``run_to_completion`` to
+    override the ambient floor."""
+
+    max_retries: int
+
+    @abstractmethod
+    def should_retry(self, exc: Exception) -> bool: ...
+
+    @abstractmethod
+    async def try_backoff(self, try_count: int): ...
+
+
+class FreshRetryPolicy[S: StateLike, I: StateLike](ABC):
+    """Fresh-start escalation, independent of the floor policy: for failures
+    a checkpoint-resume can't fix (the thread is wedged, not the request),
+    rebuild the input from the crashed attempt's last checkpointed state and
+    start over on the fresh thread id ``rebuild_input`` returns.
+
+    Deliberately NOT a :class:`RetryPolicy`: specifying an escalation does not
+    require restating a floor — a plain ``FreshRetryPolicy`` rides whatever
+    floor is ambiently installed. A type inheriting BOTH overrides the floor
+    as well."""
+
+    max_fresh_retries: int
+
+    @abstractmethod
+    def should_retry_fresh(self, exc: Exception) -> bool: ...
+
+    @abstractmethod
+    async def rebuild_input(
+        self, last_state: S, last_input: I
+    ) -> tuple[I, str]: ...
+
+
+type RetryPredicate = Callable[[Exception], bool]
+
+type Backoff = Callable[[int], Awaitable[None]]
+
+async def exponential_backoff(
+    i: int
+):
+    await asyncio.sleep((2 * 2 ** i) * 60) # aggressive backoff in *minutes*
+
+DEFAULT_MAX_RETRIES = 3
+
+class DefaultRetryPolicy(RetryPolicy):
+    def __init__(
+        self,
+        should_retry: RetryPredicate,
+        backoff: Backoff = exponential_backoff,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ):
+        self._should_retry = should_retry
+        self.backoff_policy = backoff
+        self.max_retries = max_retries
+
+    @override
+    def should_retry(self, exc: Exception) -> bool:
+        return self._should_retry(exc)
+
+    @override
+    async def try_backoff(self, try_count: int):
+        await self.backoff_policy(try_count)
+
+
+_run_retry_policy: ContextVar[RetryPolicy | None] = ContextVar("_run_retry_policy", default=None)
+"""The run-wide retry floor. Read by every ``run_graph`` (nested sub-agent
+runs included) when no per-run policy overrides it; ``None`` means failures
+propagate on the first attempt, as before."""
+
+
+def install_retry_policy(policy: RetryPolicy | None) -> Token[RetryPolicy | None]:
+    """Install the run-wide retry floor.
+
+    The pipeline harness calls this once per run (mirroring
+    ``install_run_summary``) before any graph work spawns; contextvar
+    inheritance carries it into every task of the run. Returns the token so
+    scoped callers (tests) can reset."""
+    return _run_retry_policy.set(policy)
+

--- a/composer/llm/anthropic.py
+++ b/composer/llm/anthropic.py
@@ -219,6 +219,19 @@ class AnthropicService(ProviderServiceBase):
         }
         return to_ret
 
+    @override
+    def should_retry(self, exc: Exception) -> bool:
+        """Mirrors the SDK's own ``_should_retry`` status roster (408/409/429
+        and every 5xx, which covers 529 overloaded) plus connection-level
+        failures (``APITimeoutError`` subclasses ``APIConnectionError``).
+        400-class request errors are deterministic — an over-long prompt fails
+        identically on every attempt — and are deliberately excluded."""
+        if isinstance(exc, anthropic.APIConnectionError):
+            return True
+        if isinstance(exc, anthropic.APIStatusError):
+            return exc.status_code in (408, 409, 429) or exc.status_code >= 500
+        return False
+
 @dataclass
 class AnthropicModelProvider:
     """``ModelProvider`` for Anthropic. Probes ``model_name`` once at

--- a/composer/llm/openai.py
+++ b/composer/llm/openai.py
@@ -151,6 +151,18 @@ class OpenAIService(ProviderServiceBase):
             OpenAIFileUploader.lazy
         )
 
+    @override
+    def should_retry(self, exc: Exception) -> bool:
+        """Same shape as the Anthropic mapping — the OpenAI SDK shares the
+        Stainless exception taxonomy: connection-level failures and
+        408/409/429/5xx statuses are transient; 400-class request errors are
+        deterministic and excluded."""
+        if isinstance(exc, openai.APIConnectionError):
+            return True
+        if isinstance(exc, openai.APIStatusError):
+            return exc.status_code in (408, 409, 429) or exc.status_code >= 500
+        return False
+
 @dataclass
 class OpenAIRenderer:
     def text_block(self, text: str, *, cache_level: CacheLevel = CacheLevel.NONE) -> dict:

--- a/composer/llm/provider.py
+++ b/composer/llm/provider.py
@@ -36,6 +36,14 @@ class ProviderService(Protocol):
     def cache_marker(self, payload: "RawMessageType", cache_level: CacheLevel) -> "RawMessageType":
         ...
 
+    def should_retry(self, exc: Exception) -> bool:
+        """Whether ``exc`` is a transient provider-side failure worth retrying
+        (rate limits, overload, dropped connections) — as opposed to a
+        deterministic request error (an over-long prompt 400s identically
+        every time). The harness assembles this into the run-wide retry
+        policy (``composer.io.context.install_retry_policy``)."""
+        ...
+
 class ProviderServiceBase(ABC):
     def __init__(self,
         mem_fact: Callable[["AsyncPostgresBackend"], "BaseTool"],
@@ -58,6 +66,11 @@ class ProviderServiceBase(ABC):
 
     def cache_marker(self, payload: "RawMessageType", cache_level: CacheLevel) -> "RawMessageType":
         return payload
+
+    def should_retry(self, exc: Exception) -> bool:
+        # Providers opt in to retryability explicitly; unknown exceptions are
+        # never worth an automatic re-run.
+        return False
 
 
 class ModelProvider(Protocol):

--- a/composer/natreq/extractor.py
+++ b/composer/natreq/extractor.py
@@ -9,7 +9,6 @@ from graphcore.graph import FlowInput, build_async_workflow
 from graphcore.tools.results import result_tool_generator
 
 from langchain_core.tools import tool, BaseTool
-from langchain_core.runnables import RunnableConfig
 from langchain_core.language_models.chat_models import BaseChatModel
 
 from langgraph.graph import MessagesState
@@ -26,7 +25,7 @@ from composer.tools.search import cvl_manual_tools
 from composer.tools.thinking import RoughDraftState, get_rough_draft_tools
 from composer.templates.loader import load_jinja_template
 from composer.io.protocol import IOHandler
-from composer.io.context import with_handler, run_graph
+from composer.io.context import with_handler, run_to_completion
 from composer.io.event_handler import NullEventHandler
 from composer.ui.tool_display import tool_display
 from composer.diagnostics.timing import set_current_task_id
@@ -149,8 +148,6 @@ async def get_requirements(
 
         thread_id = uuid.uuid1().hex
 
-        config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
-
         sys_text = sys_doc.string_contents
         input_text : list[str | dict] = [
             "The system document is as follows:",
@@ -178,6 +175,13 @@ async def get_requirements(
 
         async with with_handler(io, NullEventHandler()):  # type: ignore[arg-type]
             with set_current_task_id(REQUIREMENTS_TASK_ID):
-                final_state = await run_graph(built, ExtractionContext(rag_db=db), graph_input, config, description="Requirements extraction")  
+                final_state = await run_to_completion(
+                    built,
+                    graph_input,
+                    thread_id=thread_id,
+                    context=ExtractionContext(rag_db=db),
+                    recursion_limit=250,
+                    description="Requirements extraction",
+                )
         assert "reqs" in final_state
         return ExtractionResult(reqs=final_state["reqs"], thread_id=thread_id)

--- a/composer/natreq/judge.py
+++ b/composer/natreq/judge.py
@@ -15,7 +15,6 @@ from langgraph.checkpoint.memory import MemorySaver
 from langchain_core.tools import BaseTool, tool, InjectedToolCallId
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import ToolMessage
-from langchain_core.runnables import RunnableConfig
 from langgraph.runtime import get_runtime
 
 from composer.templates.loader import load_jinja_template
@@ -23,7 +22,7 @@ from composer.tools.thinking import RoughDraftState, get_rough_draft_tools
 from composer.core.state import AIComposerState
 from composer.core.validation import ReqsValidation
 from composer.core.context import AIComposerContext, stamp
-from composer.io.context import run_graph
+from composer.io.context import run_to_completion
 from composer.ui.tool_display import tool_display
 
 class JudgeInput(FlowInput, RoughDraftState):
@@ -150,12 +149,13 @@ def get_judge_tool(
         state: AIComposerState,
         tool_call_id: Annotated[str, InjectedToolCallId]
     ) -> Command | str:
-        judge_config: RunnableConfig = {"configurable": {"thread_id": uuid.uuid1().hex}}
-        judge_state = await run_graph(
+        judge_state = await run_to_completion(
             compiled_graph,
-            None,
             JudgeInput(input=[req_list], vfs=state["vfs"], orig_reqs=reqs, memory=None, did_read=False),
-            judge_config,
+            thread_id=uuid.uuid1().hex,
+            context=None,
+            # Preserves the langgraph default this run has always ridden on.
+            recursion_limit=250,
             description="Requirements evaluation",
             within_tool=tool_call_id
         )

--- a/composer/pipeline/cli.py
+++ b/composer/pipeline/cli.py
@@ -35,6 +35,7 @@ from .plugins import applicable_plugin_manifest
 from .run_tags import AutoProveCacheTags, CACHE_ROOT_RECORD
 from composer.io.multi_job import HandlerFactory, run_task, TaskInfo
 from composer.diagnostics.timing import RunSummary, install_run_summary
+from composer.io.context import DefaultRetryPolicy, install_retry_policy
 from composer.llm.registry import get_provider_for
 from composer.rag.models import get_model
 from composer.io.thread_logging import RunDataLogger, thread_logger, default_logging_ns
@@ -240,6 +241,11 @@ async def cli_pipeline[P: enum.Enum, H](
     print(f"autoprove logs: {text_log}\n           events: {events_log}", file=sys.stderr)
     print(f"Selected run id: {summary.run_id}")
     install_run_summary(summary)
+    # Run-wide retry floor: transient provider failures (as classified by the
+    # provider itself) resume any graph in the run from its last checkpoint
+    # instead of killing the whole pipeline. Installed once here — contextvar
+    # inheritance carries it into every task the run spawns.
+    install_retry_policy(DefaultRetryPolicy(tiered.provider_service.should_retry))
 
     disc_cache_ns: tuple[str, ...] | None = (
         user_ns(args.cache_ns, "discovery",

--- a/composer/spec/graph_builder.py
+++ b/composer/spec/graph_builder.py
@@ -2,22 +2,22 @@
 Convenience helpers for building agent sub-workflows.
 
 - bind_standard: Extracts result type from state, adds result tool + summarizer
-- run_to_completion: Thin wrapper around context.run_graph for sub-workflows
+- run_to_completion: re-exported from ``composer.io.context`` (its real home),
+  where retry policies are applied; kept here for the existing spec-land
+  importers.
 """
 
 from typing import Any, Callable, NotRequired, get_origin, get_args, cast, overload
 
 from pydantic import BaseModel
 
-from langchain_core.runnables import RunnableConfig
 from langgraph._internal._typing import StateLike
 from langgraph.graph import MessagesState
-from langgraph.graph.state import CompiledStateGraph
 
 from graphcore.graph import Builder, FlowInput
 from graphcore.tools.results import ValidationResult, result_tool_generator
 
-from composer.io.context import run_graph as _context_run_graph
+from composer.io.context import run_to_completion as run_to_completion
 
 
 def bind_standard[_S: MessagesState, _C: StateLike | None, _I: FlowInput | None, _R](
@@ -73,41 +73,3 @@ def bind_standard[_S: MessagesState, _C: StateLike | None, _I: FlowInput | None,
 
     return builder.with_state(state_type).with_tools([result_tool]).with_output_key("result").with_default_summarizer()
 
-async def run_to_completion[I: StateLike, S: StateLike, C: StateLike | None](
-    graph: CompiledStateGraph[S, C, I, Any],
-    input: I,
-    thread_id: str,
-    context: C = None,
-    *,
-    checkpoint_id: str | None = None,
-    recursion_limit: int,
-    description: str,
-    within_tool: str | None = None,
-) -> S:
-    """Run a compiled state graph to completion.
-
-    Delegates to composer.io.context.run_graph, which handles event nesting
-    automatically via context vars. Requires with_handler() to be active.
-
-    ``within_tool`` is the calling tool's ``tool_call_id`` when this graph is
-    being run as a sub-agent from inside a tool. It anchors the sub-graph's
-    UI panel under the tool-call widget so the renderer can mount nested
-    output in the right place. Pass ``self.tool_call_id`` from a tool that
-    mixes in ``WithInjectedId``; leave ``None`` for top-level / pipeline-
-    phase invocations.
-    """
-    run_conf: RunnableConfig = {
-        "configurable": {"thread_id": thread_id},
-        "recursion_limit": recursion_limit,
-    }
-    if checkpoint_id is not None:
-        run_conf["configurable"]["checkpoint_id"] = checkpoint_id
-
-    return await _context_run_graph(
-        graph=graph,
-        ctxt=context,
-        input=input,
-        run_conf=run_conf,
-        description=description,
-        within_tool=within_tool,
-    )

--- a/composer/spec/source/monitor.py
+++ b/composer/spec/source/monitor.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from langgraph.config import get_config
 from langchain_core.messages import HumanMessage
+from composer.spec.graph_builder import run_to_completion
 from graphcore.graph import MonitorReturn
 from composer.prover.ptypes import StatusCodes
 

--- a/composer/workflow/executor.py
+++ b/composer/workflow/executor.py
@@ -4,7 +4,6 @@ import uuid
 from dataclasses import dataclass
 import pathlib
 
-from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 
 from graphcore.graph import Builder
@@ -41,7 +40,7 @@ from composer.tools.relaxation import requirements_relaxation
 from composer.tools.search import cvl_manual_tools
 from composer.templates.loader import load_jinja_template
 from composer.io.protocol import CodeGenIOHandler, WorkflowPurpose
-from composer.io.context import with_handler, run_graph
+from composer.io.context import with_handler, run_to_completion
 from composer.diagnostics.timing import set_current_task_id
 from composer.ui.codegen_events import CodeGenEventHandler
 from composer.core.state import AIComposerInput, AIComposerExtra
@@ -466,12 +465,6 @@ async def _run_codegen(
     except ModuleNotFoundError:
         pass
 
-    config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
-    config["recursion_limit"] = workflow_options.recursion_limit
-
-    if workflow_options.checkpoint_id is not None:
-        config["configurable"]["checkpoint_id"] = workflow_options.checkpoint_id
-
     required_validations: list[CodegenValidation] = [ProverValidation(s) for (s, _) in spec_docs]
     if reqs_list is not None:
         required_validations.append(ReqsValidation())
@@ -483,7 +476,15 @@ async def _run_codegen(
     try:
         async with with_handler(handler, CodeGenEventHandler(handler)):
             with set_current_task_id(CODEGEN_TASK_ID):
-                final_state = await run_graph(workflow_exec, work_context, flow_input, config, description="Code generation")
+                final_state = await run_to_completion(
+                    workflow_exec,
+                    flow_input,
+                    thread_id=thread_id,
+                    context=work_context,
+                    checkpoint_id=workflow_options.checkpoint_id,
+                    recursion_limit=workflow_options.recursion_limit,
+                    description="Code generation",
+                )
 
         result = final_state.get("generated_code", None)
         if result is None:

--- a/tests/test_graph_retry.py
+++ b/tests/test_graph_retry.py
@@ -1,0 +1,561 @@
+"""Tests for the retry machinery in ``composer.io.context`` — the ambient
+(run-wide) retry floor, per-run overrides, and the ``FreshRetryPolicy``
+escalation, all first-class in ``run_graph``.
+
+The graphs are static pregel loops (plan → author) over in-memory
+checkpointers; nodes consult a scripted ``FlakyLLM`` that raises on the turns
+the script says to. No Postgres, no real backoff sleeps (policies get a
+recording backoff), no LLM.
+
+What the scenarios pin down:
+
+* a retryable failure resumes from the LAST CHECKPOINT — completed nodes do
+  not re-run, the failed node does, and the backoff is consulted with the
+  failed attempt's index;
+* a non-retryable failure propagates immediately, no backoff consulted;
+* the ambient floor (``install_retry_policy``) applies when no per-run policy
+  is passed — and to NESTED sub-graph runs, which each track their own
+  checkpoints via their own sink wrapper;
+* a per-run policy that is a ``RetryPolicy`` overrides the ambient floor;
+* the state-backoff ladder: a sub-agent that EXHAUSTS its floor bubbles into
+  the parent's floor retry, which re-enters the spawning node — respawning
+  the sub-agent on a fresh thread id with pristine state, while the exhausted
+  spawn's thread is abandoned mid-flight;
+* a plain ``FreshRetryPolicy`` (deliberately NOT a ``RetryPolicy``) rides the
+  ambient floor for transient failures while escalating wedged ones by
+  rebuilding the input on a fresh thread — attempt 1's state does not leak;
+* exhaustion, both loops: a retryable failure on the final attempt propagates
+  as-is — no parting backoff, no pointless final ``rebuild_input``.
+"""
+import operator
+import uuid
+from contextlib import contextmanager
+from typing import Annotated, Any, TypedDict, override
+
+import pytest
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.state import CompiledStateGraph
+
+from composer.io.context import (
+    Backoff,
+    DefaultRetryPolicy,
+    FreshRetryPolicy,
+    RetryPolicy,
+    install_retry_policy,
+    run_to_completion,
+    with_handler,
+)
+from composer.io.event_handler import NullEventHandler
+
+pytestmark = pytest.mark.asyncio
+
+
+class RetryState(TypedDict):
+    log: Annotated[list[str], operator.add]
+
+
+class FakeOverloadedError(Exception):
+    """Stands in for the transiently-retryable class (529/rate limit)."""
+
+
+class FakeCorruptedError(Exception):
+    """Stands in for a wedged-thread failure that needs a fresh start."""
+
+
+class FakeFatalError(Exception):
+    """Retryable by no policy."""
+
+
+def _retry_on(*types: type[Exception]):
+    return lambda e: isinstance(e, types)
+
+
+class FlakyLLM:
+    """Scripted fake: each ``ainvoke`` consumes the next script entry —
+    a str to return, or an exception instance to raise."""
+
+    def __init__(self, script: list[str | Exception]):
+        self.script = list(script)
+        self.calls = 0
+
+    async def ainvoke(self, prompt: str) -> str:
+        i = self.calls
+        self.calls += 1
+        assert i < len(self.script), f"FlakyLLM script exhausted at call {i} ({prompt!r})"
+        item = self.script[i]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class _RecordingIOHandler:
+    """IOHandler that records log_start descriptions (the retry loops label
+    attempts through them) and refuses HITL (none expected here)."""
+
+    def __init__(self) -> None:
+        self.descriptions: list[str] = []
+
+    async def log_checkpoint_id(self, *, path: list[str], checkpoint_id: str) -> None:
+        pass
+
+    async def log_state_update(self, path: list[str], st: dict) -> None:
+        pass
+
+    async def log_start(self, *, path: list[str], description: str, tool_id: str | None) -> None:
+        self.descriptions.append(description)
+
+    async def log_end(self, path: list[str]) -> None:
+        pass
+
+    async def human_interaction(self, ty: Any, debug_thunk: Any) -> str:
+        raise AssertionError("no HITL interaction expected in retry tests")
+
+
+def _recording_backoff(record: list[int]) -> Backoff:
+    async def _backoff(i: int) -> None:
+        record.append(i)
+    return _backoff
+
+
+@contextmanager
+def _ambient_policy(policy: RetryPolicy):
+    tok = install_retry_policy(policy)
+    try:
+        yield
+    finally:
+        tok.var.reset(tok)
+
+
+def _build_graph(
+    llm: FlakyLLM, node_runs: list[str]
+) -> CompiledStateGraph[RetryState, None, RetryState, RetryState]:
+    async def plan(state: RetryState) -> dict:
+        node_runs.append("plan")
+        return {"log": [f"plan: {await llm.ainvoke('plan')}"]}
+
+    async def author(state: RetryState) -> dict:
+        node_runs.append("author")
+        return {"log": [f"author: {await llm.ainvoke('author')}"]}
+
+    builder = StateGraph(RetryState)
+    builder.add_node("plan", plan)
+    builder.add_node("author", author)
+    builder.add_edge(START, "plan")
+    builder.add_edge("plan", "author")
+    builder.add_edge("author", END)
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+async def _run(
+    graph: CompiledStateGraph[RetryState, None, RetryState, RetryState],
+    handler: _RecordingIOHandler,
+    *,
+    thread_id: str,
+    retry: "RetryPolicy | FreshRetryPolicy[Any, Any] | None" = None,
+) -> RetryState:
+    async with with_handler(handler, NullEventHandler()):
+        return await run_to_completion(
+            graph,
+            {"log": ["<input>"]},
+            thread_id=thread_id,
+            context=None,
+            recursion_limit=25,
+            description="retry test",
+            retry=retry,
+        )
+
+
+# =========================================================================
+# Floor policy: resume-from-checkpoint, propagation, exhaustion
+# =========================================================================
+
+
+async def test_retryable_failures_resume_from_last_checkpoint():
+    node_runs: list[str] = []
+    llm = FlakyLLM([
+        "planned",
+        FakeOverloadedError("529 attempt 1"),
+        FakeOverloadedError("529 attempt 2"),
+        "authored",
+    ])
+    backoffs: list[int] = []
+    handler = _RecordingIOHandler()
+    policy = DefaultRetryPolicy(
+        _retry_on(FakeOverloadedError), backoff=_recording_backoff(backoffs), max_retries=3,
+    )
+
+    result = await _run(_build_graph(llm, node_runs), handler, thread_id="retry-resume", retry=policy)
+
+    assert result["log"] == ["<input>", "plan: planned", "author: authored"]
+    # Resume, not restart: plan's checkpoint survived the failures, so plan ran
+    # exactly once while the failing author task re-ran on each attempt.
+    assert node_runs == ["plan", "author", "author", "author"]
+    assert llm.calls == 4
+    # Backoff consulted once per failed attempt, with that attempt's index.
+    assert backoffs == [0, 1]
+    # Attempts are labeled for the handler.
+    assert handler.descriptions == [
+        "retry test", "retry test (Retry 1)", "retry test (Retry 2)",
+    ]
+
+
+async def test_non_retryable_failure_propagates_without_backoff():
+    node_runs: list[str] = []
+    llm = FlakyLLM(["planned", FakeFatalError("boom")])
+    backoffs: list[int] = []
+    handler = _RecordingIOHandler()
+    policy = DefaultRetryPolicy(
+        _retry_on(FakeOverloadedError), backoff=_recording_backoff(backoffs), max_retries=3,
+    )
+
+    with pytest.raises(FakeFatalError):
+        await _run(_build_graph(llm, node_runs), handler, thread_id="retry-fatal", retry=policy)
+
+    assert node_runs == ["plan", "author"]
+    assert backoffs == []
+
+
+async def test_retry_exhaustion_raises_last_error_without_parting_backoff():
+    node_runs: list[str] = []
+    llm = FlakyLLM([
+        "planned",
+        FakeOverloadedError("529 attempt 1"),
+        FakeOverloadedError("529 attempt 2"),
+    ])
+    backoffs: list[int] = []
+    handler = _RecordingIOHandler()
+    policy = DefaultRetryPolicy(
+        _retry_on(FakeOverloadedError), backoff=_recording_backoff(backoffs), max_retries=2,
+    )
+
+    with pytest.raises(FakeOverloadedError, match="attempt 2"):
+        await _run(_build_graph(llm, node_runs), handler, thread_id="retry-exhausted", retry=policy)
+
+    assert node_runs == ["plan", "author", "author"]
+    # Backoff paid between attempts only — the final failure exits immediately.
+    assert backoffs == [0]
+
+
+# =========================================================================
+# Ambient floor: applies by default, overridable per-run, reaches sub-graphs
+# =========================================================================
+
+
+async def test_ambient_floor_applies_without_explicit_policy():
+    node_runs: list[str] = []
+    llm = FlakyLLM(["planned", FakeOverloadedError("blip"), "authored"])
+    backoffs: list[int] = []
+    handler = _RecordingIOHandler()
+
+    with _ambient_policy(DefaultRetryPolicy(
+        _retry_on(FakeOverloadedError), backoff=_recording_backoff(backoffs), max_retries=3,
+    )):
+        result = await _run(_build_graph(llm, node_runs), handler, thread_id="ambient-floor")
+
+    assert result["log"] == ["<input>", "plan: planned", "author: authored"]
+    assert node_runs == ["plan", "author", "author"]
+    assert backoffs == [0]
+
+
+async def test_explicit_policy_overrides_the_ambient_floor():
+    """A per-run RetryPolicy replaces the ambient floor entirely: the ambient
+    policy would have retried this failure, the override refuses to."""
+    node_runs: list[str] = []
+    llm = FlakyLLM(["planned", FakeOverloadedError("would be retried ambiently")])
+    ambient_backoffs: list[int] = []
+    override_backoffs: list[int] = []
+    handler = _RecordingIOHandler()
+
+    with _ambient_policy(DefaultRetryPolicy(
+        _retry_on(FakeOverloadedError), backoff=_recording_backoff(ambient_backoffs), max_retries=3,
+    )):
+        with pytest.raises(FakeOverloadedError):
+            await _run(
+                _build_graph(llm, node_runs), handler, thread_id="floor-override",
+                retry=DefaultRetryPolicy(
+                    lambda e: False, backoff=_recording_backoff(override_backoffs), max_retries=3,
+                ),
+            )
+
+    assert node_runs == ["plan", "author"]
+    assert ambient_backoffs == []
+    assert override_backoffs == []
+
+
+async def test_nested_subgraph_failures_retry_under_the_ambient_floor():
+    """The capability the sink-wrapper tracking buys: a transient failure
+    inside a NESTED graph run retries from the nested run's own checkpoint,
+    without the failure ever reaching (or re-running) the parent."""
+    child_runs: list[str] = []
+    child_llm = FlakyLLM([FakeOverloadedError("nested blip"), "child works"])
+    backoffs: list[int] = []
+    handler = _RecordingIOHandler()
+
+    async def child_work(state: RetryState) -> dict:
+        child_runs.append("child-work")
+        return {"log": [f"child: {await child_llm.ainvoke('child')}"]}
+
+    child_builder = StateGraph(RetryState)
+    child_builder.add_node("child_work", child_work)
+    child_builder.add_edge(START, "child_work")
+    child_builder.add_edge("child_work", END)
+    child_graph = child_builder.compile(checkpointer=InMemorySaver())
+
+    parent_runs: list[str] = []
+
+    async def delegate(state: RetryState) -> dict:
+        parent_runs.append("delegate")
+        child_state = await run_to_completion(
+            child_graph,
+            {"log": ["<child input>"]},
+            thread_id="nested-child",
+            context=None,
+            recursion_limit=25,
+            description="nested child",
+        )
+        return {"log": [f"delegate got: {child_state['log'][-1]}"]}
+
+    parent_builder = StateGraph(RetryState)
+    parent_builder.add_node("delegate", delegate)
+    parent_builder.add_edge(START, "delegate")
+    parent_builder.add_edge("delegate", END)
+    parent_graph = parent_builder.compile(checkpointer=InMemorySaver())
+
+    with _ambient_policy(DefaultRetryPolicy(
+        _retry_on(FakeOverloadedError), backoff=_recording_backoff(backoffs), max_retries=3,
+    )):
+        async with with_handler(handler, NullEventHandler()):
+            result = await run_to_completion(
+                parent_graph,
+                {"log": ["<input>"]},
+                thread_id="nested-parent",
+                context=None,
+                recursion_limit=25,
+                description="parent",
+            )
+
+    # The nested failure was retried in place: the child node re-ran, the
+    # parent's delegate node ran exactly once, and the result flowed through.
+    assert child_runs == ["child-work", "child-work"]
+    assert parent_runs == ["delegate"]
+    assert backoffs == [0]
+    assert result["log"] == ["<input>", "delegate got: child: child works"]
+    # The retry was labeled on the nested run, not the parent.
+    assert "nested child (Retry 1)" in handler.descriptions
+    assert "parent (Retry 1)" not in handler.descriptions
+
+
+async def test_exhausted_subagent_escalates_to_parent_and_respawns_fresh():
+    """The state-backoff ladder, end to end. Spawn 1's inner floor retries
+    resume the sub-agent's own checkpoint (level 1); once exhausted, the
+    failure bubbles into the parent's floor retry (level 2), which resumes
+    the PARENT's checkpoint and re-enters the spawning node — respawning the
+    sub-agent under a fresh thread id with pristine state. Each level rolls
+    back strictly more state."""
+    act_llm = FlakyLLM([
+        FakeOverloadedError("spawn 1, act attempt 1"),
+        FakeOverloadedError("spawn 1, act attempt 2"),
+        FakeOverloadedError("spawn 2, act attempt 1"),
+        "acted",
+    ])
+    child_runs: list[str] = []
+    gather_views: list[tuple[str, ...]] = []
+
+    async def gather(state: RetryState) -> dict:
+        child_runs.append("gather")
+        gather_views.append(tuple(state["log"]))
+        return {"log": ["gathered"]}
+
+    async def act(state: RetryState) -> dict:
+        child_runs.append("act")
+        return {"log": [f"act: {await act_llm.ainvoke('act')}"]}
+
+    child_builder = StateGraph(RetryState)
+    child_builder.add_node("gather", gather)
+    child_builder.add_node("act", act)
+    child_builder.add_edge(START, "gather")
+    child_builder.add_edge("gather", "act")
+    child_builder.add_edge("act", END)
+    child_graph = child_builder.compile(checkpointer=InMemorySaver())
+
+    parent_runs: list[str] = []
+    spawned_tids: list[str] = []
+
+    async def plan(state: RetryState) -> dict:
+        parent_runs.append("plan")
+        return {"log": ["planned"]}
+
+    async def delegate(state: RetryState) -> dict:
+        parent_runs.append("delegate")
+        # Mirrors how tool bodies spawn sub-agents: a unique thread id per
+        # spawn, so a parent-level retry starts the sub-agent over instead of
+        # resuming the exhausted spawn's conversation.
+        tid = f"ladder-child-{uuid.uuid4().hex}"
+        spawned_tids.append(tid)
+        child_state = await run_to_completion(
+            child_graph,
+            {"log": ["<child input>"]},
+            thread_id=tid,
+            context=None,
+            recursion_limit=25,
+            description="child work",
+        )
+        return {"log": [f"delegate got: {child_state['log'][-1]}"]}
+
+    parent_builder = StateGraph(RetryState)
+    parent_builder.add_node("plan", plan)
+    parent_builder.add_node("delegate", delegate)
+    parent_builder.add_edge(START, "plan")
+    parent_builder.add_edge("plan", "delegate")
+    parent_builder.add_edge("delegate", END)
+    parent_graph = parent_builder.compile(checkpointer=InMemorySaver())
+
+    backoffs: list[int] = []
+    handler = _RecordingIOHandler()
+    with _ambient_policy(DefaultRetryPolicy(
+        _retry_on(FakeOverloadedError), backoff=_recording_backoff(backoffs), max_retries=2,
+    )):
+        async with with_handler(handler, NullEventHandler()):
+            result = await run_to_completion(
+                parent_graph,
+                {"log": ["<input>"]},
+                thread_id="ladder-parent",
+                context=None,
+                recursion_limit=25,
+                description="parent ladder",
+            )
+
+    # Level 1 (within a spawn): inner retries RESUME — act re-ran without
+    # gather re-running. Level 2 (across spawns): the respawn is FRESH —
+    # gather ran again.
+    assert child_runs == ["gather", "act", "act", "gather", "act", "act"]
+    # The parent resumed from its checkpoint: plan ran once, delegate re-ran.
+    assert parent_runs == ["plan", "delegate", "delegate"]
+    # Two distinct spawns...
+    assert len(spawned_tids) == 2 and spawned_tids[0] != spawned_tids[1]
+    # ...and both saw pristine state: no trace of the sibling spawn's history.
+    assert gather_views == [("<child input>",), ("<child input>",)]
+    # One backoff per failure that had a next attempt: spawn 1's inner retry,
+    # the parent's retry, spawn 2's inner retry — spawn 1's exhausting second
+    # failure paid none.
+    assert backoffs == [0, 0, 0]
+    assert result["log"] == ["<input>", "planned", "delegate got: act: acted"]
+    # The exhausted spawn's thread is abandoned mid-flight; the fresh spawn's
+    # completed — "backing off the state".
+    spawn1 = (await child_graph.aget_state({"configurable": {"thread_id": spawned_tids[0]}})).values
+    spawn2 = (await child_graph.aget_state({"configurable": {"thread_id": spawned_tids[1]}})).values
+    assert spawn1["log"] == ["<child input>", "gathered"]
+    assert spawn2["log"] == ["<child input>", "gathered", "act: acted"]
+    # Each level labels its own attempts.
+    assert handler.descriptions == [
+        "parent ladder",
+        "child work", "child work (Retry 1)",
+        "parent ladder (Retry 1)",
+        "child work", "child work (Retry 1)",
+    ]
+
+
+# =========================================================================
+# Fresh-start escalation
+# =========================================================================
+
+
+class _RecordingFreshPolicy(FreshRetryPolicy[Any, Any]):
+    """Fresh-only escalation — deliberately NOT a RetryPolicy, so the floor
+    (if any) comes from the ambient installation."""
+
+    max_fresh_retries = 2
+
+    def __init__(self, next_thread_id: str):
+        self._next_thread_id = next_thread_id
+        self.rebuilds: list[tuple[Any, Any]] = []
+
+    @override
+    def should_retry_fresh(self, exc: Exception) -> bool:
+        return isinstance(exc, FakeCorruptedError)
+
+    @override
+    async def rebuild_input(self, last_state: Any, last_input: Any) -> tuple[Any, str]:
+        self.rebuilds.append((last_state, last_input))
+        return ({"log": ["<fresh input>"]}, self._next_thread_id)
+
+
+async def test_fresh_start_rebuilds_input_on_a_fresh_thread():
+    node_runs: list[str] = []
+    llm = FlakyLLM([
+        "planned v1",
+        FakeCorruptedError("thread is wedged"),
+        "planned v2",
+        "authored v2",
+    ])
+    handler = _RecordingIOHandler()
+    policy = _RecordingFreshPolicy(next_thread_id="retry-fresh-2")
+
+    result = await _run(_build_graph(llm, node_runs), handler, thread_id="retry-fresh-1", retry=policy)
+
+    # The fresh attempt ran on the rebuilt input, and attempt 1's state did NOT
+    # leak into it: a fresh thread id is a genuinely fresh history.
+    assert result["log"] == ["<fresh input>", "plan: planned v2", "author: authored v2"]
+    # Restart, not resume: the whole graph re-ran on the fresh thread.
+    assert node_runs == ["plan", "author", "plan", "author"]
+    # rebuild_input saw the crashed attempt's checkpointed state (plan's work)
+    # and the input that attempt ran with.
+    assert len(policy.rebuilds) == 1
+    (last_state, last_input) = policy.rebuilds[0]
+    assert last_state["log"] == ["<input>", "plan: planned v1"]
+    assert last_input == {"log": ["<input>"]}
+    assert handler.descriptions == ["retry test", "retry test (Attempt 1)"]
+
+
+async def test_fresh_only_policy_rides_the_ambient_floor():
+    """The decoupling's point: a fresh-only policy gets transient failures
+    handled by the ambient floor AND wedged failures escalated — without
+    restating the floor."""
+    node_runs: list[str] = []
+    llm = FlakyLLM([
+        "planned v1",
+        FakeOverloadedError("transient blip"),
+        FakeCorruptedError("wedged"),
+        "planned v2",
+        "authored v2",
+    ])
+    backoffs: list[int] = []
+    handler = _RecordingIOHandler()
+    policy = _RecordingFreshPolicy(next_thread_id="fresh-floor-2")
+
+    with _ambient_policy(DefaultRetryPolicy(
+        _retry_on(FakeOverloadedError), backoff=_recording_backoff(backoffs), max_retries=3,
+    )):
+        result = await _run(
+            _build_graph(llm, node_runs), handler, thread_id="fresh-floor-1", retry=policy,
+        )
+
+    assert result["log"] == ["<fresh input>", "plan: planned v2", "author: authored v2"]
+    # The transient failure was floor-retried in place (author re-ran); the
+    # wedged failure escalated to a fresh start (whole graph re-ran).
+    assert node_runs == ["plan", "author", "author", "plan", "author"]
+    assert backoffs == [0]
+    assert len(policy.rebuilds) == 1
+
+
+async def test_fresh_start_exhaustion_raises_without_final_rebuild():
+    node_runs: list[str] = []
+    llm = FlakyLLM([
+        "planned v1",
+        FakeCorruptedError("wedged, first time"),
+        "planned v2",
+        FakeCorruptedError("wedged, second time"),
+    ])
+    handler = _RecordingIOHandler()
+    policy = _RecordingFreshPolicy(next_thread_id="fresh-exhausted-2")
+    assert policy.max_fresh_retries == 2
+
+    with pytest.raises(FakeCorruptedError, match="second time"):
+        await _run(_build_graph(llm, node_runs), handler, thread_id="fresh-exhausted-1", retry=policy)
+
+    assert node_runs == ["plan", "author", "plan", "author"]
+    # Rebuilt once, between the attempts — the final failure propagates
+    # without a pointless rebuild of an input that would never run.
+    assert len(policy.rebuilds) == 1


### PR DESCRIPTION
## Retry policies

Retries happen at 2 levels:

* Transient, _provider_ level errors. When these occur a retry policy will wait (with exponential backoff) and then try resuming the graph from exactly the last point at execution.
* "Wedged", "bad state" errors. These indicate the graph state is likely corrupted. When this occurs; the "fresh start" policy rebuilds a fresh input from the most recent state, mints a new thread id, and then kicks off again.

These policies are independent; you can have one but not the other or both at the same time. When both retry policies are installed, the transient provider exception catching is nested within the "bad state" error handler. In practice, this shouldn't matter as they are *intended* to catch different errors. 

Further, "transient error" retry can be (and usually is) applied to every graph execution in a run of the application. The "retry bad state" handler is, necessarily, graph specific, as it involves reconstructing an input state I from the last run S.

## Retry Policy and Subagents

If there is a global, run wide retry policy installed, a subagent spawned from within a tool node will first exhaust its retry policy. Once its retries are exhausted, it will bubble that exception up to the parent graph via its `ToolNode`. The provider level exception (propagated from the subgraph) will then hit the parent graph's retry policy. At this point, the parent graph will be retried from *its* most recent checkpoint; which is the tool node that spawns the subgraph. Importantly, (by convention) subagents are spawned with fresh thread ids each time, so latest attempt at the subagent will itself start with a fresh state. NB this can have a multiplicative effect on backoffs if it turns out we are spending 2 hours retrying runs that are lost causes we can revisit.

## Policy installation

As stated above, the transient retry policy is "run global", and is intended to be installed during app startup. The infrastructure is resilient to it not existing, without the context var set, all runs of the graph run without a retry policy.

Individual graph runs can, optionally, install their own transient retry handler or their own "bad state", fresh retry handler, or both. It is strongly expected that only a handful of "critical" agents will opt into the fresh retry handling, and no one will ever override the run global retry policy.

No one currently uses the state restart functionality but it is tested.