### PR TITLE
ci: split the wire round trips out of the `fuzz` marker

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,11 +41,9 @@ jobs:
           java-version: "21"
 
       - name: sync-deps
-        # --no-dev skips the `dev` group and the `apps` group it includes, so this
-        # job never builds the `rust/` wheels and never installs the pinned
-        # toolchain. Anything here that shelled out to cargo would make rustup
-        # fetch that toolchain mid-test — the fuzz step below is scoped to avoid
-        # exactly that. Every `uv run` below needs the flag too: a bare `uv run`
+        # --no-dev skips the `dev` group (and the `apps` group it includes), so this
+        # job doesn't compile the Rust crates — nothing under `expensive` or `fuzz`
+        # touches them. Every `uv run` below needs the flag too: a bare `uv run`
         # re-syncs with the default groups and would pull `apps` back in.
         run: |
           uv sync --group test --extra prover --no-dev
@@ -82,10 +80,6 @@ jobs:
           uv run --no-dev pytest -n 3 -m 'expensive' tests
         env:
           CERTORAKEY: ${{ secrets.CERTORAKEY }}
-      # `fuzz` deliberately excludes the wire round trips, which are marked `wire`:
-      # they build a cargo binary at test time and this job has no Rust toolchain.
-      # pytest.yml runs them, on every push to master, with the toolchain installed
-      # and rust/target cached.
       - name: run template fuzz tests
         run: |
           uv run --no-dev pytest -n 2 -m 'fuzz' tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,9 +41,11 @@ jobs:
           java-version: "21"
 
       - name: sync-deps
-        # --no-dev skips the `dev` group (and the `apps` group it includes), so this
-        # job doesn't compile the Rust crates — nothing under `expensive` or `fuzz`
-        # touches them. Every `uv run` below needs the flag too: a bare `uv run`
+        # --no-dev skips the `dev` group and the `apps` group it includes, so this
+        # job never builds the `rust/` wheels and never installs the pinned
+        # toolchain. Anything here that shelled out to cargo would make rustup
+        # fetch that toolchain mid-test — the fuzz step below is scoped to avoid
+        # exactly that. Every `uv run` below needs the flag too: a bare `uv run`
         # re-syncs with the default groups and would pull `apps` back in.
         run: |
           uv sync --group test --extra prover --no-dev
@@ -80,6 +82,10 @@ jobs:
           uv run --no-dev pytest -n 3 -m 'expensive' tests
         env:
           CERTORAKEY: ${{ secrets.CERTORAKEY }}
+      # `fuzz` deliberately excludes the wire round trips, which are marked `wire`:
+      # they build a cargo binary at test time and this job has no Rust toolchain.
+      # pytest.yml runs them, on every push to master, with the toolchain installed
+      # and rust/target cached.
       - name: run template fuzz tests
         run: |
           uv run --no-dev pytest -n 2 -m 'fuzz' tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,10 +174,6 @@ explicit = true
 markers = [
     "expensive: hits the real prover / network — deselect with -m 'not expensive'",
     "fuzz: fuzz tests",
-    # Kept out of `fuzz` because of what they need, not what they do: these build
-    # `wire-echo` with cargo at test time, so a job that selects them has to install
-    # the pinned Rust toolchain first (rustup's on-demand install races itself under
-    # xdist). A Rust-free job can select plain `fuzz` and stay Rust-free.
     "wire: Rust/Python wire-protocol round trips — build a cargo binary at test time"
 ]
 # optional but recommended once you're registering marks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,12 @@ explicit = true
 [tool.pytest.ini_options]
 markers = [
     "expensive: hits the real prover / network — deselect with -m 'not expensive'",
-    "fuzz: fuzz tests"
+    "fuzz: fuzz tests",
+    # Kept out of `fuzz` because of what they need, not what they do: these build
+    # `wire-echo` with cargo at test time, so a job that selects them has to install
+    # the pinned Rust toolchain first (rustup's on-demand install races itself under
+    # xdist). A Rust-free job can select plain `fuzz` and stay Rust-free.
+    "wire: Rust/Python wire-protocol round trips — build a cargo binary at test time"
 ]
 # optional but recommended once you're registering marks:
 addopts = "--strict-markers"   # a typo'd mark becomes an error, not a silent no-match

--- a/tests/test_wire_roundtrip.py
+++ b/tests/test_wire_roundtrip.py
@@ -38,8 +38,8 @@ because a wire name and a direction are not properties of a class. So two checks
 being silently exercised by nothing.
 
 Everything talks to the ``wire-echo`` binary over one long-lived pipe (see its module docs). The
-round trips are marked ``fuzz``; the field-set and completeness checks are deterministic and always
-run.
+round trips are marked ``wire`` rather than ``fuzz``, since selecting them commits a job to
+building that binary; the field-set and completeness checks are deterministic and always run.
 """
 
 import enum
@@ -366,7 +366,7 @@ _EXAMPLES = 200
 # `deadline=None` throughout: an example spans a subprocess round trip, so per-example timing is
 # noisy enough to trip the default deadline for reasons unrelated to the protocol.
 
-@pytest.mark.fuzz
+@pytest.mark.wire
 @pytest.mark.parametrize("case", OUTBOUND, ids=[c.ty for c in OUTBOUND])
 @settings(deadline=None, max_examples=_EXAMPLES)
 @given(data=st.data())
@@ -380,7 +380,7 @@ def test_outbound_payload_survives_the_wheel(
     assert case.adapter.validate_python(echoed) == case.adapter.validate_python(sent)
 
 
-@pytest.mark.fuzz
+@pytest.mark.wire
 @pytest.mark.parametrize("case", INBOUND, ids=[c.ty for c in INBOUND])
 @settings(deadline=None, max_examples=_EXAMPLES)
 @given(entropy=st.binary(min_size=1, max_size=512))


### PR DESCRIPTION
The nightly Integration Tests job died in `run template fuzz tests` the first night the wire
round-trip suite existed — [run 32218703320](https://github.com/Certora/AutoProver/actions/runs/32218703320/job/95964997297),
13 errors, one cause.

**`-m 'fuzz' tests` selects two unrelated suites, and only one of them is Python.** The 36 template
tests the step is named for, and the 13 round trips in `tests/test_wire_roundtrip.py`, whose
`wire_echo` fixture builds `wire-echo` with cargo at test time. The step runs `pytest -n 2` and that
fixture is session-scoped *per xdist worker*, so both workers asked rustup to install the pinned 1.96
toolchain at the same instant. rustup's install path is not safe against concurrent invocations: one
call rolled back (`failed to install component: 'rustc-x86_64-unknown-linux-gnu', detected conflict:
'bin/rust-gdb'`) and the other found what the rollback left behind (`the 'cargo' binary ... is not
applicable to the '1.96-x86_64-unknown-linux-gnu' toolchain`). Not a flake that turned:
`rust-toolchain.toml` and the suite both landed in #97 on 08-18, after that morning's scheduled run,
so this was the first nightly to select them — 29 fuzz tests on 08-18, 49 on 08-19.

**Installing the toolchain first would stop the crash and buy nothing.** That is what `pytest.yml`
does, for exactly this hazard, and it is the wrong answer here: this job would pay an uncached cargo
build inside a 20-minute budget to re-run tests it cannot deepen and does not uniquely cover. They
pin `max_examples=200` in their own `@settings`, so this job's `HYPOTHESIS_PROFILE: extended` never
reaches them — that profile is registered in `test_fuzzed_templates.py` alone. And `pytest.yml`
selects `-m 'not expensive'`, which includes them, on every PR and every push to master, with the
toolchain installed and `rust/target` cached.

So the marker splits by requirement rather than by kind. `wire` says nothing about what those tests
do — they are fuzz tests — only about what selecting them commits a job to: having the pinned Rust
toolchain. A job with no Rust can now ask for `fuzz` and stay that way, which is what this one wants.
The `sync-deps` comment claiming the job "doesn't compile the Rust crates" stopped being true the
moment those tests carried `fuzz`; it now says that no toolchain gets installed, and points at the
step that depends on that.

## Tests

The selector counts are the whole behavioural change:

```
-m 'fuzz'          → 36  test_fuzzed_templates.py   the nightly, Rust-free again
-m 'wire'          → 13  test_wire_roundtrip.py
-m 'not expensive' → 35  test_wire_roundtrip.py     pytest.yml, unchanged
```

`pytest -m wire tests/test_wire_roundtrip.py`: 13 passed. `pytest -m "not expensive"`: 1036 passed,
11 skipped. `pyright`: 0 errors.

Nothing in PR CI exercises the nightly's selector — `pytest.yml` never runs `-m fuzz` — so the first
real proof is the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)