### PR TITLE
Make the Rust toolchain a documented prerequisite, and stop uv racing rustup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,12 @@ loose). Both flags matter:
   every non-default group the two commands above need, `ci` (pyright) included, or the sync
   that fixes one of them breaks the other:
   `uv sync --group test --group ci --group ragbuild --extra cpu --extra certora-cli`.
+- **The Rust toolchain.** That sync's default `dev` group builds the maturin crates under
+  `rust/`, so it needs cargo. If the toolchain `rust-toolchain.toml` pins is not installed
+  yet, install it first and on its own — `rustup toolchain install --no-self-update`, no
+  argument, so rustup reads the channel, profile and components from that file. uv builds
+  those crates concurrently and rustup's on-demand install is not concurrency-safe, so
+  letting the build trigger it races.
 
 ## Python
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,24 @@ The rest of this document covers the **host `uv` flow** for development.
 You need everything from the [AIComposer infrastructure setup](AICOMPOSER_INFRA.md):
 
 - Python 3.12+, `uv`, Docker with compose
+- `rustup` — a default `uv sync` builds the `rust/` crates (see below)
 - `ANTHROPIC_API_KEY` in your environment
 - PostgreSQL databases running (see below)
 - RAG database populated
 - Solidity compiler(s) on `$PATH` (naming convention `solcX.Y`, e.g. `solc8.29`)
+
+### Rust toolchain
+
+A `uv sync`, or any `uv run`, which revalidates path dependencies, builds the maturin crates under `rust/`. Without a
+toolchain the sync fails outright rather than skipping. Install [rustup](https://rustup.rs) (a distro `cargo` package is
+not enough: `rust-toolchain.toml` pins the toolchain and rustup is what reads it), then once, from the repo root:
+
+```bash
+rustup toolchain install --no-self-update
+```
+
+Not working on the Rust side? `uv sync --no-dev` skips the crates entirely — the Rust tests then skip themselves instead
+of failing, and the CI pyright job runs this way.
 
 ### Certora Prover
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ not enough: `rust-toolchain.toml` pins the toolchain and rustup is what reads it
 rustup toolchain install --no-self-update
 ```
 
+Re-run that after any bump to `rust-toolchain.toml`'s `channel` — rustup would otherwise install the new toolchain from
+inside the build, where the concurrent cargo calls a sync makes race each other and one dies mid-download.
+
 Not working on the Rust side? `uv sync --no-dev` skips the crates entirely — the Rust tests then skip themselves instead
 of failing, and the CI pyright job runs this way.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,15 @@ apps = [
 ]
 
 [tool.uv]
+# The `apps` group builds several maturin crates. On a machine that does not have the
+# pinned toolchain yet, each one's cargo call asks rustup to install it, and rustup's
+# install path is not safe against concurrent invocations — whichever call wins clears
+# $RUSTUP_HOME/downloads and the others die renaming a half-downloaded component.
+# Costs next to nothing: the crates share one cargo workspace, so their builds already
+# serialize on rust/target's build-dir lock. This only covers builds uv itself drives;
+# installing the toolchain first (see README) also covers rust-analyzer and a second
+# terminal.
+concurrent-builds = 1
 conflicts = [
     [{ extra = "cpu" }, { extra = "cuda" }],
     [


### PR DESCRIPTION
## The failure

```
× Failed to build `run-confined @ .../rust/run-confined`
  ╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)
      info: syncing channel updates for '1.96-x86_64-unknown-linux-gnu'
      error: component download failed for cargo-x86_64-unknown-linux-gnu: could not rename
      downloaded file from '.../downloads/ecc53a3c….partial' to '.../downloads/ecc53a3c…':
      No such file or directory (os error 2)
```

Nothing in that message names the actual cause. `dev` is one of uv's default groups and pulls in `apps`, so a plain `uv sync` — or any `uv run`, which revalidates path dependencies — builds the maturin crates under `rust/`. On a machine that doesn't yet have the toolchain `rust-toolchain.toml` pins, each crate's cargo call asks rustup to install it, and rustup's install path is not safe against concurrent invocations: whichever call wins clears `$RUSTUP_HOME/downloads` and the others die renaming a half-downloaded component.

CI already installs the toolchain in a step of its own for exactly this reason (`.github/workflows/pytest.yml`). Nothing carried that over to dev machines.

## What's here

**`README.md`** — `rustup` joins the Prerequisites list, with a section giving the argless `rustup toolchain install --no-self-update` (it takes channel, profile and components from `rust-toolchain.toml`, so the pin stays in one place), the note that a distro `cargo` package is not enough, and the `--no-dev` escape hatch for anyone not working on the Rust side.

**`CLAUDE.md`** — the same, on the pre-validation pass, since the sync recipe there is the command that trips this.

**`pyproject.toml`** — `concurrent-builds = 1` under `[tool.uv]`, closing the uv-driven half of the race for whoever skips the docs.

The docs matter more than the setting: fixing machine state covers *every* concurrent cargo caller, whereas `concurrent-builds` only covers builds uv itself drives. rust-analyzer running `cargo metadata` on the workspace the moment the repo opens in an editor races identically, and no uv setting reaches it.

## Measured, not assumed

Max crates building at once, on master's two maturin crates:

| configuration | concurrent builds |
|---|---|
| no key, no env (uv default) | 2 |
| `[tool.uv] concurrent-builds = 1` | 1 |
| `UV_CONCURRENT_BUILDS=1` | 1 |
| `UV_CONCURRENT_BUILDS=8` | 2 |

So the config key genuinely applies rather than merely parsing, and the env var overrides it. Serializing costs next to nothing here: the crates share one cargo workspace, so their builds already contend on `rust/target`'s build-dir lock.

## Verification

- `pytest -m "not expensive"` — **956 passed, 12 deselected**
- `pyright` — **0 errors**

## Note for reviewers

This bites whenever the pinned toolchain is *missing*, not only on a fresh checkout — so the next bump to `rust-toolchain.toml`'s `channel` re-arms it for the whole team at once. That's the case worth keeping in mind if this text gets edited down further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)