### PR TITLE
autosetup: try the optimizer under legacy codegen before reaching for via-ir

### DIFF
--- a/certora_autosetup/setup/setup_prover.py
+++ b/certora_autosetup/setup/setup_prover.py
@@ -650,6 +650,7 @@ class SetupProver:
             solc_default_version=self.solc_default_version,
             verbose=self.verbose,
             build_config_dir=self.build_config_dir,
+            declared_via_ir=bool(getattr(self.build_system_config, "via_ir", False)),
         )
 
         return workaround_manager.run_compilation_with_workarounds(

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -32,6 +32,15 @@ from certora_autosetup.utils.solc_version_resolver import (
 )
 from certora_autosetup.utils.types import ContractHandle
 
+# Solc's legacy-codegen stack-too-deep, as opposed to the YulException the via-ir pipeline
+# raises. Matched against whitespace-normalized output, since solc hard-wraps diagnostics.
+_STACK_TOO_DEEP_RE = re.compile(r"CompilerError:\s*Stack too deep", re.IGNORECASE)
+
+# How many contracts may be given via-ir one at a time before the rest of the scene is
+# switched with them. Each individual escalation costs one full compile of the scene to
+# discover, so this bounds the walk; below it, contracts keep their summaries.
+VIA_IR_SCENE_THRESHOLD = 10
+
 
 class AbstractMainContractError(Exception):
     """Raised when the main (verify-target) contract compiled to no bytecode — it is
@@ -141,6 +150,7 @@ class CompilationWorkaroundManager:
         verbose: int = 0,
         solc_convention: SolcConvention = SolcConvention.CERTORA,
         build_config_dir: Optional[Path] = None,
+        declared_via_ir: bool = False,
     ):
         self.project_root = project_root
         # Where foundry.toml / remappings.txt / package.json are read from. Distinct from
@@ -163,6 +173,13 @@ class CompilationWorkaroundManager:
         # to the scalar on finalize — an unseeded partial map (e.g. a single cancun
         # entry) must never be promoted to a global scalar.
         self._evm_version_seeded = False
+        # Contracts given via-ir one at a time, for the scene-wide threshold in
+        # _apply_via_ir_workaround.
+        self._via_ir_contracts: Set[str] = set()
+        # What the project's own build config asks for. The value is never inherited into
+        # the conf (build_systems/base.py drops it deliberately), but it does say where a
+        # via-ir escalation is going to end up, so the walk can be skipped.
+        self.declared_via_ir = declared_via_ir
         # Convert default version to the detected convention
         if solc_convention == SolcConvention.SOLC_SELECT and solc_default_version.startswith("solc") \
                 and not solc_default_version.startswith("solc-"):
@@ -409,9 +426,52 @@ class CompilationWorkaroundManager:
                 # contract's entry from its pragma is always safe.
                 enabled=True,
             ),
+            # solc's own advice on a legacy stack-too-deep is to compile via-ir "while
+            # enabling the optimizer" — the optimizer is what reclaims stack slots, and it
+            # does so under legacy codegen too. Enabling it alone keeps legacy codegen,
+            # which via-ir would replace: via-ir inlines internal functions and with them
+            # the internal summaries CVL applies, so it is the more expensive answer.
+            CompilationWorkaround(
+                name="stack_too_deep_optimizer",
+                detect_fn=lambda output: (
+                    "detected"
+                    if self._detect_stack_too_deep_errors(output, contracts) is not None
+                    and self._yul_optimizer_pending(compilation_config, contracts)
+                    else None
+                ),
+                apply_fn=self._apply_optimizer,
+                enabled=not global_via_ir_enabled,
+            ),
+            # The optimizer can clear the contract compile and still leave the
+            # autofinder-instrumented one over the stack limit, since instrumentation adds
+            # slots of its own. Accepting the fallback costs local-variable finders in the
+            # files that fall back; via-ir would cost internal summaries in every file it is
+            # enabled for, so this comes first. Only fires on output produced after the
+            # optimizer was tried, not in the pass that just enabled it.
+            CompilationWorkaround(
+                name="stack_too_deep_autofinder",
+                detect_fn=lambda output: (
+                    "detected"
+                    if self._autofinder_relaxation_pending(output, compilation_config)
+                    and not self._yul_optimizer_pending(compilation_config, contracts)
+                    and "stack_too_deep_optimizer" not in applied_this_pass
+                    else None
+                ),
+                apply_fn=self._apply_yul_exception_workaround,
+                enabled=not global_via_ir_enabled,
+            ),
+            # Last of the legacy rungs: only once the optimizer is on and the autofinder
+            # assertion is no longer what is failing the run.
             CompilationWorkaround(
                 name="stack_too_deep_via_ir",
-                detect_fn=lambda output: self._detect_stack_too_deep_errors(output, contracts),
+                detect_fn=lambda output: (
+                    self._detect_stack_too_deep_errors(output, contracts)
+                    if not self._yul_optimizer_pending(compilation_config, contracts)
+                    and not self._autofinder_relaxation_pending(output, compilation_config)
+                    and "stack_too_deep_optimizer" not in applied_this_pass
+                    and "stack_too_deep_autofinder" not in applied_this_pass
+                    else None
+                ),
                 apply_fn=self._apply_via_ir_workaround_to_config,
                 enabled=not global_via_ir_enabled,
             ),
@@ -460,7 +520,7 @@ class CompilationWorkaroundManager:
                     and self._yul_optimizer_pending(compilation_config, contracts)
                     else None
                 ),
-                apply_fn=self._apply_optimizer_for_via_ir,
+                apply_fn=self._apply_optimizer,
                 enabled=True,
             ),
             # Escalation after yul_exception_add_optimizer: with optimizer +
@@ -688,6 +748,24 @@ class CompilationWorkaroundManager:
     # =========================================================================
     # Detection methods
     # =========================================================================
+
+    def _autofinder_relaxation_pending(self, output: str, compilation_config: Dict) -> bool:
+        """True when the run is failing on the autofinder-instrumented compile and the
+        assertion that turns that into a failure is still on.
+
+        certoraRun compiles each file twice: once as written, once instrumented to expose
+        internal functions and local variables. The instrumented copy carries extra stack
+        slots, so it can be the only one over the limit — the contracts themselves compile.
+        Relaxing the assertion accepts a finder-less fallback for those files while leaving
+        codegen alone.
+        """
+        if not compilation_config.get("assert_autofinder_success", False):
+            return False
+        normalized = re.sub(r"\s+", " ", output)
+        return (
+            "Encountered an exception generating autofinder" in normalized
+            and bool(_STACK_TOO_DEEP_RE.search(normalized))
+        )
 
     def _detect_stack_too_deep_errors(
         self, output: str, contracts: List[ContractHandle]
@@ -1191,7 +1269,7 @@ class CompilationWorkaroundManager:
             self._optimizer_off(optimize_map.get(c.contract_name)) for c in contracts
         )
 
-    def _apply_optimizer_for_via_ir(
+    def _apply_optimizer(
         self,
         _detect_result: str,
         updated_config_dict: Dict,
@@ -1199,7 +1277,10 @@ class CompilationWorkaroundManager:
         config_file: Path,
         contracts: List[ContractHandle],
     ) -> Dict:
-        """Apply optimizer alongside via-ir to resolve YulException stack-too-deep.
+        """Enable the optimizer to resolve a stack-too-deep, under either codegen pipeline.
+
+        Reached from the legacy rung (CompilerError: Stack too deep) and from the Yul rung
+        (YulException), because the optimizer's stack-limit evader is what relieves both.
 
         With a per-contract solc_optimize_map (foundry compilation_restrictions)
         only the entries whose optimizer is off are enabled — explicit project
@@ -1216,13 +1297,13 @@ class CompilationWorkaroundManager:
                 optimize_map[name] = "200"
             updated_config_dict["solc_optimize_map"] = optimize_map
             self.log(
-                "Detected YulException stack-too-deep with via-ir — enabling the "
-                f"optimizer (200 runs) in solc_optimize_map for {enabled}",
+                "Stack-too-deep — enabling the optimizer (200 runs) in "
+                f"solc_optimize_map for {enabled}",
                 "WARNING",
             )
         else:
             self.log(
-                "Detected YulException stack-too-deep with via-ir — adding solc_optimize 200",
+                "Stack-too-deep — adding solc_optimize 200",
                 "WARNING",
             )
             compilation_config["solc_optimize"] = "200"
@@ -1620,11 +1701,37 @@ class CompilationWorkaroundManager:
         return True
 
     def _apply_via_ir_workaround(self, contract_needing_via_ir: str, config_dict: Dict) -> Dict:
-        """Add solc_via_ir_map entry for contract that needs via-ir compilation."""
-        # solc_via_ir_map is seeded up front by _seed_compile_maps; just set the
-        # contract that needs via-ir to True.
+        """Enable via-ir for the contract that needs it — or, past the point where naming
+        them one at a time pays off, for the whole scene.
+
+        Per contract is the better answer while the count is small: every contract left on
+        legacy codegen keeps the internal-function summaries via-ir would inline away. But
+        each one costs a full compile of the scene to discover, so a project that needs it
+        widely spends dozens of compiles walking there. Past VIA_IR_SCENE_THRESHOLD the
+        finder loss is already broad and the rest of the scene is likely to follow, so the
+        remaining contracts are switched in one step. A project whose build config declares
+        via-ir skips the walk entirely — it has told us where this ends.
+        """
+        # solc_via_ir_map is seeded up front by _seed_compile_maps.
+        self._via_ir_contracts.add(contract_needing_via_ir)
         config_dict["solc_via_ir_map"][contract_needing_via_ir] = True
-        self.log(f"Adding via-ir workaround for contract: {contract_needing_via_ir}")
+
+        scene_wide = self.declared_via_ir or len(self._via_ir_contracts) >= VIA_IR_SCENE_THRESHOLD
+        if scene_wide and not all(config_dict["solc_via_ir_map"].values()):
+            for name in config_dict["solc_via_ir_map"]:
+                config_dict["solc_via_ir_map"][name] = True
+            reason = (
+                "the build config declares via-ir"
+                if self.declared_via_ir
+                else f"{len(self._via_ir_contracts)} contracts have needed it individually"
+            )
+            self.log(
+                f"Enabling via-ir for the whole scene ({reason}); the remaining contracts "
+                f"lose their internal-function summaries too",
+                "WARNING",
+            )
+        else:
+            self.log(f"Adding via-ir workaround for contract: {contract_needing_via_ir}")
 
         return config_dict
 

--- a/certora_autosetup/utils/compilation_workarounds.py
+++ b/certora_autosetup/utils/compilation_workarounds.py
@@ -427,10 +427,12 @@ class CompilationWorkaroundManager:
                 enabled=True,
             ),
             # solc's own advice on a legacy stack-too-deep is to compile via-ir "while
-            # enabling the optimizer" — the optimizer is what reclaims stack slots, and it
-            # does so under legacy codegen too. Enabling it alone keeps legacy codegen,
-            # which via-ir would replace: via-ir inlines internal functions and with them
-            # the internal summaries CVL applies, so it is the more expensive answer.
+            # enabling the optimizer". The optimizer is what reclaims stack slots, and it
+            # does so under legacy codegen too. Enabling it alone leaves codegen as it is,
+            # where via-ir replaces it: via-ir inlines internal functions, which can leave
+            # the internal summaries CVL applies with nothing to attach to. It does not
+            # always cost them, but it is a risk worth not taking when the optimizer alone
+            # may do.
             CompilationWorkaround(
                 name="stack_too_deep_optimizer",
                 detect_fn=lambda output: (
@@ -444,10 +446,12 @@ class CompilationWorkaroundManager:
             ),
             # The optimizer can clear the contract compile and still leave the
             # autofinder-instrumented one over the stack limit, since instrumentation adds
-            # slots of its own. Accepting the fallback costs local-variable finders in the
-            # files that fall back; via-ir would cost internal summaries in every file it is
-            # enabled for, so this comes first. Only fires on output produced after the
-            # optimizer was tried, not in the pass that just enabled it.
+            # slots of its own. Falling back puts the local-variable finders for those files
+            # at risk; via-ir puts the internal summaries at risk in every file it is enabled
+            # for. Neither loss is certain — a file can fall back and still give useful
+            # finders, and an inlined contract can still be summarized — but the second
+            # exposure is the wider one, so this rung comes first. Only fires on output
+            # produced after the optimizer was tried, not in the pass that just enabled it.
             CompilationWorkaround(
                 name="stack_too_deep_autofinder",
                 detect_fn=lambda output: (
@@ -1705,10 +1709,10 @@ class CompilationWorkaroundManager:
         them one at a time pays off, for the whole scene.
 
         Per contract is the better answer while the count is small: every contract left on
-        legacy codegen keeps the internal-function summaries via-ir would inline away. But
+        legacy codegen keeps the internal-function summaries via-ir might inline away. But
         each one costs a full compile of the scene to discover, so a project that needs it
         widely spends dozens of compiles walking there. Past VIA_IR_SCENE_THRESHOLD the
-        finder loss is already broad and the rest of the scene is likely to follow, so the
+        exposure is already broad and the rest of the scene is likely to follow, so the
         remaining contracts are switched in one step. A project whose build config declares
         via-ir skips the walk entirely — it has told us where this ends.
         """

--- a/tests/test_compilation_workarounds.py
+++ b/tests/test_compilation_workarounds.py
@@ -7,6 +7,7 @@ import pytest
 
 import certora_autosetup.utils.remappings as remappings_mod
 from certora_autosetup.utils.compilation_workarounds import (
+    VIA_IR_SCENE_THRESHOLD,
     CompilationWorkaroundManager,
     UnimplementedContractError,
 )
@@ -67,6 +68,12 @@ UNRELATED_OUTPUT = (
 @pytest.fixture
 def manager(tmp_path: Path) -> CompilationWorkaroundManager:
     return CompilationWorkaroundManager(project_root=tmp_path)
+
+
+@pytest.fixture
+def manager_declaring_via_ir(tmp_path: Path) -> CompilationWorkaroundManager:
+    """A manager for a project whose own build config declares via_ir."""
+    return CompilationWorkaroundManager(project_root=tmp_path, declared_via_ir=True)
 
 
 def test_detects_wrapped_yul_stack_too_deep(manager: CompilationWorkaroundManager) -> None:
@@ -190,20 +197,21 @@ def test_unnamed_return_warning_fires_once(manager, monkeypatch, tmp_path) -> No
 
 
 def test_noop_pass_exits_without_recompile(manager, monkeypatch, tmp_path) -> None:
-    # Run 1: via-ir applies for Foo. Run 2: the identical stack-too-deep hit
-    # fires again, re-applying is a no-op; the catch-all is suppressed because
-    # a specific workaround applied this pass, and the pass changed nothing ->
-    # exit without recompiling.
+    # Run 1: the optimizer goes on, legacy codegen kept. Run 2: the same stack-too-deep
+    # survives it, so via-ir applies for Foo. Run 3: the identical hit fires again,
+    # re-applying is a no-op; the catch-all is suppressed because a specific workaround
+    # applied this pass, and the pass changed nothing -> exit without recompiling.
     contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
     success, updated, _, fake_run = _run_loop_with_output(
         manager, monkeypatch, tmp_path, PERSISTENT_STACK_TOO_DEEP_OUTPUT, contracts
     )
     assert success is False
+    assert updated["solc_optimize"] == "200"
     # The first application is preserved (uniform one-contract map collapses
     # back to the scalar on exit).
     assert updated["solc_via_ir"] is True
     assert "use_relpaths_for_solc_json" not in updated
-    assert fake_run.calls == 2
+    assert fake_run.calls == 3
 
 
 def test_different_detect_results_keep_workaround_enabled(manager, monkeypatch, tmp_path) -> None:
@@ -218,11 +226,12 @@ def test_different_detect_results_keep_workaround_enabled(manager, monkeypatch, 
         manager,
         monkeypatch,
         tmp_path,
-        [PERSISTENT_STACK_TOO_DEEP_OUTPUT, STACK_TOO_DEEP_BAR_OUTPUT],
+        [PERSISTENT_STACK_TOO_DEEP_OUTPUT, PERSISTENT_STACK_TOO_DEEP_OUTPUT, STACK_TOO_DEEP_BAR_OUTPUT],
         contracts,
     )
     assert success is True
-    assert fake_run.calls == 3
+    # Pass 1 spends the optimizer rung; Foo and Bar then need one via-ir application each.
+    assert fake_run.calls == 4
     # Both contracts got via-ir, so the uniform map collapsed to the scalar on
     # exit. A guard that disabled the workaround after its first application
     # would leave Bar's entry False and the map uncollapsed.
@@ -262,7 +271,9 @@ def test_multiple_workarounds_apply_in_one_pass(manager, monkeypatch, tmp_path) 
     )
     assert success is True
     assert fake_run.calls == 2
-    assert updated["solc_via_ir"] is True
+    # The stack-too-deep half is answered by the optimizer first — via-ir is a later rung.
+    assert updated["solc_optimize"] == "200"
+    assert "solc_via_ir" not in updated
     assert updated["ignore_solidity_warnings"] is True
     assert "use_relpaths_for_solc_json" not in updated
 
@@ -966,3 +977,103 @@ def test_unimplemented_contract_is_terminal(manager, monkeypatch, tmp_path) -> N
     assert "TokenInstance1" in str(excinfo.value)
     assert "certora/harnesses/TokenInstance1.sol" in str(excinfo.value)
     assert fake_run.calls == 1
+
+
+# --- the legacy stack-too-deep ladder: optimizer, then autofinder, then via-ir ----------
+
+AUTOFINDER_STACK_TOO_DEEP_OUTPUT = (
+    "Compiling contracts/Foo.sol to expose internal function information and local variables...\n"
+    "Encountered an exception generating autofinder contracts/Foo.sol (solc8.21 had an error:\n"
+    "CompilerError: Stack too deep. Try compiling with `--via-ir` (cli) or the equivalent\n"
+    "`viaIR: true` (standard JSON) while enabling the optimizer.\n"
+)
+
+
+def test_legacy_stack_too_deep_enables_the_optimizer_before_via_ir(manager, monkeypatch, tmp_path) -> None:
+    # solc's advice on this error names both the pipeline and the optimizer. The optimizer
+    # alone keeps legacy codegen, so it is what the first pass must try.
+    contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    success, updated, config, fake_run = _run_loop(
+        manager, monkeypatch, tmp_path, [PERSISTENT_STACK_TOO_DEEP_OUTPUT], contracts
+    )
+    assert success is True
+    assert fake_run.calls == 2
+    assert updated["solc_optimize"] == "200"
+    assert "solc_via_ir" not in updated and "solc_via_ir_map" not in updated
+
+
+def test_via_ir_follows_when_the_optimizer_did_not_clear_it(manager, monkeypatch, tmp_path) -> None:
+    # Still failing with the optimizer on: via-ir is the next rung, and it stays scoped to
+    # the contract that failed.
+    contracts = [
+        ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol"),
+        ContractHandle(contract_name="Bar", source_file="contracts/Bar.sol"),
+    ]
+    success, updated, _, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [PERSISTENT_STACK_TOO_DEEP_OUTPUT, PERSISTENT_STACK_TOO_DEEP_OUTPUT],
+        contracts,
+    )
+    assert success is True
+    assert fake_run.calls == 3
+    assert updated["solc_optimize"] == "200"
+    assert updated["solc_via_ir_map"] == {"Foo": True, "Bar": False}
+
+
+def test_autofinder_stack_too_deep_relaxes_the_assertion_before_via_ir(manager, monkeypatch, tmp_path) -> None:
+    # The contracts compile; only the instrumented copies are over the limit. Accepting the
+    # finder fallback for those files keeps legacy codegen for every contract.
+    contracts = [ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol")]
+    success, updated, config, fake_run = _run_loop(
+        manager,
+        monkeypatch,
+        tmp_path,
+        [AUTOFINDER_STACK_TOO_DEEP_OUTPUT, AUTOFINDER_STACK_TOO_DEEP_OUTPUT],
+        contracts,
+        extra_config={"assert_autofinder_success": True},
+    )
+    assert success is True
+    assert fake_run.calls == 3
+    assert config["assert_autofinder_success"] is False
+    assert "solc_via_ir" not in updated and "solc_via_ir_map" not in updated
+
+
+def test_via_ir_goes_scene_wide_past_the_threshold(manager, monkeypatch, tmp_path) -> None:
+    # Naming contracts one at a time costs a compile each; past the threshold the rest of
+    # the scene is switched in one step.
+    names = [f"C{i}" for i in range(VIA_IR_SCENE_THRESHOLD + 4)]
+    contracts = [ContractHandle(contract_name=n, source_file=f"contracts/{n}.sol") for n in names]
+    outputs = [
+        f"Compiling contracts/{n}.sol...\nsolc8.21 had an error:\nCompilerError: Stack too deep.\n"
+        for n in names[:VIA_IR_SCENE_THRESHOLD]
+    ]
+    # One extra leading failure for the optimizer rung to consume.
+    success, updated, _, _ = _run_loop(manager, monkeypatch, tmp_path, [outputs[0]] + outputs, contracts)
+
+    assert success is True
+    # Uniform True map collapses to the scalar on exit — every contract is on via-ir.
+    assert updated["solc_via_ir"] is True
+    assert "solc_via_ir_map" not in updated
+
+
+def test_declared_via_ir_skips_the_per_contract_walk(manager_declaring_via_ir, monkeypatch, tmp_path) -> None:
+    # The project's build config already says where this ends; walking there one contract
+    # per compile only costs compiles. The declared value is still not inherited — the
+    # optimizer value emitted is ours.
+    contracts = [
+        ContractHandle(contract_name="Foo", source_file="contracts/Foo.sol"),
+        ContractHandle(contract_name="Bar", source_file="contracts/Bar.sol"),
+    ]
+    success, updated, _, fake_run = _run_loop(
+        manager_declaring_via_ir,
+        monkeypatch,
+        tmp_path,
+        [PERSISTENT_STACK_TOO_DEEP_OUTPUT, PERSISTENT_STACK_TOO_DEEP_OUTPUT],
+        contracts,
+    )
+    assert success is True
+    assert updated["solc_via_ir"] is True
+    assert "solc_via_ir_map" not in updated
+    assert updated["solc_optimize"] == "200"


### PR DESCRIPTION
## What was wrong

Solc's stack-too-deep message names two remedies: compile with `--via-ir` *while enabling the
optimizer*. The ladder acted on the first half only.

`stack_too_deep_via_ir` (`compilation_workarounds.py:385`) answers `CompilerError: Stack too deep` by
switching via-ir on for the failing contract. The optimizer rung sits behind
`_detect_yul_exception_stack_too_deep`, whose regex requires a literal `YulException:` prefix, and
only the via-ir pipeline emits that. So the loop tried legacy, then via-ir with the optimizer, and
never tried legacy with the optimizer.

That matters because via-ir is not a free substitution. It inlines internal functions and takes the
CVL internal summaries with them, which is why `build_systems/base.py:137` refuses to inherit a
project's declared `via_ir` in the first place.

## What changed

Three rungs now precede via-ir on a legacy stack-too-deep:

1. `stack_too_deep_optimizer` enables the optimizer, keeping legacy codegen.
2. `stack_too_deep_autofinder` handles the case where only the autofinder-instrumented compile is
   over the stack limit. The contracts themselves compile; accepting the finder fallback for those
   files costs local-variable finders there and keeps every contract on legacy codegen.
3. `stack_too_deep_via_ir`, as before, per contract, and only once the two above have been tried.

Per-contract via-ir also stops walking a large scene one compile at a time. Past ten contracts, or
when the project's own build config declares via-ir, the remaining contracts are switched together.
The declared value is still never inherited: it only says where the walk ends, and the optimizer
value emitted is ours.

The optimizer apply is shared with the Yul rung rather than duplicated, so Foundry's
`compilation_restrictions` map keeps its explicit runs values and the scalar is never written beside
the map.

## Measurements

Three experiments ran before the code, in the fleet image, compilation analysis only.

| | before | after |
|---|---|---|
| 43-contract project | ladder ends with via-ir on 1 contract, fails | **rc=0 in 7m40s**, `solc_via_ir_map` all False |
| 171-contract project | ladder ends with via-ir on 7 contracts, fails | optimizer then autofinder rung, no via-ir |
| 105-contract project | 18 accretion passes, 60-minute cap, no result | scene-wide via-ir at our own `solc_optimize 200`, rc=0 in 13m32s |

The 43-contract run went through the real ladder end to end, not a hand-built conf: exactly two rungs
fired, `stack_too_deep_optimizer` then `stack_too_deep_autofinder`, and certoraRun reported
`all solc_via_ir_map values are set to False`.

Two findings worth carrying forward:

- Legacy plus optimizer is **not** enough on its own. With `assert_autofinder_success: True`, which is
  what `setup_prover.py:409` emits, both projects still fail: 35 of 171 and 15 of 43 files fall back
  during autofinder instrumentation. That is why rung 2 exists, and it is a real cost, paid instead of
  the larger one of inlining every contract.
- The declared `optimizer_runs` values (10,000,000 and 100,000) make no difference. 200 compiles the
  same scenes, so nothing needs to be inherited from the project.

## Tests

`pytest -m "not expensive"`: 978 passed, 11 skipped. `pyright`: 0 errors.

Five new cases pin the ladder: the optimizer fires first and sets no via-ir; via-ir follows and stays
scoped to the failing contract; the autofinder rung relaxes the assertion without touching codegen;
the scene flips past the threshold; a declared `via_ir` skips the walk. Three existing tests moved by
one compile each, since the ladder now spends a pass on the optimizer before via-ir. Their assertions
were tightened to the new sequence rather than loosened.