### PR TITLE
Generalize findings to support non-Prover backends

### DIFF
--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -208,13 +208,13 @@ class Formalizer[FormT: BackendResult, U: FeatureUnit](ABC):
     def findings_policy(
         self, outcomes: list[ComponentOutcome[FormT, U]]
     ) -> FindingsPolicy | None:
-        """How this backend writes its violated rules up as findings, or None if it produces none.
+        """How this backend writes violated rules up as findings, or None to produce none.
 
-        Returning None is how a backend opts out — the report then builds no findings for it, with
-        no backend-specific branching in the report layer. Default: None.
+        None is the opt-out: the report then builds no findings and never starts the heavy model.
+        Default: None.
 
-        Takes ``outcomes`` because a backend whose evidence is in its own results has nowhere else
-        to read it from; one whose evidence is a run-scoped store ignores them."""
+        ``outcomes`` is for backends whose evidence lives on the results. A backend that keeps
+        evidence in a run-scoped store can ignore them."""
         return None
 
     async def finalize(self, outcomes: list[ComponentOutcome[FormT, U]], run: PipelineRun) -> None:
@@ -710,7 +710,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                 components=inputs, llm=run.env.llm_lite(), fetch_verdicts=formalizer.fetch_verdicts,
                 source_edits=await formalizer.source_edits(outcomes, run),
                 verification_artifacts=artifact_records,
-                # Findings only when the backend declared a policy — skip the heavy model otherwise.
+                # Findings only when the backend supplies evidence — skip the heavy model otherwise.
                 findings_llm=run.env.llm_heavy() if findings else None,
                 findings=findings,
             )

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -56,7 +56,8 @@ from composer.spec.prop_inference import (
 from composer.llm.types import CacheLevel
 from composer.input.files import Document
 from composer.spec.source.report.build import build_report
-from composer.spec.source.report.collect import ReportComponentInput, Verdict, EvidenceFetcher, Formalized
+from composer.spec.source.report.collect import Formalized, ReportComponentInput, Verdict
+from composer.spec.source.report.findings import FindingsPolicy
 from composer.spec.source.report.schema import (
     AutoProverReport, RuleName, ReportBackend, SourceEditRecord, VerificationArtifactRecord,
 )
@@ -204,10 +205,16 @@ class Formalizer[FormT: BackendResult, U: FeatureUnit](ABC):
         Never called for gave-up or budget-curtailed components."""
         ...
 
-    def findings_evidence(self) -> EvidenceFetcher | None:
-        """The per-rule evidence source for findings synthesis, or None if this backend produces no
-        findings. Returning None is how a backend opts out — the report then builds no findings for
-        it, with no backend-specific branching in the report layer. Default: None."""
+    def findings_policy(
+        self, outcomes: list[ComponentOutcome[FormT, U]]
+    ) -> FindingsPolicy | None:
+        """How this backend writes its violated rules up as findings, or None if it produces none.
+
+        Returning None is how a backend opts out — the report then builds no findings for it, with
+        no backend-specific branching in the report layer. Default: None.
+
+        Takes ``outcomes`` because a backend whose evidence is in its own results has nowhere else
+        to read it from; one whose evidence is a run-scoped store ignores them."""
         return None
 
     async def finalize(self, outcomes: list[ComponentOutcome[FormT, U]], run: PipelineRun) -> None:
@@ -695,7 +702,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
         for o in outcomes
         for pa in o.artifacts
     ]
-    findings_evidence = formalizer.findings_evidence()
+    findings = formalizer.findings_policy(outcomes)
     try:
         async def _report() -> AutoProverReport:
             return await build_report(
@@ -703,10 +710,9 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                 components=inputs, llm=run.env.llm_lite(), fetch_verdicts=formalizer.fetch_verdicts,
                 source_edits=await formalizer.source_edits(outcomes, run),
                 verification_artifacts=artifact_records,
-                # Findings only when the backend supplies evidence — skip the heavy model otherwise.
-                findings_llm=run.env.llm_heavy() if findings_evidence else None,
-                fetch_evidence=findings_evidence,
-
+                # Findings only when the backend declared a policy — skip the heavy model otherwise.
+                findings_llm=run.env.llm_heavy() if findings else None,
+                findings=findings,
             )
         report = await run.runner(
             job=_report,

--- a/composer/rustapp/adapter.py
+++ b/composer/rustapp/adapter.py
@@ -60,6 +60,8 @@ from composer.pipeline.ecosystem import ChainTag, Ecosystem
 from composer.sandbox.command import DEFAULT_TIMEOUT_S
 from composer.sandbox.config import BackendSpec, SandboxConfig
 from composer.rustapp.descriptor import AppDescriptor, PhaseRole, PhaseSpec
+from composer.rustapp.findings import rust_findings
+from composer.spec.source.report.findings import FindingsPolicy
 from composer.rustapp.phases import PhaseModel
 from composer.rustapp.result import RustArtifact, RustFormalResult, RustSetupSpec
 from composer.rustapp.toolchain import project_toolchain, source_unit
@@ -385,6 +387,7 @@ class RustFormalizer(Formalizer[RustFormalResult, FeatureUnit]):
             checks=outcome.property_checks,
             skipped=outcome.skipped,
             verdicts=outcome.verdicts,
+            expected_failures=outcome.expected_failures,
             # What the stamping run actually covered, in the order the host ran it — each target
             # with its checks. A callout-mode wheel keys its deliverable sections on the names, and
             # carrying the checks alongside is what makes "which properties are these results
@@ -396,16 +399,29 @@ class RustFormalizer(Formalizer[RustFormalResult, FeatureUnit]):
     async def fetch_verdicts(
         self, formalized: Formalized[RustFormalResult]
     ) -> dict[RuleName, Verdict]:
+        # Fold in expect_check_failure so a declared check cannot show as a pass, and rejoin the
+        # wheel's two halves: the report has one ``message`` per row, and a green row's whole worth
+        # is the accounting — but the evidence leads, because a BAD row's first line is what a
+        # reader is looking for.
         return {
             name: Verdict(
                 outcome=v.outcome,
                 line=v.line,
                 duration_seconds=v.duration_seconds,
                 unit_file=v.unit_file or formalized.unit_file,
-                message=v.detail,
+                message="\n\n".join(part for part in (v.detail, v.accounting) if part) or None,
             )
-            for name, v in formalized.result.verdicts.items()
+            for name, v in formalized.result.reported_verdicts().items()
         }
+
+    @override
+    def findings_policy(
+        self, outcomes: list[ComponentOutcome[RustFormalResult, FeatureUnit]]
+    ) -> FindingsPolicy | None:
+        # Evidence is in the results themselves — a wheel reports per check, and there is no
+        # run-scoped store beside it holding what it saw. What that evidence *means* is the wheel's
+        # declaration, and a wheel that made none produces no findings.
+        return rust_findings(outcomes, self._descriptor.findings)
 
     @override
     async def finalize(

--- a/composer/rustapp/adapter.py
+++ b/composer/rustapp/adapter.py
@@ -399,28 +399,24 @@ class RustFormalizer(Formalizer[RustFormalResult, FeatureUnit]):
     async def fetch_verdicts(
         self, formalized: Formalized[RustFormalResult]
     ) -> dict[RuleName, Verdict]:
-        # Fold in expect_check_failure so a declared check cannot show as a pass, and rejoin the
-        # wheel's two halves: the report has one ``message`` per row, and a green row's whole worth
-        # is the accounting — but the evidence leads, because a BAD row's first line is what a
-        # reader is looking for.
+        res = formalized.result
         return {
             name: Verdict(
                 outcome=v.outcome,
                 line=v.line,
                 duration_seconds=v.duration_seconds,
                 unit_file=v.unit_file or formalized.unit_file,
-                message="\n\n".join(part for part in (v.detail, v.accounting) if part) or None,
+                message=v.detail,
+                accounting=v.accounting,
+                expected_failure=res.expected_failure(name),
             )
-            for name, v in formalized.result.reported_verdicts().items()
+            for name, v in res.reported_verdicts().items()
         }
 
     @override
     def findings_policy(
         self, outcomes: list[ComponentOutcome[RustFormalResult, FeatureUnit]]
     ) -> FindingsPolicy | None:
-        # Evidence is in the results themselves — a wheel reports per check, and there is no
-        # run-scoped store beside it holding what it saw. What that evidence *means* is the wheel's
-        # declaration, and a wheel that made none produces no findings.
         return rust_findings(outcomes, self._descriptor.findings)
 
     @override

--- a/composer/rustapp/descriptor.py
+++ b/composer/rustapp/descriptor.py
@@ -95,15 +95,13 @@ DeliverableMode = Annotated[PerComponent | Callout, Field(discriminator="mode")]
 
 
 class FindingsDeclaration(WireModel):
-    """How a violated check of this backend becomes a written audit finding.
+    """What this backend's evidence is, so the host can write a violated check up as a finding.
 
-    Declared by the wheel because a write-up rests on claims only the wheel can make: what its
-    evidence *is*, what that evidence establishes, and how to read its own markers. The host owns
-    everything around that — which rows, their properties and groups, the concurrency, grouping the
-    rows that share one finding, composing the record — and none of the prose."""
+    The wheel supplies that claim; the host owns the rest (which rows, properties, groups,
+    grouping, composing)."""
 
-    #: The *domain* half of the write-up system prompt. The host wraps it in the contract (how
-    #: severity is reached, which sections come back), so no wheel restates that.
+    #: Domain half of the write-up system prompt. The host adds how severity is reached and
+    #: which sections come back.
     domain: str
 
 
@@ -227,9 +225,8 @@ class AppDescriptor(WireModel):
     #: rebuttal tool's ``evidence_type`` is built from. Declared per wheel because the evidence a
     #: backend can produce is a property of that backend.
     evidence_kinds: list[str]
-    #: How this backend's violated checks are written up as audit findings — ``None`` produces none,
-    #: and the report carries only the verdict rows. Declining is the default because a write-up has
-    #: to say what the evidence behind it is, and only the wheel knows.
+    #: How violated checks are written up. ``None`` (the default) produces no findings, only
+    #: verdict rows: a write-up has to say what the evidence is, and only the wheel knows.
     findings: FindingsDeclaration | None
 
     def unit_noun(self, *, plural: bool = False) -> str:

--- a/composer/rustapp/descriptor.py
+++ b/composer/rustapp/descriptor.py
@@ -94,6 +94,19 @@ class Callout(WireModel):
 DeliverableMode = Annotated[PerComponent | Callout, Field(discriminator="mode")]
 
 
+class FindingsDeclaration(WireModel):
+    """How a violated check of this backend becomes a written audit finding.
+
+    Declared by the wheel because a write-up rests on claims only the wheel can make: what its
+    evidence *is*, what that evidence establishes, and how to read its own markers. The host owns
+    everything around that — which rows, their properties and groups, the concurrency, grouping the
+    rows that share one finding, composing the record — and none of the prose."""
+
+    #: The *domain* half of the write-up system prompt. The host wraps it in the contract (how
+    #: severity is reached, which sections come back), so no wheel restates that.
+    domain: str
+
+
 class PhaseSpec(WireModel):
     """One task-grouping phase; ``key`` becomes the synthesized enum member name.
 
@@ -214,6 +227,10 @@ class AppDescriptor(WireModel):
     #: rebuttal tool's ``evidence_type`` is built from. Declared per wheel because the evidence a
     #: backend can produce is a property of that backend.
     evidence_kinds: list[str]
+    #: How this backend's violated checks are written up as audit findings — ``None`` produces none,
+    #: and the report carries only the verdict rows. Declining is the default because a write-up has
+    #: to say what the evidence behind it is, and only the wheel knows.
+    findings: FindingsDeclaration | None
 
     def unit_noun(self, *, plural: bool = False) -> str:
         """The noun for a formalized unit, with the generic default applied — so no frontend

--- a/composer/rustapp/findings.py
+++ b/composer/rustapp/findings.py
@@ -1,0 +1,78 @@
+"""Findings synthesis for a Rust wheel's results: where its evidence comes from, and how to ask for
+a write-up of it.
+
+The shared loop is `composer.spec.source.report.findings`, and `RuleEvidence` is its shape. What is
+here is the part that reads a *wheel's* results into it — every field it works from is wire
+(`Verdict.detail`, `Verdict.accounting`, `Verdict.finding`, the result's declared failures), so
+nothing in this module knows what any particular backend checks or what its evidence means.
+
+Those are the wheel's to say, and it says them in `FindingsDeclaration`: the domain half of the
+system prompt (what its evidence *is*), and how severity is reached. A wheel that declares nothing
+produces no findings — see `AppDescriptor.findings`.
+"""
+from typing import TypedDict
+
+from composer.pipeline.ptypes import ComponentOutcome, Delivered
+from composer.rustapp.descriptor import FindingsDeclaration
+from composer.rustapp.result import RustFormalResult
+from composer.spec.gen_types import TypedTemplate
+from composer.spec.source.report.collect import RuleEvidence
+from composer.spec.source.report.findings import FindingsPolicy, FindingsPromptParams
+from composer.spec.source.report.schema import RuleRef
+from composer.spec.system_model import FeatureUnit
+from composer.templates.loader import load_jinja_template
+
+type RustOutcomes = list[ComponentOutcome[RustFormalResult, FeatureUnit]]
+
+
+_WRITE_UP_PROMPT = TypedTemplate[FindingsPromptParams]("autoprove_report_findings_rust_prompt.j2")
+
+
+def observations(outcomes: RustOutcomes) -> dict[RuleRef, RuleEvidence]:
+    """Every delivered check as evidence, keyed as the report keys its rows: ``(file, name)``.
+
+    Rebuilt rather than looked up: ``collect`` uses the verdict's file, falling back to the
+    component artifact, and a callout-mode wheel gives every component that same fallback — so the
+    check name alone does not identify a row.
+
+    First component naming a key wins, as in ``collect``: where two of them do collapse onto one
+    row, the evidence here has to be the same run's as the message there.
+
+    ``analysis`` stays unset — a wheel reports what its run found, not a reading of why the check
+    broke, and a reader must be able to tell the two apart."""
+    observed: dict[RuleRef, RuleEvidence] = {}
+    for o in outcomes:
+        if not isinstance(o.result, Delivered):
+            continue
+        res = o.result.result
+        for check, verdict in res.verdicts.items():
+            ref = (verdict.unit_file or o.result.unit_file, check)
+            observed.setdefault(ref, RuleEvidence(
+                label=o.feat.display_name,
+                counterexample=verdict.detail,
+                ran=verdict.outcome,
+                accounting=verdict.accounting,
+                declared=res.expected_failures.get(check),
+                finding=verdict.finding,
+            ))
+    return observed
+
+
+def rust_findings(
+    outcomes: RustOutcomes, declared: FindingsDeclaration | None,
+) -> FindingsPolicy | None:
+    """This run's findings policy, around the observations its own results carry — or ``None`` for a
+    wheel that declared none, which produces no findings at all."""
+    if declared is None:
+        return None
+    observed = observations(outcomes)
+
+    async def fetch(ref: RuleRef) -> list[RuleEvidence]:
+        found = observed.get(ref)
+        return [found] if found is not None else []
+
+    return FindingsPolicy(
+        fetch_evidence=fetch,
+        domain=declared.domain,
+        prompt=_WRITE_UP_PROMPT,
+    )

--- a/composer/rustapp/findings.py
+++ b/composer/rustapp/findings.py
@@ -1,14 +1,9 @@
-"""Findings synthesis for a Rust wheel's results: where its evidence comes from, and how to ask for
-a write-up of it.
+"""Map a Rust wheel's results onto the shared findings loop.
 
-The shared loop is `composer.spec.source.report.findings`, and `RuleEvidence` is its shape. What is
-here is the part that reads a *wheel's* results into it — every field it works from is wire
-(`Verdict.detail`, `Verdict.accounting`, `Verdict.finding`, the result's declared failures), so
-nothing in this module knows what any particular backend checks or what its evidence means.
-
-Those are the wheel's to say, and it says them in `FindingsDeclaration`: the domain half of the
-system prompt (what its evidence *is*). Severity is the host's. A wheel that declares nothing
-produces no findings — see `AppDescriptor.findings`.
+The loop and `RuleEvidence` live in `composer.spec.source.report.findings`. This module only
+reads wire fields (`Verdict.detail`, `accounting`, `finding_key`, declared failures) into that
+shape. What the evidence means is `FindingsDeclaration.domain`; severity is the host's.
+No declaration, no findings — see `AppDescriptor.findings`.
 """
 from composer.pipeline.ptypes import ComponentOutcome, Delivered
 from composer.rustapp.descriptor import FindingsDeclaration
@@ -28,15 +23,12 @@ _WRITE_UP_PROMPT = TypedTemplate[FindingsPromptParams]("autoprove_report_finding
 def observations(outcomes: RustOutcomes) -> dict[RuleRef, RuleEvidence]:
     """Every delivered check as evidence, keyed as the report keys its rows: ``(file, name)``.
 
-    Rebuilt rather than looked up: ``collect`` uses the verdict's file, falling back to the
-    component artifact, and a callout-mode wheel gives every component that same fallback — so the
-    check name alone does not identify a row.
+    Rebuilt to match ``collect``: the key uses the verdict's file, then the component artifact,
+    and the first component that names a key wins. A check name alone is not enough — one
+    deliverable can hold several components' checks.
 
-    First component naming a key wins, as in ``collect``: where two of them do collapse onto one
-    row, the evidence here has to be the same run's as the message there.
-
-    ``analysis`` stays unset — a wheel reports what its run found, not a reading of why the check
-    broke, and a reader must be able to tell the two apart."""
+    ``analysis`` is left unset. The wheel reports what the run found, not why the check broke.
+    """
     observed: dict[RuleRef, RuleEvidence] = {}
     for o in outcomes:
         if not isinstance(o.result, Delivered):
@@ -49,8 +41,8 @@ def observations(outcomes: RustOutcomes) -> dict[RuleRef, RuleEvidence]:
                 counterexample=verdict.detail,
                 ran=verdict.outcome,
                 accounting=verdict.accounting,
-                declared=res.expected_failures.get(check),
-                finding=verdict.finding,
+                expected_failure_reason=res.expected_failures.get(check),
+                finding_key=verdict.finding_key,
             ))
     return observed
 
@@ -58,8 +50,7 @@ def observations(outcomes: RustOutcomes) -> dict[RuleRef, RuleEvidence]:
 def rust_findings(
     outcomes: RustOutcomes, declared: FindingsDeclaration | None,
 ) -> FindingsPolicy | None:
-    """This run's findings policy, around the observations its own results carry — or ``None`` for a
-    wheel that declared none, which produces no findings at all."""
+    """This run's findings policy from the outcomes, or ``None`` if the wheel declared none."""
     if declared is None:
         return None
     observed = observations(outcomes)

--- a/composer/rustapp/findings.py
+++ b/composer/rustapp/findings.py
@@ -7,11 +7,9 @@ here is the part that reads a *wheel's* results into it — every field it works
 nothing in this module knows what any particular backend checks or what its evidence means.
 
 Those are the wheel's to say, and it says them in `FindingsDeclaration`: the domain half of the
-system prompt (what its evidence *is*), and how severity is reached. A wheel that declares nothing
+system prompt (what its evidence *is*). Severity is the host's. A wheel that declares nothing
 produces no findings — see `AppDescriptor.findings`.
 """
-from typing import TypedDict
-
 from composer.pipeline.ptypes import ComponentOutcome, Delivered
 from composer.rustapp.descriptor import FindingsDeclaration
 from composer.rustapp.result import RustFormalResult
@@ -20,7 +18,6 @@ from composer.spec.source.report.collect import RuleEvidence
 from composer.spec.source.report.findings import FindingsPolicy, FindingsPromptParams
 from composer.spec.source.report.schema import RuleRef
 from composer.spec.system_model import FeatureUnit
-from composer.templates.loader import load_jinja_template
 
 type RustOutcomes = list[ComponentOutcome[RustFormalResult, FeatureUnit]]
 

--- a/composer/rustapp/result.py
+++ b/composer/rustapp/result.py
@@ -19,7 +19,9 @@ from pydantic import BaseModel, Field
 
 from composer.rustapp.wire import Target, Verdict
 from composer.authoring.state import SkippedProperty
-from composer.spec.source.report.schema import Outcome
+from composer.spec.source.report.schema import (
+    ExpectedFailure, Outcome, ReproducedExpectedFailure, UnreproducedExpectedFailure,
+)
 from composer.spec.types import CheckName, PropertyTitle
 
 
@@ -33,20 +35,6 @@ class RustSetupSpec(BaseModel):
     source: str
 
 
-def _declared_finding(ran: Verdict, reason: str) -> Verdict:
-    """Mark ``ran`` as a declared finding, keeping the run's own ``detail``."""
-    if ran.outcome is Outcome.BAD:
-        lead = f"DECLARED EXPECTED TO FAIL — the violation below is the finding: {reason}"
-    else:
-        lead = (
-            f"DECLARED EXPECTED TO FAIL — a violation here is the finding: {reason}\n"
-            f"NOT REPRODUCED: this run reported {ran.outcome.value}, so the finding rests on the "
-            f"author's reading rather than on a counterexample from this run."
-        )
-    body = f"{lead}\n\n{ran.detail}" if ran.detail else lead
-    return ran.model_copy(update={"outcome": Outcome.BAD, "detail": body})
-
-
 class RustFormalResult(BaseModel):
     """A successful Rust formalization. ``checks`` holds the property→check-names
     map as JSON-friendly lists; ``property_checks()`` re-tuples it for the
@@ -58,8 +46,8 @@ class RustFormalResult(BaseModel):
     checks: list[tuple[PropertyTitle, list[CheckName]]] = Field(default_factory=list)
     skipped: list[SkippedProperty] = Field(default_factory=list)
     output_link: str | None = None
-    # Per-check verdicts from the wheel (what the run observed). Empty for run-service-backed
-    # backends (they use fetch_verdicts). Use ``reported_verdicts`` for what to report.
+    # What the run observed, per check. Empty when a run service supplies verdicts later.
+    # Use ``reported_verdicts`` for what to show.
     verdicts: dict[CheckName, Verdict] = Field(default_factory=dict)
     # Checks the author marked expected-to-fail, name -> why. The wheel never sees these.
     expected_failures: dict[CheckName, str] = Field(default_factory=dict)
@@ -79,20 +67,26 @@ class RustFormalResult(BaseModel):
         return [(title, list(names)) for title, names in self.checks]
 
     def reported_verdicts(self) -> dict[CheckName, Verdict]:
-        """Verdicts as the report and console should show them.
-
-        A declared check reports BAD even if this run did not reproduce it, so a
-        documented finding cannot show as a pass. The detail says which case it is:
-        a reproduced finding keeps the counterexample; an unreproduced one says
-        ``NOT REPRODUCED``."""
+        """Verdicts as the console should show them: an expected-to-fail check is BAD
+        even if this run did not hit it. ``detail`` stays what the run reported."""
         return {
             name: (
-                _declared_finding(verdict, self.expected_failures[name])
-                if name in self.expected_failures
+                verdict.model_copy(update={"outcome": Outcome.BAD})
+                if name in self.expected_failures and verdict.outcome is not Outcome.BAD
                 else verdict
             )
             for name, verdict in self.verdicts.items()
         }
+
+    def expected_failure(self, check: CheckName) -> ExpectedFailure | None:
+        """How an ``expect_check_failure`` fared this run, or ``None`` if the check was not marked."""
+        reason = self.expected_failures.get(check)
+        if reason is None:
+            return None
+        ran = self.verdicts[check].outcome
+        if ran is Outcome.BAD:
+            return ReproducedExpectedFailure(reason=reason)
+        return UnreproducedExpectedFailure(reason=reason, ran=ran)
 
     def display_name(self, check: CheckName) -> str:
         """Row name for one check: the property title when it verifies exactly one, else the check name."""

--- a/composer/rustapp/result.py
+++ b/composer/rustapp/result.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 
 from composer.rustapp.wire import Target, Verdict
 from composer.authoring.state import SkippedProperty
+from composer.spec.source.report.schema import Outcome
 from composer.spec.types import CheckName, PropertyTitle
 
 
@@ -32,6 +33,20 @@ class RustSetupSpec(BaseModel):
     source: str
 
 
+def _declared_finding(ran: Verdict, reason: str) -> Verdict:
+    """Mark ``ran`` as a declared finding, keeping the run's own ``detail``."""
+    if ran.outcome is Outcome.BAD:
+        lead = f"DECLARED EXPECTED TO FAIL — the violation below is the finding: {reason}"
+    else:
+        lead = (
+            f"DECLARED EXPECTED TO FAIL — a violation here is the finding: {reason}\n"
+            f"NOT REPRODUCED: this run reported {ran.outcome.value}, so the finding rests on the "
+            f"author's reading rather than on a counterexample from this run."
+        )
+    body = f"{lead}\n\n{ran.detail}" if ran.detail else lead
+    return ran.model_copy(update={"outcome": Outcome.BAD, "detail": body})
+
+
 class RustFormalResult(BaseModel):
     """A successful Rust formalization. ``checks`` holds the property→check-names
     map as JSON-friendly lists; ``property_checks()`` re-tuples it for the
@@ -43,10 +58,11 @@ class RustFormalResult(BaseModel):
     checks: list[tuple[PropertyTitle, list[CheckName]]] = Field(default_factory=list)
     skipped: list[SkippedProperty] = Field(default_factory=list)
     output_link: str | None = None
-    # Per-check verdicts baked in at formalize time by a self-contained backend (check name -> the
-    # wheel's :class:`~composer.rustapp.wire.Verdict`, validated at the seam). Empty for
-    # run-service-backed backends (they use fetch_verdicts).
+    # Per-check verdicts from the wheel (what the run observed). Empty for run-service-backed
+    # backends (they use fetch_verdicts). Use ``reported_verdicts`` for what to report.
     verdicts: dict[CheckName, Verdict] = Field(default_factory=dict)
+    # Checks the author marked expected-to-fail, name -> why. The wheel never sees these.
+    expected_failures: dict[CheckName, str] = Field(default_factory=dict)
     # What the stamping gate run covered: each validation *target* — one invocation of the checker —
     # with the checks it covered, in the order they ran. Several checks may share one target
     # (Crucible puts a component's whole property set in one fuzz target), so this is neither
@@ -61,6 +77,27 @@ class RustFormalResult(BaseModel):
 
     def property_checks(self) -> list[tuple[PropertyTitle, list[CheckName]]]:
         return [(title, list(names)) for title, names in self.checks]
+
+    def reported_verdicts(self) -> dict[CheckName, Verdict]:
+        """Verdicts as the report and console should show them.
+
+        A declared check reports BAD even if this run did not reproduce it, so a
+        documented finding cannot show as a pass. The detail says which case it is:
+        a reproduced finding keeps the counterexample; an unreproduced one says
+        ``NOT REPRODUCED``."""
+        return {
+            name: (
+                _declared_finding(verdict, self.expected_failures[name])
+                if name in self.expected_failures
+                else verdict
+            )
+            for name, verdict in self.verdicts.items()
+        }
+
+    def display_name(self, check: CheckName) -> str:
+        """Row name for one check: the property title when it verifies exactly one, else the check name."""
+        titles = self.check_properties().get(check, [])
+        return titles[0] if len(titles) == 1 else check
 
     def check_properties(self) -> dict[CheckName, list[PropertyTitle]]:
         """``checks`` inverted: check name -> the property titles it verifies. For display, where

--- a/composer/rustapp/results.py
+++ b/composer/rustapp/results.py
@@ -3,9 +3,8 @@
 The canonical results artifact is ``report.json`` (the shared report phase). But — as with the
 CVL and Foundry backends — the console/TUI otherwise surface only a counts block, so a completed
 run reads as "success" with no visible verdicts. This turns the per-check verdicts baked into the
-pipeline result (:attr:`RustFormalResult.verdicts`, published by ``validate``) into a compact
-tally + per-check listing, using the report's own outcome labels so the wording matches the HTML
-report.
+pipeline result (:meth:`RustFormalResult.reported_verdicts`) into a compact tally + listing,
+using the report's own outcome labels so a declared finding reads the same here as in the HTML.
 
 Backend-agnostic: the outcome wording is parametrized by the descriptor's ``backend_tag``, so any
 Rust app whose results carry verdicts gets the same summary.
@@ -19,13 +18,12 @@ from composer.pipeline.core import CorePipelineResult, Delivered
 from composer.rustapp.result import RustFormalResult
 from composer.spec.source.report.render import outcome_glyph, outcome_label
 from composer.spec.source.report.schema import Outcome, ReportBackend
-from composer.spec.types import CheckName, PropertyTitle
 
 # ``RowName``: what a verdict row is called in the console/TUI listing. Phantom-typed like
 # ``CheckName`` / ``PropertyTitle`` / ``ComponentName`` so it is a sibling of all three — the
-# row is whatever :func:`_row_name` (or a component's display name) chose to show, and is never
-# looked up as one of them. Defined here because the row is a display concept of this rollup,
-# not an identity field of the analyzed system.
+# row is whatever :meth:`RustFormalResult.display_name` (or a component's display name) chose
+# to show, and is never looked up as one of them. Defined here because the row is a display
+# concept of this rollup, not an identity field of the analyzed system.
 if TYPE_CHECKING:
     class RowName(str): ...
 else:
@@ -40,9 +38,9 @@ _ORDER = [Outcome.GOOD, Outcome.BAD, Outcome.TIMEOUT, Outcome.ERROR, Outcome.UNK
 class CheckVerdict:
     """One check's outcome: its display name and the neutral ``Outcome``."""
 
-    #: Whatever :func:`_row_name` chose to call the row — a property's title, a check's name,
-    #: or a component's display name. A :class:`RowName` so it belongs to none of those
-    #: namespaces and is never looked up as one of them.
+    #: Whatever :meth:`RustFormalResult.display_name` chose to call the row — a property's
+    #: title, a check's name, or a component's display name. A :class:`RowName` so it belongs
+    #: to none of those namespaces and is never looked up as one of them.
     name: RowName
     outcome: Outcome
 
@@ -68,13 +66,6 @@ class VerdictSummary:
         )
 
 
-def _row_name(check: CheckName, properties: list[PropertyTitle]) -> RowName:
-    """What to call one check's row: the property's own words when it verifies exactly one, and
-    otherwise the check's own name — the only thing that names the row unambiguously when one check
-    discharges several properties (or the author mapped none to it)."""
-    return RowName(properties[0] if len(properties) == 1 else check)
-
-
 def summarize_verdicts(
     result: CorePipelineResult[RustFormalResult], backend_tag: ReportBackend
 ) -> VerdictSummary:
@@ -82,7 +73,7 @@ def summarize_verdicts(
 
     One row per *check*, not per component: a component's gate run bakes a verdict per check it
     covered, and all of them are rows (reading only the first would report one check where five
-    ran). Rows are named by :func:`_row_name`.
+    ran). Rows are named by :meth:`RustFormalResult.display_name`.
 
     Only *delivered* components carry verdicts; give-ups / exceptions are already surfaced in
     ``result.failures`` and skipped here. A delivered component that bakes none at all (a
@@ -96,10 +87,9 @@ def summarize_verdicts(
         if not formalized.verdicts:
             verdicts.append(CheckVerdict(RowName(o.feat.display_name), Outcome.UNKNOWN))
             continue
-        titles = formalized.check_properties()
         verdicts.extend(
-            CheckVerdict(_row_name(name, titles.get(name, [])), baked.outcome)
-            for name, baked in formalized.verdicts.items()
+            CheckVerdict(RowName(formalized.display_name(name)), reported.outcome)
+            for name, reported in formalized.reported_verdicts().items()
         )
     return VerdictSummary(verdicts, backend_tag)
 

--- a/composer/rustapp/results.py
+++ b/composer/rustapp/results.py
@@ -3,8 +3,8 @@
 The canonical results artifact is ``report.json`` (the shared report phase). But — as with the
 CVL and Foundry backends — the console/TUI otherwise surface only a counts block, so a completed
 run reads as "success" with no visible verdicts. This turns the per-check verdicts baked into the
-pipeline result (:meth:`RustFormalResult.reported_verdicts`) into a compact tally + listing,
-using the report's own outcome labels so a declared finding reads the same here as in the HTML.
+pipeline result (`reported_verdicts`) into a compact tally + listing, using the report's
+own outcome labels so a declared finding reads the same here as in the HTML.
 
 Backend-agnostic: the outcome wording is parametrized by the descriptor's ``backend_tag``, so any
 Rust app whose results carry verdicts gets the same summary.

--- a/composer/rustapp/wire.py
+++ b/composer/rustapp/wire.py
@@ -345,13 +345,24 @@ class Verdict(WireModel):
     #: Human-readable explanation of a non-GOOD outcome — the counterexample / assertion message for
     #: a BAD, the error text for an ERROR.
     detail: str | None
+    #: What the run behind this verdict cost and covered — its budget, its coverage, how far it got.
+    #: Present on a GOOD too, and mostly only there: a passing check's strength is otherwise
+    #: invisible, while a failure explains itself through :attr:`detail`. Kept apart from it because
+    #: they are separate claims — one is evidence about the program, the other about the run — and a
+    #: reader asking for a counterexample should not be handed run accounting inside one.
+    accounting: str | None
+    #: Which *finding* this verdict belongs to, when one piece of evidence condemns several checks
+    #: at once — an opaque key produced by the wheel and only ever compared, never read into. Rows
+    #: sharing one are written up once; ``None`` is a verdict standing on its own evidence.
+    finding: str | None
 
     @classmethod
     def with_outcome(cls, outcome: Outcome) -> "Verdict":
         """A bare verdict: the outcome, no diagnostics. Mirrors the Rust ``Verdict::with_outcome``,
         and exists for the same reason — every field being required is right for the wire and no
-        reason for a caller that has only an outcome to spell four nulls to say so."""
-        return cls(outcome=outcome, line=None, duration_seconds=None, unit_file=None, detail=None)
+        reason for a caller that has only an outcome to spell six nulls to say so."""
+        return cls(outcome=outcome, line=None, duration_seconds=None, unit_file=None, detail=None,
+                   accounting=None, finding=None)
 
 
 class ValidateBuildFailed(WireModel):

--- a/composer/rustapp/wire.py
+++ b/composer/rustapp/wire.py
@@ -41,7 +41,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Callable, Literal, Protocol, S
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from composer.spec.source.report.schema import Outcome
-from composer.spec.types import CheckName, ComponentName, PropertyTitle, PropertyType
+from composer.spec.types import CheckName, ComponentName, FindingKey, PropertyTitle, PropertyType
 
 # ``TargetName``: what a backend selects when it invokes the checker — one :class:`Target`'s name
 # (Crucible: the component's harness fn / Cargo feature). Phantom-typed like the vocabulary in
@@ -345,16 +345,12 @@ class Verdict(WireModel):
     #: Human-readable explanation of a non-GOOD outcome — the counterexample / assertion message for
     #: a BAD, the error text for an ERROR.
     detail: str | None
-    #: What the run behind this verdict cost and covered — its budget, its coverage, how far it got.
-    #: Present on a GOOD too, and mostly only there: a passing check's strength is otherwise
-    #: invisible, while a failure explains itself through :attr:`detail`. Kept apart from it because
-    #: they are separate claims — one is evidence about the program, the other about the run — and a
-    #: reader asking for a counterexample should not be handed run accounting inside one.
+    #: What the run spent and covered (budget, coverage, how far it got). Present on a GOOD too.
+    #: Kept apart from ``detail``: that is evidence about the program; this is about the run.
     accounting: str | None
-    #: Which *finding* this verdict belongs to, when one piece of evidence condemns several checks
-    #: at once — an opaque key produced by the wheel and only ever compared, never read into. Rows
-    #: sharing one are written up once; ``None`` is a verdict standing on its own evidence.
-    finding: str | None
+    #: Opaque key grouping several checks under one finding. The host compares it and never
+    #: reads into it. ``None`` means this verdict stands on its own.
+    finding_key: FindingKey | None
 
     @classmethod
     def with_outcome(cls, outcome: Outcome) -> "Verdict":
@@ -362,7 +358,7 @@ class Verdict(WireModel):
         and exists for the same reason — every field being required is right for the wire and no
         reason for a caller that has only an outcome to spell six nulls to say so."""
         return cls(outcome=outcome, line=None, duration_seconds=None, unit_file=None, detail=None,
-                   accounting=None, finding=None)
+                   accounting=None, finding_key=None)
 
 
 class ValidateBuildFailed(WireModel):

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -175,12 +175,11 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
         return prover_findings(self._evidence)
 
     async def _evidence(self, ref: RuleRef) -> list[RuleEvidence]:
-        # Every instantiation the run analyzed, not just one: a parametric rule can fail differently
-        # per binding while the report shows a single row for the whole rule.
+        # Every instantiation the run analyzed: a parametric rule can fail differently per
+        # binding while the report shows one row.
         #
-        # The ref's file half is dropped: `CexAnalysisStore` is keyed by rule name (a `RulePath` has
-        # no spec file to key on), so two components whose specs name the same rule share evidence
-        # here. Closing that needs the capture to carry the file, not this call.
+        # CexAnalysisStore is keyed by rule name only, so the file half of the ref is dropped.
+        # Two components whose specs share a rule name share evidence here.
         return [
             RuleEvidence(label=r.label, analysis=r.analysis, counterexample=r.counterexample)
             for r in await self._deps.analysis_store.for_rule(ref[1])

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -50,11 +50,13 @@ from composer.spec.source.author import batch_cvl_generation, EditingTools, Sour
 from composer.spec.source.artifacts import ProverArtifactStore, ComponentSpec, InvariantSpec
 from composer.spec.source.report_prover import make_prover_fetcher
 from composer.spec.source.report.collect import (
-    Formalized, EvidenceFetcher, ReportComponentInput, RuleEvidence, Verdict, VerdictFetcher,
+    Formalized, ReportComponentInput, RuleEvidence, Verdict, VerdictFetcher,
 )
 from composer.spec.source.report.schema import (
-    AppliedEditRecord, ComponentName, RuleName, SourceEditRecord,
+    AppliedEditRecord, ComponentName, RuleName, RuleRef, SourceEditRecord,
 )
+from composer.spec.source.report.findings import FindingsPolicy
+from composer.spec.source.prover_findings import prover_findings
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.spec.source.munge.vfs_diff import diff_against_baseline
 
@@ -166,16 +168,22 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
         return records
 
     @override
-    def findings_evidence(self) -> EvidenceFetcher | None:
-        # Prover runs capture per-rule counterexample analysis, so this backend opts into findings.
-        return self._fetch_evidence
+    def findings_policy(
+        self, outcomes: list[ComponentOutcome[GeneratedCVL, ContractComponentInstance]]
+    ) -> FindingsPolicy:
+        # Evidence is the run-scoped CEX capture, not the outcomes.
+        return prover_findings(self._evidence)
 
-    async def _fetch_evidence(self, rule_name: str) -> list[RuleEvidence]:
+    async def _evidence(self, ref: RuleRef) -> list[RuleEvidence]:
         # Every instantiation the run analyzed, not just one: a parametric rule can fail differently
         # per binding while the report shows a single row for the whole rule.
+        #
+        # The ref's file half is dropped: `CexAnalysisStore` is keyed by rule name (a `RulePath` has
+        # no spec file to key on), so two components whose specs name the same rule share evidence
+        # here. Closing that needs the capture to carry the file, not this call.
         return [
             RuleEvidence(label=r.label, analysis=r.analysis, counterexample=r.counterexample)
-            for r in await self._deps.analysis_store.for_rule(rule_name)
+            for r in await self._deps.analysis_store.for_rule(ref[1])
         ]
 
     @override

--- a/composer/spec/source/prover_findings.py
+++ b/composer/spec/source/prover_findings.py
@@ -1,9 +1,7 @@
-"""The Certora Prover's half of findings synthesis: where its evidence comes from, and what the
-model is told that evidence is.
+"""The Certora Prover's half of findings synthesis.
 
-The shared loop is `composer.spec.source.report.findings`. What is here is only what makes a finding
-a *Prover* finding — a prompt that says the Prover refuted the rule with a concrete counterexample,
-and the root-cause analysis captured during the run to ground it in.
+The shared loop is `composer.spec.source.report.findings`. This module supplies the Prover
+prompt (a concrete counterexample refuted the rule) and the run-scoped analysis store.
 """
 from typing import TypedDict
 

--- a/composer/spec/source/prover_findings.py
+++ b/composer/spec/source/prover_findings.py
@@ -1,0 +1,32 @@
+"""The Certora Prover's half of findings synthesis: where its evidence comes from, and what the
+model is told that evidence is.
+
+The shared loop is `composer.spec.source.report.findings`. What is here is only what makes a finding
+a *Prover* finding — a prompt that says the Prover refuted the rule with a concrete counterexample,
+and the root-cause analysis captured during the run to ground it in.
+"""
+from typing import TypedDict
+
+from composer.spec.gen_types import TypedTemplate
+from composer.spec.source.report.collect import EvidenceFetcher
+from composer.spec.source.report.findings import FindingsPolicy, FindingsPromptParams
+from composer.templates.loader import load_jinja_template
+
+
+class ProverDomainParams(TypedDict):
+    """``autoprove_report_findings_prover_domain.j2`` takes no parameters — the prose is static.
+    Declared empty rather than skipped so the template is still covered by the strict-render fuzz
+    test: adding a ``{{ ... }}`` without declaring it here then fails."""
+
+
+_PROVER_DOMAIN = TypedTemplate[ProverDomainParams]("autoprove_report_findings_prover_domain.j2")
+_WRITE_UP_PROMPT = TypedTemplate[FindingsPromptParams]("autoprove_report_findings_prompt.j2")
+
+
+def prover_findings(fetch_evidence: EvidenceFetcher) -> FindingsPolicy:
+    """The Prover's findings policy, around the run-scoped capture that holds its evidence."""
+    return FindingsPolicy(
+        fetch_evidence=fetch_evidence,
+        domain=_PROVER_DOMAIN.bind({}).render_to(load_jinja_template),
+        prompt=_WRITE_UP_PROMPT,
+    )

--- a/composer/spec/source/report/build.py
+++ b/composer/spec/source/report/build.py
@@ -9,15 +9,16 @@ producing no high-level section; the caller additionally treats the whole phase 
 """
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 from langchain_core.language_models.chat_models import BaseChatModel
 
 from composer.spec.types import Curtailed
 from composer.spec.source.report.collect import (
-    EvidenceFetcher, ReportableResult, ReportComponentInput, VerdictFetcher, collect,
+    ReportableResult, ReportComponentInput, VerdictFetcher, collect,
 )
 from composer.spec.source.report.coverage import ValidationError, validate
-from composer.spec.source.report.findings import build_findings
+from composer.spec.source.report.findings import FindingsPolicy, build_findings
 from composer.spec.source.report.grouping import (
     build_fallback_grouping, build_groups, call_grouping_llm, PropertyGroup
 )
@@ -48,14 +49,13 @@ async def build_report[R: ReportableResult](
     source_edits: list[SourceEditRecord] | None = None,
     verification_artifacts: list[VerificationArtifactRecord] | None = None,
     findings_llm: BaseChatModel | None = None,
-    fetch_evidence: EvidenceFetcher | None = None,
+    findings: FindingsPolicy | None = None,
 ) -> AutoProverReport:
     """Build and return the in-memory `AutoProverReport`. Persistence is the caller's job.
 
-    When ``findings_llm`` is supplied, violated rules are additionally synthesized into
-    audit-issue `Finding`s (best-effort; a synthesis failure yields no findings
-    rather than failing the report). ``fetch_evidence`` supplies each violation's captured
-    counterexample analysis; it is optional."""
+    When the backend supplies a ``findings`` policy, violated rules are additionally written up
+    as audit-issue `Finding`s (best-effort; a synthesis failure yields no findings rather than
+    failing the report)."""
     properties, rules, skipped, gave_up, curtailed, dropped = await collect(
         components, fetch_verdicts=fetch_verdicts
     )
@@ -116,12 +116,12 @@ async def build_report[R: ReportableResult](
     # Violated rules -> findings. Its own guard: findings synthesis must never fail the report
     # (the whole phase is also best-effort in the caller, but this keeps a working report even when
     # only findings break).
-    findings: list[Finding] = []
-    if findings_llm is not None:
+    written: list[Finding] = []
+    if findings is not None and findings_llm is not None:
         try:
-            findings = await build_findings(
+            written = await build_findings(
                 contract_name=contract_name, rules=rules, properties=properties, groups=groups,
-                fetch_evidence=fetch_evidence, llm=findings_llm,
+                policy=findings, llm=findings_llm,
             )
         except Exception as e:  # noqa: BLE001
             if RERAISE_REPORT_FAILURES:
@@ -142,6 +142,6 @@ async def build_report[R: ReportableResult](
         source_edits=source_edits or [],
         verification_artifacts=verification_artifacts or [],
         coverage=coverage,
-        findings=findings,
+        findings=written,
     )
     return report

--- a/composer/spec/source/report/build.py
+++ b/composer/spec/source/report/build.py
@@ -9,7 +9,6 @@ producing no high-level section; the caller additionally treats the whole phase 
 """
 import logging
 from datetime import datetime, timezone
-from typing import Any
 
 from langchain_core.language_models.chat_models import BaseChatModel
 

--- a/composer/spec/source/report/build.py
+++ b/composer/spec/source/report/build.py
@@ -52,9 +52,9 @@ async def build_report[R: ReportableResult](
 ) -> AutoProverReport:
     """Build and return the in-memory `AutoProverReport`. Persistence is the caller's job.
 
-    When the backend supplies a ``findings`` policy, violated rules are additionally written up
-    as audit-issue `Finding`s (best-effort; a synthesis failure yields no findings rather than
-    failing the report)."""
+    When the backend supplies a ``findings`` policy, violated rules are written up as
+    `Finding`s. Best-effort: a synthesis failure yields no findings rather than failing the
+    report."""
     properties, rules, skipped, gave_up, curtailed, dropped = await collect(
         components, fetch_verdicts=fetch_verdicts
     )
@@ -112,9 +112,7 @@ async def build_report[R: ReportableResult](
         if c.formalized is not None and not isinstance(c.formalized, Curtailed)
         and c.formalized.run_link
     }
-    # Violated rules -> findings. Its own guard: findings synthesis must never fail the report
-    # (the whole phase is also best-effort in the caller, but this keeps a working report even when
-    # only findings break).
+    # Findings are best-effort: a failure here must not take down the rest of the report.
     written: list[Finding] = []
     if findings is not None and findings_llm is not None:
         try:

--- a/composer/spec/source/report/collect.py
+++ b/composer/spec/source/report/collect.py
@@ -18,10 +18,11 @@ from pathlib import Path
 from typing import Protocol
 
 from composer.authoring.state import SkippedProperty
-from composer.spec.types import Curtailed, PropertyFormulation
+from composer.spec.types import Curtailed, FindingKey, PropertyFormulation
 from composer.spec.source.report.schema import (
-    ComponentName, CurtailedComponent, CurtailedSkip, DraftedProperty, FormalizedProperty,
-    GaveUpComponent, Outcome, PropertyTitle, RuleName, RuleRef, RuleVerdict, SkippedClaim,
+    ComponentName, CurtailedComponent, CurtailedSkip, ExpectedFailure, DraftedProperty,
+    FormalizedProperty, GaveUpComponent, Outcome, PropertyTitle, RuleName, RuleRef,
+    RuleVerdict, SkippedClaim,
 )
 
 _log = logging.getLogger(__name__)
@@ -82,10 +83,15 @@ class Verdict:
     #: a BAD, error text for an ERROR). Provenance/diagnostics only; ``None`` when the backend
     #: gives no detail (the prover/foundry fetchers don't).
     message: str | None = None
+    #: What the run spent and covered. ``None`` when the backend does not report it (prover,
+    #: foundry). Kept apart from ``message`` so render can show them separately.
+    accounting: str | None = None
+    #: Author-marked expected failure. ``None`` when the check was not marked.
+    expected_failure: ExpectedFailure | None = None
 
     def merge(self, other: "Verdict | None") -> "Verdict":
         """Combine two results for one unit within a run: higher-priority outcome wins,
-        line/duration/unit_file/message kept from whichever side has them."""
+        line/duration/unit_file/message/accounting/expected_failure kept from whichever side has them."""
         if other is None:
             return self
         hi, lo = (
@@ -99,6 +105,8 @@ class Verdict:
             hi.duration_seconds if hi.duration_seconds is not None else lo.duration_seconds,
             hi.unit_file or lo.unit_file,
             hi.message or lo.message,
+            hi.accounting or lo.accounting,
+            hi.expected_failure or lo.expected_failure,
         )
 
 
@@ -155,45 +163,34 @@ def _curtailed_component[R: ReportableResult](
 
 @dataclass(frozen=True)
 class RuleEvidence:
-    """One failing instance of a violated rule: what a run observed about it, split by where each
-    part came from.
+    """One failing instance of a violated rule.
 
-    A backend fills the parts it has and leaves the rest ``None``. Absence always means "this run
-    recorded nothing of that kind" — never that it recorded something empty — so the fields mean the
-    same thing whichever backend produced them, and a prompt can say what is missing rather than
-    guessing."""
+    A backend fills the parts it has and leaves the rest ``None``. ``None`` means the run
+    recorded nothing of that kind, not that it recorded something empty.
+    """
 
-    #: Which instance this is, where a rule can fail more than once: a parametric binding
-    #: (``rule r(method f)``) for the prover, the component for a per-component backend. ``""``
-    #: when the rule fails only once.
+    #: Which instance this is when a rule can fail more than once: a parametric binding for
+    #: the prover, the component for a per-component backend. ``""`` when it fails only once.
     label: str = ""
-    #: The backend's own account of *why* the check failed, where it produces one — a root-cause
-    #: explanation rather than the raw failure.
+    #: Why the check failed, when the backend produces a root-cause account.
     analysis: str | None = None
     #: What reproduces the failure: a counterexample trace, a crashing input, an assertion message.
     counterexample: str | None = None
-    #: The run's own outcome for this check, before any authored declaration is folded into the
-    #: outcome the report shows. ``None`` for a backend that captures evidence only for failures,
-    #: where it would add nothing; where a check can be reported BAD on the author's say-so, this is
-    #: the only thing that says whether the run actually reproduced it.
+    #: The run's own outcome, before any expected-to-fail mark is folded in. ``None`` if the
+    #: backend only records evidence for failures. Distinguishes a reproduced finding from one
+    #: the author marked expected to fail but this run did not hit.
     ran: Outcome | None = None
-    #: The run's evidence about *itself*: what it spent against its budget, how far it reached, and
-    #: whether this check was exercised at all. What makes a result weigh something — and what a
-    #: proof of concept must not be padded with.
+    #: What the run spent and covered. Do not put this in a proof of concept.
     accounting: str | None = None
-    #: Why the author declared a failure here to be expected, when they did. Present means the row
-    #: is a claim the author made, not only something the run tripped over.
-    declared: str | None = None
-    #: Which *finding* this belongs to, when one piece of evidence condemns several checks at once.
-    #: Opaque and compared across the whole report — the same string on two components merges them.
-    #: ``None`` is evidence standing on its own.
-    finding: str | None = None
+    #: Why the author marked this check expected to fail, when they did.
+    expected_failure_reason: str | None = None
+    #: Opaque key grouping several checks under one finding. Compared across the whole report:
+    #: the same string on two components merges them. ``None`` stands on its own.
+    finding_key: FindingKey | None = None
 
 
-#: Every captured failing instance of a violated rule, or ``[]`` when the backend has none for it.
-#: Keyed by `RuleRef` — ``(file, name)``, how the report identifies a row — because a name alone
-#: does not: one deliverable can hold several components' checks, and two authors given the same
-#: property write the same name.
+#: Evidence for one violated rule, or ``[]`` if the backend has none.
+#: Keyed by `RuleRef` — ``(file, name)`` — because a check name alone does not identify a row.
 type EvidenceFetcher = Callable[[RuleRef], Awaitable[list[RuleEvidence]]]
 
 
@@ -273,6 +270,7 @@ async def collect[R: ReportableResult](
                 rules_by_key[key] = RuleVerdict(
                     name=unit_name, spec_file=key[0], outcome=v.outcome, line=v.line,
                     duration_seconds=v.duration_seconds, prover_link=run_link, message=v.message,
+                    accounting=v.accounting, expected_failure=v.expected_failure,
                 )
 
     # A referenced unit with no verdict still needs an (UNKNOWN) entry to render.

--- a/composer/spec/source/report/collect.py
+++ b/composer/spec/source/report/collect.py
@@ -185,7 +185,8 @@ class RuleEvidence:
     #: is a claim the author made, not only something the run tripped over.
     declared: str | None = None
     #: Which *finding* this belongs to, when one piece of evidence condemns several checks at once.
-    #: Opaque — only ever compared, never read into. ``None`` is evidence standing on its own.
+    #: Opaque and compared across the whole report — the same string on two components merges them.
+    #: ``None`` is evidence standing on its own.
     finding: str | None = None
 
 

--- a/composer/spec/source/report/collect.py
+++ b/composer/spec/source/report/collect.py
@@ -12,6 +12,7 @@ already in memory.
 """
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
@@ -154,20 +155,45 @@ def _curtailed_component[R: ReportableResult](
 
 @dataclass(frozen=True)
 class RuleEvidence:
-    """One failing instance of a violated rule: the backend's root-cause explanation and a concrete
-    counterexample, either of which may be absent. A parametric rule (``rule r(method f)``) fails once
-    per binding, so a rule's evidence is a list of these; ``label`` names the instance ("" when the
-    rule is not parametric)."""
+    """One failing instance of a violated rule: what a run observed about it, split by where each
+    part came from.
+
+    A backend fills the parts it has and leaves the rest ``None``. Absence always means "this run
+    recorded nothing of that kind" — never that it recorded something empty — so the fields mean the
+    same thing whichever backend produced them, and a prompt can say what is missing rather than
+    guessing."""
+
+    #: Which instance this is, where a rule can fail more than once: a parametric binding
+    #: (``rule r(method f)``) for the prover, the component for a per-component backend. ``""``
+    #: when the rule fails only once.
     label: str = ""
+    #: The backend's own account of *why* the check failed, where it produces one — a root-cause
+    #: explanation rather than the raw failure.
     analysis: str | None = None
+    #: What reproduces the failure: a counterexample trace, a crashing input, an assertion message.
     counterexample: str | None = None
+    #: The run's own outcome for this check, before any authored declaration is folded into the
+    #: outcome the report shows. ``None`` for a backend that captures evidence only for failures,
+    #: where it would add nothing; where a check can be reported BAD on the author's say-so, this is
+    #: the only thing that says whether the run actually reproduced it.
+    ran: Outcome | None = None
+    #: The run's evidence about *itself*: what it spent against its budget, how far it reached, and
+    #: whether this check was exercised at all. What makes a result weigh something — and what a
+    #: proof of concept must not be padded with.
+    accounting: str | None = None
+    #: Why the author declared a failure here to be expected, when they did. Present means the row
+    #: is a claim the author made, not only something the run tripped over.
+    declared: str | None = None
+    #: Which *finding* this belongs to, when one piece of evidence condemns several checks at once.
+    #: Opaque — only ever compared, never read into. ``None`` is evidence standing on its own.
+    finding: str | None = None
 
 
-class EvidenceFetcher(Protocol):
-    """Backend hook: every captured failing instance of a violated rule, or ``[]`` when the backend has
-    none for it. Prover reads the run-scoped CEX-analysis capture."""
-    async def __call__(self, rule_name: str, /) -> list[RuleEvidence]:
-        ...
+#: Every captured failing instance of a violated rule, or ``[]`` when the backend has none for it.
+#: Keyed by `RuleRef` — ``(file, name)``, how the report identifies a row — because a name alone
+#: does not: one deliverable can hold several components' checks, and two authors given the same
+#: property write the same name.
+type EvidenceFetcher = Callable[[RuleRef], Awaitable[list[RuleEvidence]]]
 
 
 async def collect[R: ReportableResult](

--- a/composer/spec/source/report/findings.py
+++ b/composer/spec/source/report/findings.py
@@ -3,12 +3,12 @@
 For each violated rule (a `RuleVerdict` with ``outcome == Outcome.BAD``) this asks a model to write
 the issue up, grounded in the `RuleEvidence` the backend hands back for it.
 
-Evidence has one shape for every backend. Backends differ in what they can *fill* — the prover has a
-root-cause analysis and a counterexample trace, a fuzzing wheel has a crashing input and an account
-of what its run covered — but "instance, explanation, reproducer, and what the run itself did" is not
-a claim about any one of them. What is genuinely per-backend is where that evidence is *fetched*
-from and what the model is told it means; a `FindingsPolicy` carries those — as values, not hooks,
-save the fetcher.
+Evidence has one shape for every backend. Backends differ in what they can *fill* — one fills a
+root-cause analysis and a counterexample, another fills a reproducer and an account of what the
+run covered — but "instance, explanation, reproducer, and what the run itself did" is not a claim
+about any one of them. What is genuinely per-backend is where that evidence is *fetched* from and
+what the model is told it means; a `FindingsPolicy` carries those — as values, not hooks, save the
+fetcher.
 
 The rest is shared outright: walking the BAD rules, resolving each one's properties and the audit
 groups they sit in, collapsing rows that are one finding, binding the prompt, building the proof of
@@ -21,7 +21,7 @@ import asyncio
 import logging
 from collections.abc import Hashable
 from dataclasses import dataclass
-from typing import ClassVar, TypedDict
+from typing import TypedDict
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -55,10 +55,7 @@ _SEVERITY_MATRIX: dict[tuple[ImpactLevel, LikelihoodLevel], SeverityTier] = {
 
 
 def severity_for(impact: ImpactLevel, likelihood: LikelihoodLevel) -> SeverityTier:
-    """Map an assessed (impact, likelihood) pair to a severity. ``none`` impact -> informational.
-
-    For a backend whose evidence supports that judgement. One whose does not says so by assessing
-    a constant instead — see `Assessment`."""
+    """Map an assessed (impact, likelihood) pair to a severity. ``none`` impact -> informational."""
     if impact == "none":
         return "informational"
     return _SEVERITY_MATRIX[(impact, likelihood)]
@@ -116,8 +113,9 @@ class FindingsSystemParams(TypedDict):
     """The full, typed context of ``autoprove_report_findings_system.j2``.
 
     One template for every backend, because the two halves of a findings system prompt split the
-    same way everywhere: what this evidence *is* is the backend's claim, and how severity is reached
-    and what sections come back is the host's contract. Only the first varies."""
+    same way everywhere: what this evidence *is* and how far it goes is the backend's claim, and
+    how severity is reached and what sections come back is the host's contract. Only the first
+    varies."""
     #: The backend's own prose: what its evidence is, what it does and does not establish, and how to
     #: read its own markers. Leads the message; the contract follows it.
     domain: str
@@ -128,21 +126,19 @@ class FindingsPromptParams(TypedDict):
     known about it.
 
     One shape for all of them, because a backend's prompt differs in what it *says* about the
-    evidence, not in what it is given — "the Certora Prover found a concrete counterexample" is a
-    claim about the same fields a fuzzing wheel fills differently. The backend supplies the template;
-    `build_findings` binds it.
+    evidence, not in what it is given. The Prover supplies its own template; Rust-authored backends
+    share one host template. `build_findings` binds either.
 
-    ``properties`` is *every* property the rule formalizes, not a pre-picked one: a rule may jointly
-    formalize several and only the evidence says which actually broke, which is the model's job to
-    determine rather than this layer's to guess."""
+    ``properties`` is every property the covered rule(s) formalize — one rule may jointly
+    formalize several, and rows stamped as one finding contribute the union. This layer does
+    not pick which actually broke."""
     contract_name: str
     rule_name: RuleName
     properties: list[FormalizedProperty]
     groups: list[PropertyGroup]
     evidence: list[RuleEvidence]
-    #: The other BAD rows this one write-up answers for — rows the backend could not tell apart from
-    #: this one on the evidence it has. Empty in the ordinary case. Non-empty is itself something the
-    #: write-up should say: the run found one thing and cannot name which check it broke.
+    #: When several rows share one finding, the names of every covered check (including the
+    #: subject). Empty in the ordinary one-row case — the subject is ``rule_name`` alone.
     also_covers: list[RuleName]
 
 
@@ -174,9 +170,11 @@ def finding_key(rule: RuleVerdict, evidence: list[RuleEvidence]) -> Hashable:
 
     A backend whose rows are one-to-one with findings stamps nothing and nothing ever collapses. One
     whose run can conclude something it cannot attribute to a single check fans that conclusion out
-    over every check it covered and stamps them alike, so the run is written up once rather than once
-    per row it took down — for a component's whole property set, dozens of them, each guessing a
-    different check.
+    over every check it covered and stamps them alike, so those rows are written up once rather than
+    once per row.
+
+    The stamp is compared as a raw string across the whole report, with no file or component prefix:
+    the same key on two components merges them. Pick keys that are unique among this run's findings.
 
     The relation is never inferred from the evidence: rows fanned out from one conclusion look
     exactly like several checks that failed the same way, and those are two different facts about the
@@ -190,17 +188,17 @@ class FindingsPolicy:
     """What one backend's findings rest on: where its evidence comes from, what the model is told
     that evidence is, and what it can be asked to conclude from it.
 
-    Values, not hooks: the prose is a string and the prompt is a template — a Rust wheel ships the
-    first across the FFI boundary as JSON, which is the proof it was never behaviour. Only the
-    fetcher is a function, because only it does I/O."""
+    Values, not hooks: the prose is a string and the prompt is a template. A Rust-authored backend
+    ships the domain string across the FFI as JSON. Only the fetcher is a function, because only it
+    does I/O."""
 
     fetch_evidence: EvidenceFetcher
     #: The backend's half of the system message — see `FindingsSystemParams.domain`. Constant across
     #: this backend's rules; the per-rule context is `prompt`.
     domain: str
     #: The user message's template, bound by `build_findings` from `FindingsPromptParams`. The
-    #: backend owns the prose because the prompt is a claim about what its evidence *is*; it does not
-    #: own the binding, because the fields are the same for everyone.
+    #: Prover supplies its own; Rust-authored backends share one host template. Either way the
+    #: loop owns the binding, because the fields are the same for everyone.
     prompt: TypedTemplate[FindingsPromptParams]
 
 
@@ -243,36 +241,42 @@ async def build_findings(
                          exc_info=True)
             return None
 
-    # Every BAD row's evidence first, so rows whose write-up would be the same write-up collapse
-    # before any of them is paid for. The alternative is a model call per row: one crash a campaign
-    # cannot attribute condemns every check that campaign covered, which for a Crucible component is
-    # its whole property set.
+    # Every BAD row's evidence first, so rows the backend stamped as one finding collapse before
+    # any of them is paid for. Cost follows conclusions, not row count.
     fetched = await asyncio.gather(*[_evidence(r) for r in bad])
     collapsed: dict[Hashable, tuple[RuleVerdict, list[RuleEvidence]]] = {}
-    also: dict[Hashable, list[RuleName]] = {}
+    covered: dict[Hashable, list[RuleVerdict]] = {}
     for rule, evidence in zip(bad, fetched):
         if evidence is None:
             continue
         key = finding_key(rule, evidence)
         if key in collapsed:
-            also[key].append(rule.name)
+            covered[key].append(rule)
         else:
-            collapsed[key], also[key] = (rule, evidence), []
+            collapsed[key] = (rule, evidence)
+            covered[key] = [rule]
 
     async def _one(
-        rule: RuleVerdict, evidence: list[RuleEvidence], covers: list[RuleName],
+        rule: RuleVerdict, evidence: list[RuleEvidence], covered: list[RuleVerdict],
     ) -> Finding | None:
         try:
-            props = props_by_ref.get(rule.ref, [])
+            props: list[FormalizedProperty] = []
+            seen: set[PropertyKey] = set()
+            for r in covered:
+                for p in props_by_ref.get(r.ref, []):
+                    if p.key not in seen:
+                        seen.add(p.key)
+                        props.append(p)
             # A rule's properties may share a group (some may be in none); dedupe by slug, first-seen order.
             rule_groups = list({g.slug: g for p in props if (g := group_by_key.get(p.key)) is not None}.values())
+            also_covers = list(dict.fromkeys(r.name for r in covered)) if len(covered) > 1 else []
             user = policy.prompt.bind({
                 "contract_name": contract_name, "rule_name": rule.name, "properties": props,
-                "groups": rule_groups, "evidence": evidence, "also_covers": covers,
+                "groups": rule_groups, "evidence": evidence, "also_covers": also_covers,
             }).render_to(load_jinja_template)
             draft = await bound.ainvoke([SystemMessage(system), HumanMessage(user)])
             assert isinstance(draft, FindingDraft)
-            return _compose(rule, draft, evidence, rule_groups)
+            return _compose(rule, draft, evidence, rule_groups, covered)
         except Exception:  # noqa: BLE001 — one finding failing must never fail the report
             _log.warning("report: finding synthesis failed for rule %r; skipping", rule.name, exc_info=True)
             return None
@@ -282,7 +286,7 @@ async def build_findings(
     async def _bounded(key: Hashable) -> Finding | None:
         async with sem:
             rule, evidence = collapsed[key]
-            return await _one(rule, evidence, also[key])
+            return await _one(rule, evidence, covered[key])
 
     findings = await asyncio.gather(*[_bounded(k) for k in collapsed])
     return [f for f in findings if f is not None]
@@ -293,15 +297,17 @@ def _compose(
     draft: FindingDraft,
     evidence: list[RuleEvidence],
     groups: list[PropertyGroup],
+    covered: list[RuleVerdict],
 ) -> Finding:
     risk = assess(draft)
+    links = list(dict.fromkeys(r.prover_link for r in covered if r.prover_link))
     return Finding(
         title=draft.title,
         severity=risk.severity,
         content=IssueContent(
             **{f: getattr(draft, f) for f in AuthoredContent.model_fields},
             proof_of_concept=proof_of_concept(evidence),
-            references=[rule.prover_link] if rule.prover_link else None,
+            references=links or None,
         ),
         provenance=FindingProvenance(
             rule_name=rule.name,
@@ -312,5 +318,6 @@ def _compose(
             impact=risk.impact,
             likelihood=risk.likelihood,
             risk_reasoning=risk.reasoning,
+            covers=[r.ref for r in covered] if len(covered) > 1 else [],
         ),
     )

--- a/composer/spec/source/report/findings.py
+++ b/composer/spec/source/report/findings.py
@@ -1,25 +1,15 @@
-"""Synthesize findings from violated rules — the loop every backend shares.
+"""Write violated rules up as findings — the loop every backend shares.
 
-For each violated rule (a `RuleVerdict` with ``outcome == Outcome.BAD``) this asks a model to write
-the issue up, grounded in the `RuleEvidence` the backend hands back for it.
+For each BAD `RuleVerdict` this asks a model to write the issue up from the backend's
+`RuleEvidence`. Evidence has one shape; backends differ in which fields they fill. A
+`FindingsPolicy` is where the evidence comes from and what the model is told it means.
 
-Evidence has one shape for every backend. Backends differ in what they can *fill* — one fills a
-root-cause analysis and a counterexample, another fills a reproducer and an account of what the
-run covered — but "instance, explanation, reproducer, and what the run itself did" is not a claim
-about any one of them. What is genuinely per-backend is where that evidence is *fetched* from and
-what the model is told it means; a `FindingsPolicy` carries those — as values, not hooks, save the
-fetcher.
-
-The rest is shared outright: walking the BAD rules, resolving each one's properties and the audit
-groups they sit in, collapsing rows that are one finding, binding the prompt, building the proof of
-concept, bounding the concurrency, keeping one failed write-up from costing the rest, and composing
-the `Finding` the report persists.
-
-A backend that produces no findings returns no `FindingsPolicy` and never reaches here.
+The rest is shared: walking BAD rows, properties and groups, collapsing stamped findings,
+the proof of concept, concurrency, and composing the `Finding`. A backend that produces
+no findings returns no policy and never reaches here.
 """
 import asyncio
 import logging
-from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import TypedDict
 
@@ -34,13 +24,15 @@ from composer.spec.source.report.schema import (
     LikelihoodLevel, Outcome, PropertyGroup, PropertyKey, RuleName, RuleRef, RuleVerdict,
     SeverityTier,
 )
+from composer.spec.types import FindingKey
 from composer.templates.loader import load_jinja_template
+
+type FindingIdentity = FindingKey | RuleRef
 
 _log = logging.getLogger(__name__)
 
-#: Cap on concurrent findings-synthesis LLM calls (one per violated rule), so a violation-heavy run
-#: doesn't burst dozens of heavy-model requests at once (which rate limits would turn into dropped
-#: findings).
+#: Cap on concurrent findings-synthesis LLM calls, so a violation-heavy run does not burst
+#: the rate limit and drop write-ups.
 _MAX_CONCURRENT_FINDING_CALLS = 8
 
 # Impact × Likelihood -> severity. ``none`` impact (no real-world exploit path) is informational,
@@ -63,10 +55,7 @@ def severity_for(impact: ImpactLevel, likelihood: LikelihoodLevel) -> SeverityTi
 
 class FindingDraft(AuthoredContent):
     """What a findings model must return: the authored sections, a title, and the two axes
-    `severity_for` maps to a tier.
-
-    The model never picks the tier, only the axes, so the severity a reader sees is reproducible
-    from what the model actually said."""
+    `severity_for` maps to a tier. The model never picks the tier."""
     title: str = Field(description="A one-line title naming the specific broken guarantee.")
     impact_level: ImpactLevel = Field(description=(
         "How severe the consequence is if exploited: 'high' (funds lost or stolen, protocol "
@@ -86,75 +75,44 @@ class FindingDraft(AuthoredContent):
     ))
 
 
-@dataclass(frozen=True)
-class Assessment:
-    """The risk verdict on one draft: the severity, and the record of how it was reached.
-
-    The three axes are provenance — they say what the tier *rests on*, so a reader can see the
-    judgement behind it rather than only its result."""
-    severity: SeverityTier
-    impact: ImpactLevel
-    likelihood: LikelihoodLevel
-    reasoning: str
-
-
-def assess(draft: FindingDraft) -> Assessment:
-    """Severity from the matrix. Every backend's, because every backend's evidence is a violation
-    that happened — what differs is what a violation *is* there, which is what the prompt says."""
-    return Assessment(
-        severity=severity_for(draft.impact_level, draft.likelihood_level),
-        impact=draft.impact_level,
-        likelihood=draft.likelihood_level,
-        reasoning=draft.risk_reasoning,
-    )
-
-
 class FindingsSystemParams(TypedDict):
-    """The full, typed context of ``autoprove_report_findings_system.j2``.
+    """Context for ``autoprove_report_findings_system.j2``.
 
-    One template for every backend, because the two halves of a findings system prompt split the
-    same way everywhere: what this evidence *is* and how far it goes is the backend's claim, and
-    how severity is reached and what sections come back is the host's contract. Only the first
-    varies."""
-    #: The backend's own prose: what its evidence is, what it does and does not establish, and how to
-    #: read its own markers. Leads the message; the contract follows it.
+    One template for every backend: what the evidence is and how far it goes is the backend's
+    claim; how severity is reached and which sections come back is the host's."""
+    #: Backend prose: what its evidence is, what that does and does not establish, how to read
+    #: its markers. Leads the message; the host contract follows it.
     domain: str
 
 
 class FindingsPromptParams(TypedDict):
-    """The full, typed context of every backend's findings prompt: one violated rule and everything
-    known about it.
+    """Context for every backend's findings user prompt: one violated rule and what is known
+    about it.
 
-    One shape for all of them, because a backend's prompt differs in what it *says* about the
-    evidence, not in what it is given. The Prover supplies its own template; Rust-authored backends
+    One shape for all of them. The Prover supplies its own template; Rust-authored backends
     share one host template. `build_findings` binds either.
 
-    ``properties`` is every property the covered rule(s) formalize — one rule may jointly
-    formalize several, and rows stamped as one finding contribute the union. This layer does
-    not pick which actually broke."""
+    ``properties`` is every property the covered rule(s) formalize — jointly, or the union
+    when several rows share one finding. This layer does not pick which actually broke."""
     contract_name: str
     rule_name: RuleName
     properties: list[FormalizedProperty]
     groups: list[PropertyGroup]
     evidence: list[RuleEvidence]
-    #: When several rows share one finding, the names of every covered check (including the
-    #: subject). Empty in the ordinary one-row case — the subject is ``rule_name`` alone.
+    #: Names of every covered check when several rows share one finding, including the
+    #: subject. Empty for a one-row finding — the subject is ``rule_name`` alone.
     also_covers: list[RuleName]
-
 
 
 _SYSTEM = TypedTemplate[FindingsSystemParams]("autoprove_report_findings_system.j2")
 
 
 def proof_of_concept(evidence: list[RuleEvidence]) -> str | None:
-    """Every instance's reproducer, labelled once there is more than one — the report shows a single
-    row per rule, so its PoC should cover all of that rule's failing instances.
+    """Every instance's reproducer, labelled once there is more than one.
 
-    Only what this run actually refuted. A declared failure the run did not reproduce has no proof of
-    concept at all — its ground is the author's reading, which rides ``provenance.risk_reasoning`` —
-    and neither does an error that reached no verdict. Never the accounting: what a run spent is a
-    claim about the run, and padding a proof of concept with it leaves a reader unable to see where
-    the evidence ends."""
+    Only what this run actually refuted. An expected-to-fail check this run did not hit has no
+    proof of concept, and neither does an error that never reached a verdict. Never the
+    accounting — that is about the run, not the program."""
     traces = [
         (e.label, e.counterexample) for e in evidence
         if e.counterexample and (e.ran is None or e.ran is Outcome.BAD)
@@ -164,41 +122,35 @@ def proof_of_concept(evidence: list[RuleEvidence]) -> str | None:
     return "\n\n".join(f"# {label or 'counterexample'}\n{cex}" for label, cex in traces)
 
 
-def finding_key(rule: RuleVerdict, evidence: list[RuleEvidence]) -> Hashable:
-    """Identity of the *finding* behind a row: the key the backend stamped on its evidence, else the
-    row itself. Rows sharing a key are written up once — see `build_findings`.
+def finding_key(rule: RuleVerdict, evidence: list[RuleEvidence]) -> FindingIdentity:
+    """The finding behind a row: the backend's `FindingKey` stamp, else this row's `RuleRef`.
 
-    A backend whose rows are one-to-one with findings stamps nothing and nothing ever collapses. One
-    whose run can conclude something it cannot attribute to a single check fans that conclusion out
-    over every check it covered and stamps them alike, so those rows are written up once rather than
-    once per row.
-
-    The stamp is compared as a raw string across the whole report, with no file or component prefix:
-    the same key on two components merges them. Pick keys that are unique among this run's findings.
-
-    The relation is never inferred from the evidence: rows fanned out from one conclusion look
-    exactly like several checks that failed the same way, and those are two different facts about the
-    program. Only the backend can tell them apart."""
-    stamped = next((e.finding for e in evidence if e.finding is not None), None)
+    Rows that share a key are written up once. No stamp means no collapse. A stamp is compared
+    as a raw string across the whole report — the same value on two components merges them —
+    and is never inferred from matching evidence."""
+    stamped = next((e.finding_key for e in evidence if e.finding_key is not None), None)
     return stamped if stamped is not None else rule.ref
+
+
+@dataclass
+class _Cluster:
+    """One write-up: the first row, its evidence, and every row that shares its stamp."""
+    rule: RuleVerdict
+    evidence: list[RuleEvidence]
+    covered: list[RuleVerdict]
 
 
 @dataclass(frozen=True)
 class FindingsPolicy:
-    """What one backend's findings rest on: where its evidence comes from, what the model is told
-    that evidence is, and what it can be asked to conclude from it.
+    """Where one backend's evidence comes from, what it is, and how to ask for a write-up.
 
-    Values, not hooks: the prose is a string and the prompt is a template. A Rust-authored backend
-    ships the domain string across the FFI as JSON. Only the fetcher is a function, because only it
-    does I/O."""
+    ``domain`` and ``prompt`` are values (a string and a template). Only ``fetch_evidence``
+    is a function, because only it does I/O."""
 
     fetch_evidence: EvidenceFetcher
-    #: The backend's half of the system message — see `FindingsSystemParams.domain`. Constant across
-    #: this backend's rules; the per-rule context is `prompt`.
+    #: Backend half of the system message — see `FindingsSystemParams.domain`.
     domain: str
-    #: The user message's template, bound by `build_findings` from `FindingsPromptParams`. The
-    #: Prover supplies its own; Rust-authored backends share one host template. Either way the
-    #: loop owns the binding, because the fields are the same for everyone.
+    #: User-message template, bound by `build_findings` from `FindingsPromptParams`.
     prompt: TypedTemplate[FindingsPromptParams]
 
 
@@ -213,8 +165,7 @@ async def build_findings(
 ) -> list[Finding]:
     """One `Finding` per violated rule (concurrent, best-effort); ``[]`` when nothing is violated.
 
-    Fewer than one per rule where several rows are stamped as the same finding — see
-    `finding_key`."""
+    Fewer than one per rule when several rows share a finding stamp — see `finding_key`."""
     bad = [r for r in rules if r.outcome == Outcome.BAD]
     if not bad:
         return []
@@ -232,8 +183,7 @@ async def build_findings(
     system = _SYSTEM.bind({"domain": policy.domain}).render_to(load_jinja_template)
 
     async def _evidence(rule: RuleVerdict) -> list[RuleEvidence] | None:
-        """This rule's evidence, or None when fetching it failed — which drops the rule rather than
-        writing it up against nothing."""
+        """This rule's evidence, or None if fetching failed (the rule is then skipped)."""
         try:
             return await policy.fetch_evidence(rule.ref)
         except Exception:  # noqa: BLE001 — one rule failing must never fail the report
@@ -241,24 +191,21 @@ async def build_findings(
                          exc_info=True)
             return None
 
-    # Every BAD row's evidence first, so rows the backend stamped as one finding collapse before
-    # any of them is paid for. Cost follows conclusions, not row count.
+    # Fetch every BAD row first so stamped findings collapse before any write-up is paid for.
     fetched = await asyncio.gather(*[_evidence(r) for r in bad])
-    collapsed: dict[Hashable, tuple[RuleVerdict, list[RuleEvidence]]] = {}
-    covered: dict[Hashable, list[RuleVerdict]] = {}
+    clusters: dict[FindingIdentity, _Cluster] = {}
     for rule, evidence in zip(bad, fetched):
         if evidence is None:
             continue
         key = finding_key(rule, evidence)
-        if key in collapsed:
-            covered[key].append(rule)
+        cluster = clusters.get(key)
+        if cluster is None:
+            clusters[key] = _Cluster(rule, evidence, [rule])
         else:
-            collapsed[key] = (rule, evidence)
-            covered[key] = [rule]
+            cluster.covered.append(rule)
 
-    async def _one(
-        rule: RuleVerdict, evidence: list[RuleEvidence], covered: list[RuleVerdict],
-    ) -> Finding | None:
+    async def _one(cluster: _Cluster) -> Finding | None:
+        rule, evidence, covered = cluster.rule, cluster.evidence, cluster.covered
         try:
             props: list[FormalizedProperty] = []
             seen: set[PropertyKey] = set()
@@ -283,12 +230,11 @@ async def build_findings(
 
     sem = asyncio.Semaphore(_MAX_CONCURRENT_FINDING_CALLS)
 
-    async def _bounded(key: Hashable) -> Finding | None:
+    async def _bounded(cluster: _Cluster) -> Finding | None:
         async with sem:
-            rule, evidence = collapsed[key]
-            return await _one(rule, evidence, covered[key])
+            return await _one(cluster)
 
-    findings = await asyncio.gather(*[_bounded(k) for k in collapsed])
+    findings = await asyncio.gather(*[_bounded(c) for c in clusters.values()])
     return [f for f in findings if f is not None]
 
 
@@ -299,11 +245,10 @@ def _compose(
     groups: list[PropertyGroup],
     covered: list[RuleVerdict],
 ) -> Finding:
-    risk = assess(draft)
     links = list(dict.fromkeys(r.prover_link for r in covered if r.prover_link))
     return Finding(
         title=draft.title,
-        severity=risk.severity,
+        severity=severity_for(draft.impact_level, draft.likelihood_level),
         content=IssueContent(
             **{f: getattr(draft, f) for f in AuthoredContent.model_fields},
             proof_of_concept=proof_of_concept(evidence),
@@ -315,9 +260,9 @@ def _compose(
             outcome=rule.outcome,
             group_slugs=[g.slug for g in groups],
             prover_link=rule.prover_link,
-            impact=risk.impact,
-            likelihood=risk.likelihood,
-            risk_reasoning=risk.reasoning,
+            impact=draft.impact_level,
+            likelihood=draft.likelihood_level,
+            risk_reasoning=draft.risk_reasoning,
             covers=[r.ref for r in covered] if len(covered) > 1 else [],
         ),
     )

--- a/composer/spec/source/report/findings.py
+++ b/composer/spec/source/report/findings.py
@@ -1,27 +1,40 @@
-"""Synthesize findings from violated rules.
+"""Synthesize findings from violated rules — the loop every backend shares.
 
-For each violated rule (a `RuleVerdict` with ``outcome == Outcome.BAD``) this asks an LLM to write up
-the issue, grounded in the rule's counterexample analysis (captured during the run and looked up via
-the backend's `EvidenceFetcher`) and the properties the rule formalizes. The model assesses the impact
-and likelihood; this module computes the severity from them via a fixed matrix — the LLM never picks a
-severity directly. Findings are produced only when the backend supplies an evidence fetcher; each
-finding is best-effort, so a synthesis failure drops that one finding rather than the report.
+For each violated rule (a `RuleVerdict` with ``outcome == Outcome.BAD``) this asks a model to write
+the issue up, grounded in the `RuleEvidence` the backend hands back for it.
+
+Evidence has one shape for every backend. Backends differ in what they can *fill* — the prover has a
+root-cause analysis and a counterexample trace, a fuzzing wheel has a crashing input and an account
+of what its run covered — but "instance, explanation, reproducer, and what the run itself did" is not
+a claim about any one of them. What is genuinely per-backend is where that evidence is *fetched*
+from and what the model is told it means; a `FindingsPolicy` carries those — as values, not hooks,
+save the fetcher.
+
+The rest is shared outright: walking the BAD rules, resolving each one's properties and the audit
+groups they sit in, collapsing rows that are one finding, binding the prompt, building the proof of
+concept, bounding the concurrency, keeping one failed write-up from costing the rest, and composing
+the `Finding` the report persists.
+
+A backend that produces no findings returns no `FindingsPolicy` and never reaches here.
 """
 import asyncio
 import logging
-from typing import TypedDict
+from collections.abc import Hashable
+from dataclasses import dataclass
+from typing import ClassVar, TypedDict
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import Field
 
 from composer.spec.gen_types import TypedTemplate
-from composer.templates.loader import load_jinja_template
 from composer.spec.source.report.collect import EvidenceFetcher, RuleEvidence
 from composer.spec.source.report.schema import (
     AuthoredContent, Finding, FindingProvenance, FormalizedProperty, ImpactLevel, IssueContent,
-    LikelihoodLevel, Outcome, PropertyGroup, PropertyKey, RuleRef, RuleVerdict, SeverityTier,
+    LikelihoodLevel, Outcome, PropertyGroup, PropertyKey, RuleName, RuleRef, RuleVerdict,
+    SeverityTier,
 )
+from composer.templates.loader import load_jinja_template
 
 _log = logging.getLogger(__name__)
 
@@ -42,34 +55,21 @@ _SEVERITY_MATRIX: dict[tuple[ImpactLevel, LikelihoodLevel], SeverityTier] = {
 
 
 def severity_for(impact: ImpactLevel, likelihood: LikelihoodLevel) -> SeverityTier:
-    """Map an assessed (impact, likelihood) pair to a severity. ``none`` impact -> informational."""
+    """Map an assessed (impact, likelihood) pair to a severity. ``none`` impact -> informational.
+
+    For a backend whose evidence supports that judgement. One whose does not says so by assessing
+    a constant instead — see `Assessment`."""
     if impact == "none":
         return "informational"
     return _SEVERITY_MATRIX[(impact, likelihood)]
 
 
-class FindingsSystemParams(TypedDict):
-    """``autoprove_report_findings_system.j2`` takes no parameters — the instructions are static.
-    Declared empty rather than skipped so the template is still covered by the strict-render fuzz
-    test: adding a ``{{ ... }}`` without declaring it here then fails."""
-
-
-class FindingsPromptParams(TypedDict):
-    """The full, typed context of ``autoprove_report_findings_prompt.j2``. Every key is required."""
-    contract_name: str
-    rule_name: str
-    properties: list[FormalizedProperty]
-    groups: list[PropertyGroup]
-    instances: list[RuleEvidence]
-
-
-_FINDINGS_SYSTEM = TypedTemplate[FindingsSystemParams]("autoprove_report_findings_system.j2")
-_FINDINGS_PROMPT = TypedTemplate[FindingsPromptParams]("autoprove_report_findings_prompt.j2")
-
-
 class FindingDraft(AuthoredContent):
-    """Write up a single confirmed vulnerability finding for a formal-verification rule that the
-    Certora Prover refuted with a concrete counterexample."""
+    """What a findings model must return: the authored sections, a title, and the two axes
+    `severity_for` maps to a tier.
+
+    The model never picks the tier, only the axes, so the severity a reader sees is reproducible
+    from what the model actually said."""
     title: str = Field(description="A one-line title naming the specific broken guarantee.")
     impact_level: ImpactLevel = Field(description=(
         "How severe the consequence is if exploited: 'high' (funds lost or stolen, protocol "
@@ -79,14 +79,129 @@ class FindingDraft(AuthoredContent):
         "code-quality observation)."
     ))
     likelihood_level: LikelihoodLevel = Field(description=(
-        "How reachable the counterexample is: 'high' (any actor, no special preconditions), 'medium' "
+        "How reachable the violation is: 'high' (any actor, no special preconditions), 'medium' "
         "(a specific but reachable state, ordering, or setup), or 'low' (privileged access, an unusual "
         "configuration, or a narrow window)."
     ))
     risk_reasoning: str = Field(description=(
         "One to three sentences justifying the impact and likelihood you assigned, grounded in the "
-        "counterexample."
+        "evidence you were given."
     ))
+
+
+@dataclass(frozen=True)
+class Assessment:
+    """The risk verdict on one draft: the severity, and the record of how it was reached.
+
+    The three axes are provenance — they say what the tier *rests on*, so a reader can see the
+    judgement behind it rather than only its result."""
+    severity: SeverityTier
+    impact: ImpactLevel
+    likelihood: LikelihoodLevel
+    reasoning: str
+
+
+def assess(draft: FindingDraft) -> Assessment:
+    """Severity from the matrix. Every backend's, because every backend's evidence is a violation
+    that happened — what differs is what a violation *is* there, which is what the prompt says."""
+    return Assessment(
+        severity=severity_for(draft.impact_level, draft.likelihood_level),
+        impact=draft.impact_level,
+        likelihood=draft.likelihood_level,
+        reasoning=draft.risk_reasoning,
+    )
+
+
+class FindingsSystemParams(TypedDict):
+    """The full, typed context of ``autoprove_report_findings_system.j2``.
+
+    One template for every backend, because the two halves of a findings system prompt split the
+    same way everywhere: what this evidence *is* is the backend's claim, and how severity is reached
+    and what sections come back is the host's contract. Only the first varies."""
+    #: The backend's own prose: what its evidence is, what it does and does not establish, and how to
+    #: read its own markers. Leads the message; the contract follows it.
+    domain: str
+
+
+class FindingsPromptParams(TypedDict):
+    """The full, typed context of every backend's findings prompt: one violated rule and everything
+    known about it.
+
+    One shape for all of them, because a backend's prompt differs in what it *says* about the
+    evidence, not in what it is given — "the Certora Prover found a concrete counterexample" is a
+    claim about the same fields a fuzzing wheel fills differently. The backend supplies the template;
+    `build_findings` binds it.
+
+    ``properties`` is *every* property the rule formalizes, not a pre-picked one: a rule may jointly
+    formalize several and only the evidence says which actually broke, which is the model's job to
+    determine rather than this layer's to guess."""
+    contract_name: str
+    rule_name: RuleName
+    properties: list[FormalizedProperty]
+    groups: list[PropertyGroup]
+    evidence: list[RuleEvidence]
+    #: The other BAD rows this one write-up answers for — rows the backend could not tell apart from
+    #: this one on the evidence it has. Empty in the ordinary case. Non-empty is itself something the
+    #: write-up should say: the run found one thing and cannot name which check it broke.
+    also_covers: list[RuleName]
+
+
+
+_SYSTEM = TypedTemplate[FindingsSystemParams]("autoprove_report_findings_system.j2")
+
+
+def proof_of_concept(evidence: list[RuleEvidence]) -> str | None:
+    """Every instance's reproducer, labelled once there is more than one — the report shows a single
+    row per rule, so its PoC should cover all of that rule's failing instances.
+
+    Only what this run actually refuted. A declared failure the run did not reproduce has no proof of
+    concept at all — its ground is the author's reading, which rides ``provenance.risk_reasoning`` —
+    and neither does an error that reached no verdict. Never the accounting: what a run spent is a
+    claim about the run, and padding a proof of concept with it leaves a reader unable to see where
+    the evidence ends."""
+    traces = [
+        (e.label, e.counterexample) for e in evidence
+        if e.counterexample and (e.ran is None or e.ran is Outcome.BAD)
+    ]
+    if len(traces) <= 1:
+        return traces[0][1] if traces else None
+    return "\n\n".join(f"# {label or 'counterexample'}\n{cex}" for label, cex in traces)
+
+
+def finding_key(rule: RuleVerdict, evidence: list[RuleEvidence]) -> Hashable:
+    """Identity of the *finding* behind a row: the key the backend stamped on its evidence, else the
+    row itself. Rows sharing a key are written up once — see `build_findings`.
+
+    A backend whose rows are one-to-one with findings stamps nothing and nothing ever collapses. One
+    whose run can conclude something it cannot attribute to a single check fans that conclusion out
+    over every check it covered and stamps them alike, so the run is written up once rather than once
+    per row it took down — for a component's whole property set, dozens of them, each guessing a
+    different check.
+
+    The relation is never inferred from the evidence: rows fanned out from one conclusion look
+    exactly like several checks that failed the same way, and those are two different facts about the
+    program. Only the backend can tell them apart."""
+    stamped = next((e.finding for e in evidence if e.finding is not None), None)
+    return stamped if stamped is not None else rule.ref
+
+
+@dataclass(frozen=True)
+class FindingsPolicy:
+    """What one backend's findings rest on: where its evidence comes from, what the model is told
+    that evidence is, and what it can be asked to conclude from it.
+
+    Values, not hooks: the prose is a string and the prompt is a template — a Rust wheel ships the
+    first across the FFI boundary as JSON, which is the proof it was never behaviour. Only the
+    fetcher is a function, because only it does I/O."""
+
+    fetch_evidence: EvidenceFetcher
+    #: The backend's half of the system message — see `FindingsSystemParams.domain`. Constant across
+    #: this backend's rules; the per-rule context is `prompt`.
+    domain: str
+    #: The user message's template, bound by `build_findings` from `FindingsPromptParams`. The
+    #: backend owns the prose because the prompt is a claim about what its evidence *is*; it does not
+    #: own the binding, because the fields are the same for everyone.
+    prompt: TypedTemplate[FindingsPromptParams]
 
 
 async def build_findings(
@@ -95,13 +210,13 @@ async def build_findings(
     rules: list[RuleVerdict],
     properties: list[FormalizedProperty],
     groups: list[PropertyGroup],
-    fetch_evidence: EvidenceFetcher | None,
+    policy: FindingsPolicy,
     llm: BaseChatModel,
 ) -> list[Finding]:
-    """One `Finding` per violated rule (concurrent, best-effort). Findings are produced only when the
-    backend supplies an evidence fetcher; returns ``[]`` otherwise or when nothing is violated."""
-    if fetch_evidence is None:
-        return []
+    """One `Finding` per violated rule (concurrent, best-effort); ``[]`` when nothing is violated.
+
+    Fewer than one per rule where several rows are stamped as the same finding — see
+    `finding_key`."""
     bad = [r for r in rules if r.outcome == Outcome.BAD]
     if not bad:
         return []
@@ -115,63 +230,77 @@ async def build_findings(
             props_by_ref.setdefault(ref, []).append(p)
     group_by_key: dict[PropertyKey, PropertyGroup] = {k: g for g in groups for k in g.members}
 
-    system = _FINDINGS_SYSTEM.bind({}).render_to(load_jinja_template)
     bound = llm.with_structured_output(FindingDraft)
+    system = _SYSTEM.bind({"domain": policy.domain}).render_to(load_jinja_template)
 
-    async def _one(rule: RuleVerdict) -> Finding | None:
+    async def _evidence(rule: RuleVerdict) -> list[RuleEvidence] | None:
+        """This rule's evidence, or None when fetching it failed — which drops the rule rather than
+        writing it up against nothing."""
         try:
-            instances = await fetch_evidence(rule.name)
-            # Every rule in the report is referenced by >=1 property (collect drops orphans), so pass
-            # ALL of them: the rule may jointly formalize several, and only the counterexample says
-            # which one actually broke — that is the LLM's job, not ours to pre-guess.
+            return await policy.fetch_evidence(rule.ref)
+        except Exception:  # noqa: BLE001 — one rule failing must never fail the report
+            _log.warning("report: evidence fetch failed for rule %r; skipping", rule.name,
+                         exc_info=True)
+            return None
+
+    # Every BAD row's evidence first, so rows whose write-up would be the same write-up collapse
+    # before any of them is paid for. The alternative is a model call per row: one crash a campaign
+    # cannot attribute condemns every check that campaign covered, which for a Crucible component is
+    # its whole property set.
+    fetched = await asyncio.gather(*[_evidence(r) for r in bad])
+    collapsed: dict[Hashable, tuple[RuleVerdict, list[RuleEvidence]]] = {}
+    also: dict[Hashable, list[RuleName]] = {}
+    for rule, evidence in zip(bad, fetched):
+        if evidence is None:
+            continue
+        key = finding_key(rule, evidence)
+        if key in collapsed:
+            also[key].append(rule.name)
+        else:
+            collapsed[key], also[key] = (rule, evidence), []
+
+    async def _one(
+        rule: RuleVerdict, evidence: list[RuleEvidence], covers: list[RuleName],
+    ) -> Finding | None:
+        try:
             props = props_by_ref.get(rule.ref, [])
             # A rule's properties may share a group (some may be in none); dedupe by slug, first-seen order.
             rule_groups = list({g.slug: g for p in props if (g := group_by_key.get(p.key)) is not None}.values())
-            user = _FINDINGS_PROMPT.bind({
-                "contract_name": contract_name,
-                "rule_name": rule.name,
-                "properties": props,
-                "groups": rule_groups,
-                "instances": instances,
+            user = policy.prompt.bind({
+                "contract_name": contract_name, "rule_name": rule.name, "properties": props,
+                "groups": rule_groups, "evidence": evidence, "also_covers": covers,
             }).render_to(load_jinja_template)
             draft = await bound.ainvoke([SystemMessage(system), HumanMessage(user)])
             assert isinstance(draft, FindingDraft)
-            return _compose(rule, draft, instances, rule_groups)
+            return _compose(rule, draft, evidence, rule_groups)
         except Exception:  # noqa: BLE001 — one finding failing must never fail the report
             _log.warning("report: finding synthesis failed for rule %r; skipping", rule.name, exc_info=True)
             return None
 
     sem = asyncio.Semaphore(_MAX_CONCURRENT_FINDING_CALLS)
 
-    async def _bounded(rule: RuleVerdict) -> Finding | None:
+    async def _bounded(key: Hashable) -> Finding | None:
         async with sem:
-            return await _one(rule)
+            rule, evidence = collapsed[key]
+            return await _one(rule, evidence, also[key])
 
-    findings = await asyncio.gather(*[_bounded(r) for r in bad])
+    findings = await asyncio.gather(*[_bounded(k) for k in collapsed])
     return [f for f in findings if f is not None]
-
-
-def _proof_of_concept(instances: list[RuleEvidence]) -> str | None:
-    """Every instance's counterexample, labelled once there is more than one — the report shows a
-    single row per rule, so its PoC should cover all of that rule's failing instances."""
-    traces = [(i.label, i.counterexample) for i in instances if i.counterexample]
-    if len(traces) <= 1:
-        return traces[0][1] if traces else None
-    return "\n\n".join(f"# {label or 'counterexample'}\n{cex}" for label, cex in traces)
 
 
 def _compose(
     rule: RuleVerdict,
     draft: FindingDraft,
-    instances: list[RuleEvidence],
+    evidence: list[RuleEvidence],
     groups: list[PropertyGroup],
 ) -> Finding:
+    risk = assess(draft)
     return Finding(
         title=draft.title,
-        severity=severity_for(draft.impact_level, draft.likelihood_level),
+        severity=risk.severity,
         content=IssueContent(
             **{f: getattr(draft, f) for f in AuthoredContent.model_fields},
-            proof_of_concept=_proof_of_concept(instances),
+            proof_of_concept=proof_of_concept(evidence),
             references=[rule.prover_link] if rule.prover_link else None,
         ),
         provenance=FindingProvenance(
@@ -180,8 +309,8 @@ def _compose(
             outcome=rule.outcome,
             group_slugs=[g.slug for g in groups],
             prover_link=rule.prover_link,
-            impact=draft.impact_level,
-            likelihood=draft.likelihood_level,
-            risk_reasoning=draft.risk_reasoning,
+            impact=risk.impact,
+            likelihood=risk.likelihood,
+            risk_reasoning=risk.reasoning,
         ),
     )

--- a/composer/spec/source/report/render.py
+++ b/composer/spec/source/report/render.py
@@ -29,9 +29,10 @@ from collections.abc import Sequence
 from composer.spec.gen_types import TypedTemplate
 from composer.templates.loader import load_jinja_template
 from composer.spec.source.report.schema import (
-    AutoProverReport, ComponentName, CoverageReport, CurtailedComponent, Finding,
-    FormalizedProperty, GaveUpComponent, GroupStatus, Outcome, PropertyGroup, PropertyKey,
-    ReportBackend, RuleRef, RuleVerdict, SkippedClaim, SourceEditRecord,
+    AutoProverReport, ComponentName, CoverageReport, CurtailedComponent, ExpectedFailure,
+    Finding, FormalizedProperty, GaveUpComponent, GroupStatus, Outcome, PropertyGroup,
+    PropertyKey, ReportBackend, RuleRef, RuleVerdict, SkippedClaim, SourceEditRecord,
+    UnreproducedExpectedFailure,
 )
 
 
@@ -143,6 +144,12 @@ class ChipView(TypedDict):
     n: int
 
 
+class ExpectedFailureView(TypedDict):
+    kind: str
+    reason: str
+    ran: str | None
+
+
 class RowView(TypedDict):
     name: str
     label: str
@@ -153,6 +160,10 @@ class RowView(TypedDict):
     #: Backend diagnostic for a non-GOOD row (e.g. the fuzzer's counterexample / failed-assertion
     #: message). ``None`` when the backend supplied none.
     message: str | None
+    #: What the run spent and covered. ``None`` when the backend does not report it.
+    accounting: str | None
+    #: Author-marked expected failure. ``ran`` is set only when this run did not reproduce it.
+    expected_failure: ExpectedFailureView | None
 
 
 class GroupView(TypedDict):
@@ -260,6 +271,20 @@ def _is_url(link: str) -> bool:
     return link.startswith("http://") or link.startswith("https://")
 
 
+def _expected_failure_view(
+    expected_failure: ExpectedFailure | None, unit_labels: dict[Outcome, str],
+) -> ExpectedFailureView | None:
+    if expected_failure is None:
+        return None
+    if isinstance(expected_failure, UnreproducedExpectedFailure):
+        return {
+            "kind": "unreproduced",
+            "reason": expected_failure.reason,
+            "ran": unit_labels[expected_failure.ran],
+        }
+    return {"kind": "reproduced", "reason": expected_failure.reason, "ran": None}
+
+
 def _link_view(link: str | None) -> LinkView:
     """How a run link renders: a clickable URL, a plain 'local run' label, or an em-dash."""
     if link and _is_url(link):
@@ -323,6 +348,8 @@ def _group_view(
             "link": _link_view(rule.prover_link if rule else None),
             "descriptions": descriptions[ref],
             "message": rule.message if rule else None,
+            "accounting": rule.accounting if rule else None,
+            "expected_failure": _expected_failure_view(rule.expected_failure, unit_labels) if rule else None,
         })
     return {
         "slug": group.slug,

--- a/composer/spec/source/report/schema.py
+++ b/composer/spec/source/report/schema.py
@@ -248,13 +248,14 @@ adds its own literal here, plus its wording in ``report/render.py``."""
 #
 # A `Finding` is a title, a severity, and a write-up, composed by the shared loop in
 # ``report/findings.py`` from the evidence the backend hands back for a violated rule and the
-# properties/groups that rule breaks. The field
+# properties/groups the covered rule(s) break. The field
 # set follows the "Submit Issue" body of the Sherlock Audit Engine API — schema at
 # https://api-audit-engine.sherlock.xyz/v1/docs/public — so a finding maps cleanly onto a submission,
 # but the source ``locations`` a submission needs
 # (``{owner}/{repo}`` / file / line) are NOT produced here: a run knows only local paths and CVL-spec
 # lines, so the submission layer reconstructs locations from the engagement scope + the counterexample.
-# The report-time locator is on ``provenance`` (rule name, spec file, prover-run link).
+# The report-time locator is on ``provenance`` (rule name, spec file, prover-run link, and
+# ``covers`` when several rows share one finding).
 # ---------------------------------------------------------------------------
 
 type SeverityTier = Literal["critical", "high", "medium", "low", "informational"]
@@ -268,9 +269,9 @@ class AuthoredContent(BaseModel):
     """The written sections of a finding. These are what the findings LLM produces, so the field
     descriptions double as its instructions."""
     summary: str = Field(description="A one to three sentence summary of the finding.")
-    description: str = Field(description="The full technical explanation of the vulnerability and how it manifests, grounded in the counterexample.")
+    description: str = Field(description="The full technical explanation of the vulnerability and how it manifests, grounded in the evidence you were given.")
     impact: str = Field(description="The concrete consequence if the issue is exploited — funds at risk, denial of service, data exposure, and so on.")
-    attack_path: str | None = Field(default=None, description="The step-by-step path from the counterexample that triggers the issue, when one applies.")
+    attack_path: str | None = Field(default=None, description="The step-by-step path that triggers the issue, only when the evidence carries a reproducing sequence. Omit this field when nothing reproduced.")
     assumptions_and_uncertainties: str | None = Field(default=None, description="Assumptions the finding relies on, and anything you are uncertain about.")
 
 
@@ -292,6 +293,10 @@ class FindingProvenance(BaseModel):
     likelihood: LikelihoodLevel | None = None
     #: The findings LLM's justification for the assessed impact and likelihood.
     risk_reasoning: str | None = None
+    #: Every violated rule this write-up answers for, when the backend stamped several rows as
+    #: one finding. Empty in the ordinary one-row case. Each entry is ``(spec_file, name)``;
+    #: ``rule_name`` / ``spec_file`` above are the first of them.
+    covers: list[RuleRef] = Field(default_factory=list)
 
 
 class Finding(BaseModel):
@@ -328,6 +333,7 @@ class AutoProverReport(BaseModel):
     #: formalization (Lean proofs et al.), written to disk by the artifact store.
     verification_artifacts: list[VerificationArtifactRecord] = Field(default_factory=list)
     coverage: CoverageReport
-    #: Audit issues for violated rules (one per BAD rule). Empty when nothing is violated or the
-    #: backend declares no findings policy — see ``Formalizer.findings_policy``.
+    #: Audit issues for violated rules. One per BAD rule, except that rows the backend stamped as
+    #: the same finding collapse to one. Empty when nothing is violated or the backend declares no
+    #: findings policy — see ``Formalizer.findings_policy``.
     findings: list[Finding] = Field(default_factory=list)

--- a/composer/spec/source/report/schema.py
+++ b/composer/spec/source/report/schema.py
@@ -246,9 +246,9 @@ adds its own literal here, plus its wording in ``report/render.py``."""
 # ---------------------------------------------------------------------------
 # Findings — violated rules surfaced as audit issues.
 #
-# A `Finding` records a violated rule (a `RuleVerdict` with ``outcome == Outcome.BAD``) as an audit
-# issue: a ``title``, a ``severity``, and the ``content`` write-up, synthesized from the rule's
-# counterexample analysis and the properties/groups it breaks (see ``report/findings.py``). The field
+# A `Finding` is a title, a severity, and a write-up, composed by the shared loop in
+# ``report/findings.py`` from the evidence the backend hands back for a violated rule and the
+# properties/groups that rule breaks. The field
 # set follows the "Submit Issue" body of the Sherlock Audit Engine API — schema at
 # https://api-audit-engine.sherlock.xyz/v1/docs/public — so a finding maps cleanly onto a submission,
 # but the source ``locations`` a submission needs
@@ -328,7 +328,6 @@ class AutoProverReport(BaseModel):
     #: formalization (Lean proofs et al.), written to disk by the artifact store.
     verification_artifacts: list[VerificationArtifactRecord] = Field(default_factory=list)
     coverage: CoverageReport
-    #: Violated rules surfaced as audit issues (one per BAD rule; empty
-    #: when nothing is violated, when synthesis was unavailable, or for a non-prover backend). Prose
-    #: is synthesized at report time — see ``report/findings.py``.
+    #: Audit issues for violated rules (one per BAD rule). Empty when nothing is violated or the
+    #: backend declares no findings policy — see ``Formalizer.findings_policy``.
     findings: list[Finding] = Field(default_factory=list)

--- a/composer/spec/source/report/schema.py
+++ b/composer/spec/source/report/schema.py
@@ -11,7 +11,7 @@ The report is a **per-run snapshot** — no guarantee that property/group slugs 
 runs. Bump `schema_version` on a breaking change.
 """
 from enum import Enum
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
@@ -74,6 +74,27 @@ class GroupStatus(str, Enum):
     UNKNOWN = "UNKNOWN"
 
 
+class ReproducedExpectedFailure(BaseModel):
+    """The author marked this check expected to fail, and this run reproduced it."""
+    kind: Literal["reproduced"] = "reproduced"
+    reason: str
+
+
+class UnreproducedExpectedFailure(BaseModel):
+    """The author marked this check expected to fail, but this run did not hit it.
+
+    ``ran`` is the outcome the run actually reached (never BAD)."""
+    kind: Literal["unreproduced"] = "unreproduced"
+    reason: str
+    ran: Outcome
+
+
+ExpectedFailure = Annotated[
+    ReproducedExpectedFailure | UnreproducedExpectedFailure,
+    Field(discriminator="kind"),
+]
+
+
 class RuleVerdict(BaseModel):
     """One CVL rule/invariant (or foundry test) and its outcome — the verdict table the report
     references by `RuleRef`. Stored once even when properties across several groups are formalized
@@ -91,6 +112,14 @@ class RuleVerdict(BaseModel):
         default=None,
         description="Human-readable explanation of a non-GOOD outcome (e.g. the fuzzer's "
         "counterexample / failed-assertion message). Diagnostics only; may be absent.",
+    )
+    accounting: str | None = Field(
+        default=None,
+        description="What the run spent and covered. Absent when the backend does not report it.",
+    )
+    expected_failure: ExpectedFailure | None = Field(
+        default=None,
+        description="Author-marked expected failure, and whether this run reproduced it.",
     )
 
     @property
@@ -246,16 +275,12 @@ adds its own literal here, plus its wording in ``report/render.py``."""
 # ---------------------------------------------------------------------------
 # Findings — violated rules surfaced as audit issues.
 #
-# A `Finding` is a title, a severity, and a write-up, composed by the shared loop in
-# ``report/findings.py`` from the evidence the backend hands back for a violated rule and the
-# properties/groups the covered rule(s) break. The field
-# set follows the "Submit Issue" body of the Sherlock Audit Engine API — schema at
-# https://api-audit-engine.sherlock.xyz/v1/docs/public — so a finding maps cleanly onto a submission,
-# but the source ``locations`` a submission needs
-# (``{owner}/{repo}`` / file / line) are NOT produced here: a run knows only local paths and CVL-spec
-# lines, so the submission layer reconstructs locations from the engagement scope + the counterexample.
-# The report-time locator is on ``provenance`` (rule name, spec file, prover-run link, and
-# ``covers`` when several rows share one finding).
+# A `Finding` is a title, a severity, and a write-up from ``report/findings.py``. The field set
+# follows the Sherlock Audit Engine "Submit Issue" body
+# (https://api-audit-engine.sherlock.xyz/v1/docs/public). Source ``locations`` are not produced
+# here — a run knows only local paths — so the submission layer reconstructs them. The
+# report-time locator is on ``provenance`` (rule, spec file, prover-run link, and ``covers``
+# when several rows share one finding).
 # ---------------------------------------------------------------------------
 
 type SeverityTier = Literal["critical", "high", "medium", "low", "informational"]
@@ -293,9 +318,9 @@ class FindingProvenance(BaseModel):
     likelihood: LikelihoodLevel | None = None
     #: The findings LLM's justification for the assessed impact and likelihood.
     risk_reasoning: str | None = None
-    #: Every violated rule this write-up answers for, when the backend stamped several rows as
-    #: one finding. Empty in the ordinary one-row case. Each entry is ``(spec_file, name)``;
-    #: ``rule_name`` / ``spec_file`` above are the first of them.
+    #: Every violated rule this write-up answers for when several rows share one finding.
+    #: Empty for a one-row finding. Each entry is ``(spec_file, name)``; ``rule_name`` /
+    #: ``spec_file`` above are the first of them.
     covers: list[RuleRef] = Field(default_factory=list)
 
 
@@ -333,7 +358,7 @@ class AutoProverReport(BaseModel):
     #: formalization (Lean proofs et al.), written to disk by the artifact store.
     verification_artifacts: list[VerificationArtifactRecord] = Field(default_factory=list)
     coverage: CoverageReport
-    #: Audit issues for violated rules. One per BAD rule, except that rows the backend stamped as
-    #: the same finding collapse to one. Empty when nothing is violated or the backend declares no
-    #: findings policy — see ``Formalizer.findings_policy``.
+    #: Audit issues for violated rules. One per BAD rule, or one per stamped finding when
+    #: several rows share a key. Empty when nothing is violated or the backend has no findings
+    #: policy — see ``Formalizer.findings_policy``.
     findings: list[Finding] = Field(default_factory=list)

--- a/composer/spec/types.py
+++ b/composer/spec/types.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, Protocol, Literal
 # or "Structural Invariants".
 # ``PropertyTitle``: a property's unique snake_case title — the key in a
 # component's ``property_rules`` mapping.
+# ``FindingKey``: opaque stamp grouping several checks under one finding. Compared
+# across the whole report; not a check name.
 #
 # ``SolidityIdentifier`` and ``RustIdentifier`` are **siblings** under
 # ``SourceIdentifier``; every other name is a sibling of the rest. Passing one
@@ -37,6 +39,7 @@ if TYPE_CHECKING:
     class CheckName(str): ...
     class ComponentName(str): ...
     class PropertyTitle(str): ...
+    class FindingKey(str): ...
 else:
     SourceIdentifier = str
     SolidityIdentifier = str
@@ -46,6 +49,7 @@ else:
     CheckName = str
     ComponentName = str
     PropertyTitle = str
+    FindingKey = str
 
 #: A ``CheckName`` as the CVL/prover side speaks it: a rule/invariant identifier as it appears in
 #: the prover report and in a component's ``property_rules`` mapping. The same type, not a

--- a/composer/templates/autoprove_report.html.j2
+++ b/composer/templates/autoprove_report.html.j2
@@ -239,6 +239,14 @@ ul.claims li { margin-bottom: 4px; }
     white-space: pre-wrap;
     word-break: break-word;
 }
+.accounting, .expected-failure {
+    margin-top: 6px;
+    color: var(--muted-fg);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
 section.gaps .desc { color: var(--muted-fg); margin: 6px 0 12px; font-size: 13px; }
 section.gaps p.note { margin: 4px 0 8px; font-size: 13px; }
 section.gaps details { margin: 8px 0 14px; }
@@ -402,7 +410,15 @@ pre.diff .d-file { color: var(--muted-fg); font-weight: 600; }
           <ul class="claims">{% for d in row.descriptions %}<li>{{ d }}</li>{% endfor %}</ul>
           {%- elif row.descriptions %}{{ row.descriptions[0] }}
           {%- else %}<span class="muted">(no inferred description)</span>{%- endif %}
+          {%- if row.expected_failure %}
+          <div class="expected-failure">Expected to fail: {{ row.expected_failure.reason }}
+            {%- if row.expected_failure.kind == "unreproduced" %}
+            <br>Not reproduced (this run reported {{ row.expected_failure.ran }}).
+            {%- endif %}
+          </div>
+          {%- endif %}
           {%- if row.message %}<div class="finding">{{ row.message }}</div>{%- endif %}
+          {%- if row.accounting %}<div class="accounting">{{ row.accounting }}</div>{%- endif %}
         </td>
         {%- if has_links %}
         <td class="col-link">

--- a/composer/templates/autoprove_report_findings_prompt.j2
+++ b/composer/templates/autoprove_report_findings_prompt.j2
@@ -14,12 +14,12 @@ Audit-level claim(s) it belongs to:
   - {{ g.title }}: {{ g.description }}
 {%- endfor %}
 {% endif %}
-{% if instances -%}
-{% if instances | length > 1 -%}
-This rule failed for {{ instances | length }} separate instantiations. They may share one root cause or
+{% if evidence -%}
+{% if evidence | length > 1 -%}
+This rule failed for {{ evidence | length }} separate instantiations. They may share one root cause or
 be genuinely different problems — read them all and say which is the case.
 {% endif -%}
-{% for i in instances %}
+{% for i in evidence %}
 --- Failing instantiation{% if i.label %}: {{ i.label }}{% endif %} ---
 {% if i.analysis -%}
 Prover's counterexample analysis (root cause + suggested fix), produced during the run:

--- a/composer/templates/autoprove_report_findings_prover_domain.j2
+++ b/composer/templates/autoprove_report_findings_prover_domain.j2
@@ -1,0 +1,14 @@
+You are a smart-contract security auditor writing up a single, confirmed finding for an audit
+report. A formal-verification rule was VIOLATED: the Certora Prover found a concrete counterexample
+refuting a property the code was expected to satisfy. A violation is hard evidence the property does
+not hold, so treat this as a real, confirmed issue — not a maybe.
+
+You are given the violated rule, the natural-language properties it formalizes, the audit-level
+claim(s) it belongs to, the prover's own root-cause analysis of the counterexample, and — when
+available — the counterexample trace. A single rule may jointly formalize several properties, but the
+counterexample violates one specific behavior: ground the write-up in what the counterexample actually
+shows, and address the property it truly breaks rather than assuming a particular one.
+
+A prover counterexample proves the property CAN be broken, so do not rate a genuine break as impact
+'none' merely because it looks hard to reach — lower the Likelihood instead. Reserve impact 'none' for
+a break with no real-world consequence.

--- a/composer/templates/autoprove_report_findings_rust_prompt.j2
+++ b/composer/templates/autoprove_report_findings_rust_prompt.j2
@@ -1,0 +1,58 @@
+Program: {{ contract_name }}
+
+Failing check: {{ rule_name }}
+{% if also_covers %}
+THIS EVIDENCE COULD NOT BE ATTRIBUTED TO ONE CHECK. The run reported it against {{ also_covers | length + 1 }}
+checks it covered, because nothing it reported says which of them was actually broken:
+{% for c in also_covers %}
+  - {{ c }}
+{%- endfor %}
+
+That is the finding. Say plainly that the run found a real violation it cannot place, name what it
+did report, and do not pick one of these checks and write it up as though the violation were its.
+{% endif %}
+{% if properties -%}
+Properties this check verifies (the violation breaks at least one of them — determine which):
+{% for p in properties %}
+  - ({{ p.sort }}) {{ p.title }}: {{ p.description }}
+{%- endfor %}
+{% endif -%}
+{% if groups -%}
+Audit-level claim(s) it belongs to:
+{% for g in groups %}
+  - {{ g.title }}: {{ g.description }}
+{%- endfor %}
+{% endif %}
+{% if evidence -%}
+{% for o in evidence %}
+--- What the run observed: {{ o.label }} ---
+{# No separate run outcome means the evidence is a refutation and nothing else — the same rule
+   `proof_of_concept` filters on. #}
+{% set reproduced = o.ran is none or o.ran.value == "BAD" -%}
+{% if o.declared -%}
+DECLARED BY THE AUTHOR as expected to fail. Their reason:
+{{ o.declared }}
+{% if reproduced -%}
+The run also reproduced it, so the evidence below stands behind that claim.
+{%- else -%}
+The run did NOT reproduce it — it reported {{ o.ran.value }}. The author's reason above is the only
+evidence there is. Do not describe a counterexample; say what the claim rests on.
+{%- endif %}
+{% endif -%}
+{% if reproduced %}
+What the run found, with whatever reproduces it:
+{{ o.counterexample }}
+{%- elif not o.declared and o.counterexample %}
+The run reported {{ o.ran.value }} for this check. What it said:
+{{ o.counterexample }}
+{%- endif %}
+{% if o.accounting %}
+What the run behind this spent and covered — how much weight its result carries, and what to say in
+`assumptions_and_uncertainties` about what was and was not reached:
+{{ o.accounting }}
+{%- endif %}
+{%- endfor %}
+{%- else -%}
+(No observation was captured for this check — reason only from the properties above, and say that no
+evidence was recorded.)
+{%- endif %}

--- a/composer/templates/autoprove_report_findings_rust_prompt.j2
+++ b/composer/templates/autoprove_report_findings_rust_prompt.j2
@@ -35,9 +35,9 @@ Audit-level claim(s) it belongs to:
 {# No separate run outcome means the evidence is a refutation and nothing else — the same rule
    `proof_of_concept` filters on. #}
 {% set reproduced = o.ran is none or o.ran.value == "BAD" -%}
-{% if o.declared -%}
-DECLARED BY THE AUTHOR as expected to fail. Their reason:
-{{ o.declared }}
+{% if o.expected_failure_reason -%}
+The author marked this check expected to fail. Their reason:
+{{ o.expected_failure_reason }}
 {% if reproduced -%}
 The run also reproduced it, so the evidence below stands behind that claim.
 {%- else -%}
@@ -48,7 +48,7 @@ evidence there is. Do not describe a counterexample; say what the claim rests on
 {% if reproduced %}
 What the run found, with whatever reproduces it:
 {{ o.counterexample }}
-{%- elif not o.declared and o.counterexample %}
+{%- elif not o.expected_failure_reason and o.counterexample %}
 The run reported {{ o.ran.value }} for this check. What it said:
 {{ o.counterexample }}
 {%- endif %}

--- a/composer/templates/autoprove_report_findings_rust_prompt.j2
+++ b/composer/templates/autoprove_report_findings_rust_prompt.j2
@@ -1,18 +1,24 @@
 Program: {{ contract_name }}
 
-Failing check: {{ rule_name }}
 {% if also_covers %}
-THIS EVIDENCE COULD NOT BE ATTRIBUTED TO ONE CHECK. The run reported it against {{ also_covers | length + 1 }}
+THIS EVIDENCE COULD NOT BE ATTRIBUTED TO ONE CHECK. The run reported it against {{ also_covers | length }}
 checks it covered, because nothing it reported says which of them was actually broken:
 {% for c in also_covers %}
   - {{ c }}
 {%- endfor %}
 
-That is the finding. Say plainly that the run found a real violation it cannot place, name what it
-did report, and do not pick one of these checks and write it up as though the violation were its.
+That is the finding. Say plainly that the run found a real violation it cannot place among these
+checks, name what it did report, and do not pick one of them and write it up as though the
+violation were its.
+{% else %}
+Failing check: {{ rule_name }}
 {% endif %}
 {% if properties -%}
+{% if also_covers %}
+Properties these checks verify:
+{% else %}
 Properties this check verifies (the violation breaks at least one of them — determine which):
+{% endif %}
 {% for p in properties %}
   - ({{ p.sort }}) {{ p.title }}: {{ p.description }}
 {%- endfor %}

--- a/composer/templates/autoprove_report_findings_system.j2
+++ b/composer/templates/autoprove_report_findings_system.j2
@@ -17,10 +17,6 @@ Likelihood — how reachable the break is in practice:
   - medium: needs a specific but reachable state, ordering, or non-trivial-yet-feasible setup.
   - low:    needs privileged access, an unusual configuration, or a narrow / costly window.
 
-Rate what the evidence you were given establishes, not the worst thing the code could conceivably do.
-Where that evidence does not establish that a real actor could reach the failure or profit from it,
-that belongs in the rating — say so in your reasoning rather than assuming the worst.
-
 WHAT TO PRODUCE
 
 - Ground every sentence in the evidence you are given. Do not invent an attack path, a victim, an
@@ -31,4 +27,4 @@ WHAT TO PRODUCE
 - `attack_path` is the reproducing sequence restated in the program's terms, and only when the
   evidence carries one. Leave it out for a finding nothing reproduced.
 - The title names the broken guarantee, not the check that caught it: "Initialization is accepted
-  without the authority's signature", not "c_authority_must_sign fails".
+  without the authority's signature", not the identifier of the failing check.

--- a/composer/templates/autoprove_report_findings_system.j2
+++ b/composer/templates/autoprove_report_findings_system.j2
@@ -1,17 +1,10 @@
-You are a smart-contract security auditor writing up a single, confirmed finding for an audit
-report. A formal-verification rule was VIOLATED: the Certora Prover found a concrete counterexample
-refuting a property the code was expected to satisfy. A violation is hard evidence the property does
-not hold, so treat this as a real, confirmed issue — not a maybe.
+{{ domain }}
 
-You are given the violated rule, the natural-language properties it formalizes, the audit-level
-claim(s) it belongs to, the prover's own root-cause analysis of the counterexample, and — when
-available — the counterexample trace. A single rule may jointly formalize several properties, but the
-counterexample violates one specific behavior: ground the write-up in what the counterexample actually
-shows, and address the property it truly breaks rather than assuming a particular one.
+HOW SEVERITY IS REACHED
 
 You assess two axes; the report computes the severity from them, so judge each on its own merits.
 
-Impact — what an attacker gains or users lose when the property break is exploited:
+Impact — what an attacker gains or users lose when the break is exploited:
   - high:   direct loss or theft of funds, protocol insolvency, permanently frozen assets, or
             unauthorized control of privileged functionality.
   - medium: limited, conditional, or recoverable value loss; temporary denial of service; incorrect
@@ -19,15 +12,23 @@ Impact — what an attacker gains or users lose when the property break is explo
   - low:    no funds at risk; a minor deviation from the intended guarantee.
   - none:   no real-world exploit path at all — a specification or code-quality observation.
 
-Likelihood — how reachable the counterexample is in practice:
+Likelihood — how reachable the break is in practice:
   - high:   exploitable by any actor with no special preconditions or privileged access.
   - medium: needs a specific but reachable state, ordering, or non-trivial-yet-feasible setup.
   - low:    needs privileged access, an unusual configuration, or a narrow / costly window.
 
-A prover counterexample proves the property CAN be broken, so do not rate a genuine break as impact
-'none' merely because it looks hard to reach — lower the Likelihood instead. Reserve impact 'none' for
-a break with no real-world consequence.
+Rate what the evidence you were given establishes, not the worst thing the code could conceivably do.
+Where that evidence does not establish that a real actor could reach the failure or profit from it,
+that belongs in the rating — say so in your reasoning rather than assuming the worst.
 
-Ground every claim in the supplied analysis and counterexample. Do not invent addresses, values,
-function names, or exploit steps beyond what the material supports; if the material is thin, keep the
-finding modest rather than fabricating specifics.
+WHAT TO PRODUCE
+
+- Ground every sentence in the evidence you are given. Do not invent an attack path, a victim, an
+  amount, an address, a function name, or a precondition that is not in it. Where the material is
+  thin, keep the finding modest rather than fabricating specifics.
+- `impact` is what breaks if this holds — the guarantee lost, in the program's own terms. If the
+  evidence does not say who could profit or how, say what is not established rather than guessing.
+- `attack_path` is the reproducing sequence restated in the program's terms, and only when the
+  evidence carries one. Leave it out for a finding nothing reproduced.
+- The title names the broken guarantee, not the check that caught it: "Initialization is accepted
+  without the authority's signature", not "c_authority_must_sign fails".

--- a/docs/formalization-abstraction.md
+++ b/docs/formalization-abstraction.md
@@ -500,25 +500,23 @@ Evidence is shared too. Every backend hands back `RuleEvidence`:
 | `counterexample` | What reproduces it: a counterexample trace, a crashing input, an assertion message |
 | `ran` | The run's own outcome, before any authored declaration is folded into the one the report shows |
 | `accounting` | What the run spent and how far it reached — what makes a result weigh something |
-| `declared` | Why the author declared this failure expected, when they did |
-| `finding` | Which finding this belongs to, when one piece of evidence condemns several checks |
+| `declared` | Why the author marked this check expected to fail (`expect_check_failure` / `expect_rule_failure`), when they did |
+| `finding` | Opaque key grouping several checks under one conclusion |
 
-Backends differ in what they can *fill*, not in the shape: a prover has an `analysis` and a trace, a
-fuzzing wheel has a crashing input and an `accounting`. Absence always means "this run recorded
-nothing of that kind", so the fields mean the same thing whoever produced them and a prompt can say
-what is missing instead of guessing. An earlier design made this a type parameter; it bought nothing,
-because the only code that ever reads a field is the backend's own prompt.
+Backends differ in what they can *fill*, not in the shape: one fills `analysis` and a counterexample,
+another fills `accounting` and a reproducer. Absence always means "this run recorded nothing of that
+kind", so the fields mean the same thing whoever produced them and a prompt can say what is missing
+instead of guessing.
 
-What a backend supplies is a `FindingsPolicy` — three things, only one of which is a function. It
-is a record rather than a table of hooks, which is why the name says *policy*: a Rust wheel ships
-one of its fields across the FFI boundary as JSON (`FindingsDeclaration`), and anything that
-survives serialization was never behaviour.
+What a backend supplies is a `FindingsPolicy` — three things, only one of which is a function. A
+Rust-authored backend ships its `domain` across the FFI as JSON (`FindingsDeclaration`); the host
+owns the write-up loop and binds the prompt.
 
 | Field | Why it is the backend's |
 | --- | --- |
 | `fetch_evidence` | Keyed by `RuleRef` — `(file, name)`, how the report identifies a row. A name alone does not: one deliverable can hold several components' checks, and two authors given the same property write the same name. The only hook, because it is the only one that does I/O |
 | `domain` | The *domain* half of the system message — a claim about what the evidence *is*. "The Certora Prover found a concrete counterexample" is true of one backend's and false of another's. The host wraps it in the shared contract (how severity is reached, which sections come back), so a backend restates none of that |
-| `prompt` | A `TypedTemplate[FindingsPromptParams]`, not a callable. Both backends' prompts take the same fields — rule, properties, groups, evidence, `also_covers` — so the backend owns the prose and `build_findings` owns the binding |
+| `prompt` | A `TypedTemplate[FindingsPromptParams]`. The Prover supplies its own; Rust-authored backends share one host template. The loop binds the same fields either way. |
 
 Severity is not among them. Every backend's findings are rated the same way: the model assesses
 impact and likelihood on the one `FindingDraft`, and `severity_for` maps the pair through a fixed
@@ -531,15 +529,17 @@ and is now shared: `proof_of_concept` joins the reproducers from instances the r
 (labelled once there is more than one), and `finding_key` reads the key the backend stamped.
 
 That key is what keeps the cost proportional to what was *found* rather than to how many rows it took
-down. A fuzz campaign covers a component's whole property set, and a crash it cannot place condemns
-every check in it — on a klend-sized component that is 26 BAD rows of one crash. Written up per row
-it would be 26 heavy-model calls publishing 26 accounts of the same finding, each guessing a
-different check it might have been.
+down. When a backend cannot attribute one conclusion to one check, it stamps the same key on every
+row that conclusion covers; the host writes those rows up once, against the union of their properties
+and groups. The persisted `Finding` records the covered refs on `provenance.covers`, so
+`report.json` names every row the write-up answers for. The key is compared across the whole report,
+so a per-component local id will merge independent conclusions.
 
 The relation is deliberately *stamped* and never inferred from matching evidence: rows fanned out
 from one conclusion look exactly like several checks that failed the same way, and those are two
-different facts about the program. Only whatever produced the verdicts knows which it is — a Rust
-wheel says so on `Verdict.finding`, and it stamps it at the point it decides to fan out.
+different facts about the program. Only whatever produced the verdicts knows which it is — a
+Rust-authored backend says so on `Verdict.finding`, and it stamps it at the point it decides to fan
+out.
 
 Returning `None` is how a backend opts out; the report then builds no findings for it and never
 starts the heavy model. `outcomes` is passed because a backend whose evidence is in its own results

--- a/docs/formalization-abstraction.md
+++ b/docs/formalization-abstraction.md
@@ -152,12 +152,15 @@ class Formalizer[FormT: BackendResult, U: FeatureUnit](ABC):
     def extra_report_inputs(self) -> list[ReportComponentInput[FormT]]:
         return []                     # synthetic report rows; default none
 
+    def findings_policy(self, outcomes) -> FindingsPolicy | None:
+        return None                   # how to write violated rules up; default none
+
     async def finalize(self, outcomes, run) -> None:
         return None                   # run-level artifacts from the full outcome set; default none
 ```
 
 The contract is deliberately small — one required producer (`formalize`), one required
-reader (`fetch_verdicts`), and two optional hooks. The second type parameter `U` is the
+reader (`fetch_verdicts`), and three optional hooks. The second type parameter `U` is the
 *formalized unit* the backend consumes (EVM's `ContractComponentInstance`, a Rust backend's
 `FeatureUnit`): the backend reads its concrete unit's members without casts while the driver stays
 unit-agnostic. Crucially, a `Formalizer` is **immutable and fully constructed** by whatever produced
@@ -473,7 +476,78 @@ to one entry, and uses `Verdict.merge` (priority `BAD > ERROR > TIMEOUT > UNKNOW
 roll up multiple results for one rule. Foundry's fetcher instead reads pass/fail straight off
 the result with no run service — same protocol, different source.
 
-### 4.6 `finalize` — run-level artifact
+### 4.6 `findings_policy` — writing a violation up
+
+```python
+def findings_policy(self, outcomes) -> FindingsPolicy | None:
+    return prover_findings(self._evidence)      # None to produce no findings
+```
+
+`fetch_verdicts` answers "did each rule hold". Findings answer "what did this run find", which is
+the report's first section. Both read the same BAD rows; they differ in what they say about one.
+
+The write-up loop is shared ([report/findings.py](../composer/spec/source/report/findings.py)):
+walk the BAD rules, resolve each one's properties and the audit groups they sit in, group the rows
+that share one finding, ask a model, build the proof of concept, bound the concurrency, compose the
+`Finding`.
+
+Evidence is shared too. Every backend hands back `RuleEvidence`:
+
+| Field | |
+| --- | --- |
+| `label` | Which instance, where a rule can fail more than once — a parametric binding for the prover, the component for a per-component backend |
+| `analysis` | The backend's account of *why* the check failed, where it produces one |
+| `counterexample` | What reproduces it: a counterexample trace, a crashing input, an assertion message |
+| `ran` | The run's own outcome, before any authored declaration is folded into the one the report shows |
+| `accounting` | What the run spent and how far it reached — what makes a result weigh something |
+| `declared` | Why the author declared this failure expected, when they did |
+| `finding` | Which finding this belongs to, when one piece of evidence condemns several checks |
+
+Backends differ in what they can *fill*, not in the shape: a prover has an `analysis` and a trace, a
+fuzzing wheel has a crashing input and an `accounting`. Absence always means "this run recorded
+nothing of that kind", so the fields mean the same thing whoever produced them and a prompt can say
+what is missing instead of guessing. An earlier design made this a type parameter; it bought nothing,
+because the only code that ever reads a field is the backend's own prompt.
+
+What a backend supplies is a `FindingsPolicy` — three things, only one of which is a function. It
+is a record rather than a table of hooks, which is why the name says *policy*: a Rust wheel ships
+one of its fields across the FFI boundary as JSON (`FindingsDeclaration`), and anything that
+survives serialization was never behaviour.
+
+| Field | Why it is the backend's |
+| --- | --- |
+| `fetch_evidence` | Keyed by `RuleRef` — `(file, name)`, how the report identifies a row. A name alone does not: one deliverable can hold several components' checks, and two authors given the same property write the same name. The only hook, because it is the only one that does I/O |
+| `domain` | The *domain* half of the system message — a claim about what the evidence *is*. "The Certora Prover found a concrete counterexample" is true of one backend's and false of another's. The host wraps it in the shared contract (how severity is reached, which sections come back), so a backend restates none of that |
+| `prompt` | A `TypedTemplate[FindingsPromptParams]`, not a callable. Both backends' prompts take the same fields — rule, properties, groups, evidence, `also_covers` — so the backend owns the prose and `build_findings` owns the binding |
+
+Severity is not among them. Every backend's findings are rated the same way: the model assesses
+impact and likelihood on the one `FindingDraft`, and `severity_for` maps the pair through a fixed
+matrix — the model never picks a tier, so the severity a reader sees is re-derivable from what the
+write-up said. What differs between backends is what a violation *is*, and that is the prompt's job
+to say.
+
+Everything else the loop used to take as a hook turned out to be derivable from the evidence itself,
+and is now shared: `proof_of_concept` joins the reproducers from instances the run actually refuted
+(labelled once there is more than one), and `finding_key` reads the key the backend stamped.
+
+That key is what keeps the cost proportional to what was *found* rather than to how many rows it took
+down. A fuzz campaign covers a component's whole property set, and a crash it cannot place condemns
+every check in it — on a klend-sized component that is 26 BAD rows of one crash. Written up per row
+it would be 26 heavy-model calls publishing 26 accounts of the same finding, each guessing a
+different check it might have been.
+
+The relation is deliberately *stamped* and never inferred from matching evidence: rows fanned out
+from one conclusion look exactly like several checks that failed the same way, and those are two
+different facts about the program. Only whatever produced the verdicts knows which it is — a Rust
+wheel says so on `Verdict.finding`, and it stamps it at the point it decides to fan out.
+
+Returning `None` is how a backend opts out; the report then builds no findings for it and never
+starts the heavy model. `outcomes` is passed because a backend whose evidence is in its own results
+has nowhere else to read it from — the prover's is a run-scoped store and ignores them.
+
+A failure here costs the findings, never the report.
+
+### 4.7 `finalize` — run-level artifact
 
 ```python
 async def finalize(self, outcomes, run) -> None:
@@ -648,6 +722,7 @@ system analysis, property extraction, caching, and the report, and contributes o
 | shared artifact (`StagedFormalizer`) | none — `invariants.spec` is built from the model, in `prepare_formalization` | none |
 | `formalize` | authoring session, gated by `verify_spec` | authoring session, gated by `forge_test` |
 | `fetch_verdicts` | query prover output off-thread | read ran/expected tests off the result |
+| `findings_policy` | LLM write-up per violated rule, from the captured CEX analysis | none (default `None`) |
 | `extra_report_inputs` | synthetic "Structural Invariants" | none |
 | `finalize` | `components_to_prover_runs.json` | none |
 | artifact bundle | `.spec` + `.conf` | `.t.sol` + metadata |

--- a/docs/formalization-abstraction.md
+++ b/docs/formalization-abstraction.md
@@ -538,7 +538,7 @@ so a per-component local id will merge independent conclusions.
 The relation is deliberately *stamped* and never inferred from matching evidence: rows fanned out
 from one conclusion look exactly like several checks that failed the same way, and those are two
 different facts about the program. Only whatever produced the verdicts knows which it is — a
-Rust-authored backend says so on `Verdict.finding`, and it stamps it at the point it decides to fan
+Rust-authored backend says so on `Verdict.finding_key`, and it stamps it at the point it decides to fan
 out.
 
 Returning `None` is how a backend opts out; the report then builds no findings for it and never

--- a/docs/rust-applications.md
+++ b/docs/rust-applications.md
@@ -184,6 +184,7 @@ One struct, serialized at load time, that drives everything non-backend.
 | `component_noun` | the human noun for one formalized component in the console/TUI ("instruction"); `None` → "component", read through `unit_noun()` |
 | `check_noun` | what this backend calls one check **to the model** ("rule", "harness function"); `None` → "check", read through `check_label()` |
 | `evidence_kinds` | the closed set an author may cite when rebutting the judge (§5) |
+| `findings` | how a violated check is written up as an audit finding: the domain half of the system prompt, saying what this wheel's evidence is — the host supplies the rest (§4.5). `None` → this wheel produces no findings |
 
 **Phases.** `phases: [PhaseSpec { key, label, order, role }]`. The host resolves these once into a
 `PhaseModel` ([`build_phase_model`](../composer/rustapp/host.py)): the synthesized
@@ -392,13 +393,70 @@ sees it — there is nothing to build — so the next prompt is told exactly tha
 
 ### 4.5 Report and finalize
 
-`fetch_verdicts` maps the wire verdicts `validate` baked into the result onto the report's own
-`Verdict` (its `message` is the wire `detail`), filling `unit_file` from the component when the
-wheel didn't name one. The store writes the per-component artifacts and metadata (§9), and
+`fetch_verdicts` maps the verdicts `validate` baked into the result onto the report's own
+`Verdict`, filling `unit_file` from the component when the wheel didn't name one. It reads
+`RustFormalResult.reported_verdicts()`, not the raw ones: the wheel reports what its run observed,
+and the author's `expect_check_failure` declarations are folded in on top (§6). The store writes the
+per-component artifacts and metadata (§9), and
 `finalize` receives the whole outcome set as `FinalizeInput` — program, crate, IDL path, the shared
 setup spec, and per component its `artifact_text`, `property_checks` and the `targets` its
 checks ran under — and returns `{relpath: contents}` the host writes under the project root,
 path-confined.
+
+`findings_policy` answers a different question from `fetch_verdicts`: *what did this run find*.
+The write-up loop is shared ([formalization-abstraction.md §4.6](./formalization-abstraction.md)) and
+so is the host half in [findings.py](../composer/rustapp/findings.py) — which knows only wire fields.
+What a *particular* backend's evidence means is the wheel's, declared as `AppDescriptor.findings` —
+a `FindingsDeclaration`, which the host folds into the `FindingsPolicy` the shared loop runs on.
+
+**Evidence is one shared `RuleEvidence` per check**, keyed by `(file, name)` exactly as the report
+keys its rows — a check name alone does not identify a row, because a callout-mode wheel's one crate
+holds every component's checks and two authors given the same property title write the same check
+name. A wheel fills `label` (the component), `counterexample` (`Verdict.detail`), `accounting`,
+`ran` — the wheel's *own* outcome — and `declared`, the author's `expect_check_failure` reason. Those
+last two are the split that matters: a declared check reports `BAD` either way, so only `ran` and
+`declared` together say whether a reader is looking at something the run found or a claim the author
+made.
+
+`analysis` stays empty. A wheel reports what its run found, not a reading of why the check broke, and
+the prompt has to be able to tell a reader which of the two it is holding.
+
+**`FindingsDeclaration.domain` says what the evidence is**, and it is the wheel's prose because it is
+the wheel's claim. A fuzzing wheel's says that its checker drove a harness the author wrote from a
+state that harness set up and refuted nothing symbolically — so its own markers for a suspect harness
+are something the write-up must lead with, an unreproduced declaration must not be given a
+counterexample it does not have, and the harness caveats belong in
+`assumptions_and_uncertainties`.
+
+It is only the *domain* half. The host wraps it in the contract — how severity is reached, which
+sections come back — using the same `autoprove_report_findings_system.j2` the CVL backend gets, whose
+own domain half is a template beside it. A wheel restates none of that. **A wheel that declares
+nothing produces no findings**: a write-up asserts what its evidence is, and a host that guessed
+would be publishing prose nothing stands behind.
+
+**Severity is the host's, and it is the same for every backend**: the write-up model rates impact
+and likelihood, and `severity_for` maps the pair through a fixed matrix. A wheel does not get to
+opt out — which puts the whole weight on `domain`, because a fuzzing campaign establishes that an
+assertion can be made to fail, not that anyone can profit from it, and a crash on a failed
+precondition looks exactly like a crash on a real one. That is what the wheel's prose has to say, so
+the rating is made against what the evidence actually shows. `provenance` keeps the axes and the
+model's reasoning, so a reader can re-derive the tier rather than take it on trust.
+
+**A conclusion the wheel could not attribute to one check is one finding, not one per row.** A wheel
+whose run condemns every check it covered — a campaign whose crash names a property no component in
+the run claims — stamps that fan-out with one `Verdict.finding` key. The host groups on the key, so
+the run is written up once and told which other checks it answers for, rather than picking one and
+pinning the crash on it. Nothing here infers the relation from the evidence: fanned-out rows are
+otherwise indistinguishable from several checks that failed identically, and those are two different
+facts about the program. An unstamped row stands on its own — two declared findings the run did not
+reproduce are two claims the author made, however alike the rest of their evidence looks.
+
+**Evidence about the program and evidence about the run are separate fields.** `Verdict.accounting`
+carries what the run spent and covered; `Verdict.detail` carries only the counterexample or the
+error. They are separate claims, and a proof of concept padded with run accounting leaves a reader
+unable to see where the evidence ends. `fetch_verdicts` rejoins them into the report row's one
+`message` — evidence first, because a `BAD` row's first line is what a reader is looking for — so a
+green row still says what it cost.
 
 ---
 
@@ -444,6 +502,26 @@ unstamped, unless the author marked it with `expect_check_failure(check, reason)
 counterexample reaches the report *as a finding with a justification* rather than as a row nobody
 examined. It is the same mechanism as CVL's `expect_rule_failure` and foundry's
 `expect_test_failure`.
+
+**Every verdict says what the run behind it cost.** A `GOOD` from a campaign that explored to a
+ten-minute budget is a real claim and one from a twelve-second campaign is nearly none, and a report
+row carries only its check, its outcome and its `message`. So a wheel whose negative results are
+budget-relative gives every verdict — green ones included — what its run spent against what it was
+allowed, on `Verdict.accounting`. Not on `detail`: that field is the run's evidence about the
+*program*, and it must stay exactly what the run reported. The live console shows a detail's first
+line, and a findings write-up is handed the whole of it — so accounting mixed in costs an author the
+line that tells them what broke, and costs the write-up its proof of concept.
+
+The marking is the *author's*, and the verdict is the *wheel's*; they meet on `RustFormalResult`,
+whose `reported_verdicts()` is what both the report and the console rollup read. A declared check
+reports `BAD` whatever its run said, because the alternative is the failure this exists to prevent:
+the gate accepts a declared check without ever asking the run to reproduce it, so a documented
+finding whose run did not happen to hit it would otherwise reach `report.html` as a clean row.
+The two cases are distinguished in the detail rather than in the outcome — a reproduced finding
+carries its counterexample, an unreproduced one says `NOT REPRODUCED` and names what the run did
+say — because an unreproduced finding rests on the author's reading alone and a reader has to be
+able to tell. `verdicts` itself stays verbatim: attribution remains the wheel's, and the declaration
+is applied on the way out.
 
 **The judge is structured.** When `judge` names a reviewer for an input, the session binds
 `feedback_tool`; a wheel with no judge gets no review machinery and no feedback stamp among its
@@ -528,6 +606,15 @@ or the same check twice raises `ValidateCoverageError`. The unanswered case is t
 machinery — a missing verdict is not a failing verdict, so it gives the publish gate nothing to
 object to, and a wheel that answered for nothing would stamp a component nothing had checked.
 
+A check the author marked with `expect_check_failure` is the one place the wheel's attribution is
+not the last word. The declaration is the author's — "the failure here IS the finding" — and the
+publish gate accepts such a check as clean without ever requiring the run to reproduce it, so
+nothing else stands between a documented finding and a green row. `reported_verdicts()` folds the
+two together on the host side: a declared check reports `BAD` whatever the run said, and the detail
+says which case it is — a reproduced finding carries its counterexample, an unreproduced one says
+`NOT REPRODUCED` and names the outcome the run did reach. Both the report and the console rollup
+read the fold, so they cannot disagree about whether the run found something.
+
 A stamping run records what it covered as `ran` — the targets, each with its checks — and that is
 what the publish gate validates the declared mapping against, in both directions: every claimed name
 must have run, and every name that ran must be claimed. Ground truth is the stamping run rather than
@@ -550,10 +637,11 @@ that looks merely inconclusive. `Verdict.detail` carries the counterexample or e
 `BAD` is never unexplained.
 
 [`results.py`](../composer/rustapp/results.py) rolls these up for the console/TUI: one row per
-*check*, with the tally in the report's own display order and wording. A row is named by the property
-title when the check verifies exactly one, and otherwise by the check's own name — the only thing
-that names it unambiguously once one check can carry several properties. A delivered component that
-bakes no verdicts contributes one `UNKNOWN` row so the listing accounts for every component.
+*check*, with the tally in the report's own display order and wording. A row is named by
+`RustFormalResult.display_name` — the property title when the check verifies exactly one, and
+otherwise the check's own name, the only thing that names it unambiguously once one check can carry
+several properties. A delivered component that bakes no verdicts contributes one
+`UNKNOWN` row so the listing accounts for every component.
 
 ---
 
@@ -783,6 +871,7 @@ Facts about the seam as it stands, not open design questions:
 | Declarative ABI mirror | [composer/rustapp/descriptor.py](../composer/rustapp/descriptor.py) |
 | Runtime ABI mirror + parsers | [composer/rustapp/wire.py](../composer/rustapp/wire.py) |
 | The backend, preflight, prep, report | [composer/rustapp/adapter.py](../composer/rustapp/adapter.py) |
+| Run observations → written findings | [composer/rustapp/findings.py](../composer/rustapp/findings.py) |
 | The authoring session (buffer, gate, review, publish) | [composer/rustapp/session.py](../composer/rustapp/session.py) |
 | The shared authoring workflow | [composer/authoring/](../composer/authoring/) |
 | Application assembly (enum, phases, store, backend) | [composer/rustapp/host.py](../composer/rustapp/host.py) |
@@ -797,6 +886,7 @@ Tests: `tests/test_rustapp.py` (the wheel round-trip, end to end through the hos
 Hypothesis, against the real serde types), `test_rustapp_preflight.py`, `test_rustapp_workspace_prep.py`,
 `test_rustapp_setup_cache.py`, `test_rustapp_verdicts.py`, `test_rustapp_toolchain_sem.py`,
 `test_rustapp_gate.py`, `test_rustapp_validate_target.py`, `test_rustapp_discovery_phase.py`,
+`test_rustapp_findings.py` (the declaration fold and the findings written from it),
 `test_rust_llm_agent.py`,
 `test_rust_frontend.py`, plus `test_sandbox_run_confined.py` / `test_sandbox_escape.py` for the
 launcher contract.

--- a/docs/rust-applications.md
+++ b/docs/rust-applications.md
@@ -422,11 +422,9 @@ made.
 the prompt has to be able to tell a reader which of the two it is holding.
 
 **`FindingsDeclaration.domain` says what the evidence is**, and it is the wheel's prose because it is
-the wheel's claim. A fuzzing wheel's says that its checker drove a harness the author wrote from a
-state that harness set up and refuted nothing symbolically — so its own markers for a suspect harness
-are something the write-up must lead with, an unreproduced declaration must not be given a
-counterexample it does not have, and the harness caveats belong in
-`assumptions_and_uncertainties`.
+the wheel's claim: what this checker established, what it did not, and how to read this backend's
+own markers. An unreproduced expected-to-fail check must not be given a counterexample it does not
+have; caveats about what the checker cannot show belong in `assumptions_and_uncertainties`.
 
 It is only the *domain* half. The host wraps it in the contract — how severity is reached, which
 sections come back — using the same `autoprove_report_findings_system.j2` the CVL backend gets, whose
@@ -435,21 +433,20 @@ nothing produces no findings**: a write-up asserts what its evidence is, and a h
 would be publishing prose nothing stands behind.
 
 **Severity is the host's, and it is the same for every backend**: the write-up model rates impact
-and likelihood, and `severity_for` maps the pair through a fixed matrix. A wheel does not get to
-opt out — which puts the whole weight on `domain`, because a fuzzing campaign establishes that an
-assertion can be made to fail, not that anyone can profit from it, and a crash on a failed
-precondition looks exactly like a crash on a real one. That is what the wheel's prose has to say, so
-the rating is made against what the evidence actually shows. `provenance` keeps the axes and the
+and likelihood, and `severity_for` maps the pair through a fixed matrix. A wheel does not pick a
+tier. What a violation *is* — and how far this evidence goes — is `domain`'s job to say, so the
+rating is made against what the evidence actually shows. `provenance` keeps the axes and the
 model's reasoning, so a reader can re-derive the tier rather than take it on trust.
 
-**A conclusion the wheel could not attribute to one check is one finding, not one per row.** A wheel
-whose run condemns every check it covered — a campaign whose crash names a property no component in
-the run claims — stamps that fan-out with one `Verdict.finding` key. The host groups on the key, so
-the run is written up once and told which other checks it answers for, rather than picking one and
-pinning the crash on it. Nothing here infers the relation from the evidence: fanned-out rows are
-otherwise indistinguishable from several checks that failed identically, and those are two different
-facts about the program. An unstamped row stands on its own — two declared findings the run did not
-reproduce are two claims the author made, however alike the rest of their evidence looks.
+**A conclusion the wheel could not attribute to one check is one finding, not one per row.** When
+one conclusion covers several checks, the wheel stamps those verdicts with the same
+`Verdict.finding` key. The host groups on the key, so the run is written up once against the union
+of those rows' properties and groups, and `provenance.covers` names every row the write-up answers
+for. The key is compared across the whole run: the same string on two components merges them.
+Nothing here infers the relation from the evidence: fanned-out rows are otherwise indistinguishable
+from several checks that failed identically, and those are two different facts about the program.
+An unstamped row stands on its own — two expected-to-fail checks the run did not reproduce are two
+claims the author made, however alike the rest of their evidence looks.
 
 **Evidence about the program and evidence about the run are separate fields.** `Verdict.accounting`
 carries what the run spent and covered; `Verdict.detail` carries only the counterexample or the
@@ -503,14 +500,14 @@ counterexample reaches the report *as a finding with a justification* rather tha
 examined. It is the same mechanism as CVL's `expect_rule_failure` and foundry's
 `expect_test_failure`.
 
-**Every verdict says what the run behind it cost.** A `GOOD` from a campaign that explored to a
-ten-minute budget is a real claim and one from a twelve-second campaign is nearly none, and a report
-row carries only its check, its outcome and its `message`. So a wheel whose negative results are
-budget-relative gives every verdict — green ones included — what its run spent against what it was
-allowed, on `Verdict.accounting`. Not on `detail`: that field is the run's evidence about the
-*program*, and it must stay exactly what the run reported. The live console shows a detail's first
-line, and a findings write-up is handed the whole of it — so accounting mixed in costs an author the
-line that tells them what broke, and costs the write-up its proof of concept.
+**Every verdict says what the run behind it cost.** A `GOOD` from a long, thorough run is a real
+claim and one from a short run is nearly none, and a report row carries only its check, its outcome
+and its `message`. So a wheel whose negative results are budget-relative gives every verdict —
+green ones included — what its run spent against what it was allowed, on `Verdict.accounting`. Not
+on `detail`: that field is the run's evidence about the *program*, and it must stay exactly what the
+run reported. The live console shows a detail's first line, and a findings write-up is handed the
+whole of it — so accounting mixed in costs an author the line that tells them what broke, and costs
+the write-up its proof of concept.
 
 The marking is the *author's*, and the verdict is the *wheel's*; they meet on `RustFormalResult`,
 whose `reported_verdicts()` is what both the report and the console rollup read. A declared check

--- a/docs/rust-applications.md
+++ b/docs/rust-applications.md
@@ -440,7 +440,7 @@ model's reasoning, so a reader can re-derive the tier rather than take it on tru
 
 **A conclusion the wheel could not attribute to one check is one finding, not one per row.** When
 one conclusion covers several checks, the wheel stamps those verdicts with the same
-`Verdict.finding` key. The host groups on the key, so the run is written up once against the union
+`Verdict.finding_key`. The host groups on the key, so the run is written up once against the union
 of those rows' properties and groups, and `provenance.covers` names every row the write-up answers
 for. The key is compared across the whole run: the same string on two components merges them.
 Nothing here infers the relation from the evidence: fanned-out rows are otherwise indistinguishable
@@ -451,9 +451,9 @@ claims the author made, however alike the rest of their evidence looks.
 **Evidence about the program and evidence about the run are separate fields.** `Verdict.accounting`
 carries what the run spent and covered; `Verdict.detail` carries only the counterexample or the
 error. They are separate claims, and a proof of concept padded with run accounting leaves a reader
-unable to see where the evidence ends. `fetch_verdicts` rejoins them into the report row's one
-`message` — evidence first, because a `BAD` row's first line is what a reader is looking for — so a
-green row still says what it cost.
+unable to see where the evidence ends. `fetch_verdicts` copies them onto the report row as
+`message` and `accounting`; HTML shows them as separate blocks, so a green row still says what
+it cost without padding a counterexample.
 
 ---
 
@@ -501,9 +501,10 @@ examined. It is the same mechanism as CVL's `expect_rule_failure` and foundry's
 `expect_test_failure`.
 
 **Every verdict says what the run behind it cost.** A `GOOD` from a long, thorough run is a real
-claim and one from a short run is nearly none, and a report row carries only its check, its outcome
-and its `message`. So a wheel whose negative results are budget-relative gives every verdict —
-green ones included — what its run spent against what it was allowed, on `Verdict.accounting`. Not
+claim and one from a short run is nearly none, and a report row carries its check, its outcome,
+its `message`, and optional `accounting`. So a wheel whose negative results are budget-relative
+gives every verdict — green ones included — what its run spent against what it was allowed, on
+`Verdict.accounting`. Not
 on `detail`: that field is the run's evidence about the *program*, and it must stay exactly what the
 run reported. The live console shows a detail's first line, and a findings write-up is handed the
 whole of it — so accounting mixed in costs an author the line that tells them what broke, and costs
@@ -514,11 +515,10 @@ whose `reported_verdicts()` is what both the report and the console rollup read.
 reports `BAD` whatever its run said, because the alternative is the failure this exists to prevent:
 the gate accepts a declared check without ever asking the run to reproduce it, so a documented
 finding whose run did not happen to hit it would otherwise reach `report.html` as a clean row.
-The two cases are distinguished in the detail rather than in the outcome — a reproduced finding
-carries its counterexample, an unreproduced one says `NOT REPRODUCED` and names what the run did
-say — because an unreproduced finding rests on the author's reading alone and a reader has to be
-able to tell. `verdicts` itself stays verbatim: attribution remains the wheel's, and the declaration
-is applied on the way out.
+`detail` stays what the run reported. Whether this run reproduced the mark is
+`ExpectedFailure` on the report row — `reproduced` with the author's reason, or `unreproduced`
+with the reason and the outcome the run did reach. `verdicts` itself stays verbatim: attribution
+remains the wheel's, and the expected-failure mark is applied on the way out.
 
 **The judge is structured.** When `judge` names a reviewer for an input, the session binds
 `feedback_tool`; a wheel with no judge gets no review machinery and no feedback stamp among its
@@ -607,10 +607,9 @@ A check the author marked with `expect_check_failure` is the one place the wheel
 not the last word. The declaration is the author's — "the failure here IS the finding" — and the
 publish gate accepts such a check as clean without ever requiring the run to reproduce it, so
 nothing else stands between a documented finding and a green row. `reported_verdicts()` folds the
-two together on the host side: a declared check reports `BAD` whatever the run said, and the detail
-says which case it is — a reproduced finding carries its counterexample, an unreproduced one says
-`NOT REPRODUCED` and names the outcome the run did reach. Both the report and the console rollup
-read the fold, so they cannot disagree about whether the run found something.
+outcome to `BAD`; the report row's `expected_failure` field says whether this run reproduced it. Both the
+report and the console rollup read the fold, so they cannot disagree about whether the run found
+something.
 
 A stamping run records what it covered as `ran` — the targets, each with its checks — and that is
 what the publish gate validates the declared mapping against, in both directions: every claimed name

--- a/rust/autoprover-sdk/src/descriptor.rs
+++ b/rust/autoprover-sdk/src/descriptor.rs
@@ -206,11 +206,10 @@ pub enum DeliverableMode {
 /// How a violated check of this backend becomes a written audit finding.
 ///
 /// Declared by the wheel because a write-up rests on claims only the wheel can make: what its
-/// evidence *is* — a symbolic refutation, or a fuzzer's crash against a harness the author wrote —
-/// what that evidence establishes, and how to read its own markers. The host owns everything
-/// around that: which rows, each row's properties and the audit groups they sit in, the
-/// concurrency, grouping the rows that share one finding, and composing the record. It owns none
-/// of the prose.
+/// evidence *is*, what that evidence does and does not establish, and how to read its own markers.
+/// The host owns everything around that: which rows, each row's properties and the audit groups
+/// they sit in, the concurrency, grouping the rows that share one finding, and composing the
+/// record. It owns none of the prose.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[serde(deny_unknown_fields)]

--- a/rust/autoprover-sdk/src/descriptor.rs
+++ b/rust/autoprover-sdk/src/descriptor.rs
@@ -203,20 +203,17 @@ pub enum DeliverableMode {
     },
 }
 
-/// How a violated check of this backend becomes a written audit finding.
+/// What this backend's evidence is, so the host can write a violated check up as a finding.
 ///
-/// Declared by the wheel because a write-up rests on claims only the wheel can make: what its
-/// evidence *is*, what that evidence does and does not establish, and how to read its own markers.
-/// The host owns everything around that: which rows, each row's properties and the audit groups
-/// they sit in, the concurrency, grouping the rows that share one finding, and composing the
-/// record. It owns none of the prose.
+/// The wheel supplies that claim; the host owns the rest (which rows, properties, groups,
+/// grouping, composing).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[serde(deny_unknown_fields)]
 pub struct FindingsDeclaration {
-    /// The *domain* half of the write-up system prompt — what this backend's evidence is, what it
-    /// does and does not establish, and what its markers mean. The host wraps it in the contract
-    /// (how severity is reached, which sections come back), so no wheel restates that.
+    /// Domain half of the write-up system prompt: what this evidence is, what it does and does
+    /// not establish, and how to read its markers. The host adds how severity is reached and
+    /// which sections come back.
     pub domain: String,
 }
 
@@ -270,12 +267,9 @@ pub struct AppDescriptor {
     /// backend: a fuzzing wheel can show a counterexample, a typechecking one an error from a
     /// checker that never runs code. See [`EVIDENCE_KINDS`] for the default set.
     pub evidence_kinds: Vec<String>,
-    /// How this backend's violated checks are written up as audit findings (see
-    /// [`FindingsDeclaration`]) — `None` produces none, and the report carries only the verdict rows.
-    ///
-    /// Declining is the default because a write-up has to say what the evidence behind it is, and
-    /// only the wheel knows. A run that reports verdicts without claiming to know what they
-    /// establish is a coherent wheel; one whose findings are prose the host guessed is not.
+    /// How violated checks are written up (see [`FindingsDeclaration`]). `None` (the default)
+    /// produces no findings, only verdict rows: a write-up has to say what the evidence is,
+    /// and only the wheel knows.
     #[serde(deserialize_with = "crate::required::present")]
     pub findings: Option<FindingsDeclaration>,
 }

--- a/rust/autoprover-sdk/src/descriptor.rs
+++ b/rust/autoprover-sdk/src/descriptor.rs
@@ -203,6 +203,24 @@ pub enum DeliverableMode {
     },
 }
 
+/// How a violated check of this backend becomes a written audit finding.
+///
+/// Declared by the wheel because a write-up rests on claims only the wheel can make: what its
+/// evidence *is* — a symbolic refutation, or a fuzzer's crash against a harness the author wrote —
+/// what that evidence establishes, and how to read its own markers. The host owns everything
+/// around that: which rows, each row's properties and the audit groups they sit in, the
+/// concurrency, grouping the rows that share one finding, and composing the record. It owns none
+/// of the prose.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct FindingsDeclaration {
+    /// The *domain* half of the write-up system prompt — what this backend's evidence is, what it
+    /// does and does not establish, and what its markers mean. The host wraps it in the contract
+    /// (how severity is reached, which sections come back), so no wheel restates that.
+    pub domain: String,
+}
+
 /// The complete declaration the Python host reads once at load time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -253,6 +271,14 @@ pub struct AppDescriptor {
     /// backend: a fuzzing wheel can show a counterexample, a typechecking one an error from a
     /// checker that never runs code. See [`EVIDENCE_KINDS`] for the default set.
     pub evidence_kinds: Vec<String>,
+    /// How this backend's violated checks are written up as audit findings (see
+    /// [`FindingsDeclaration`]) — `None` produces none, and the report carries only the verdict rows.
+    ///
+    /// Declining is the default because a write-up has to say what the evidence behind it is, and
+    /// only the wheel knows. A run that reports verdicts without claiming to know what they
+    /// establish is a coherent wheel; one whose findings are prose the host guessed is not.
+    #[serde(deserialize_with = "crate::required::present")]
+    pub findings: Option<FindingsDeclaration>,
 }
 
 /// The evidence an author can usually offer, for a wheel with no reason to name its own: the build

--- a/rust/autoprover-sdk/src/fuzz.rs
+++ b/rust/autoprover-sdk/src/fuzz.rs
@@ -118,7 +118,7 @@ impl<'a> Arbitrary<'a> for Verdict {
             unit_file: Option::arbitrary(u)?,
             detail: Option::arbitrary(u)?,
             accounting: Option::arbitrary(u)?,
-            finding: Option::arbitrary(u)?,
+            finding_key: Option::arbitrary(u)?,
         })
     }
 }

--- a/rust/autoprover-sdk/src/fuzz.rs
+++ b/rust/autoprover-sdk/src/fuzz.rs
@@ -117,6 +117,8 @@ impl<'a> Arbitrary<'a> for Verdict {
             duration_seconds: seconds,
             unit_file: Option::arbitrary(u)?,
             detail: Option::arbitrary(u)?,
+            accounting: Option::arbitrary(u)?,
+            finding: Option::arbitrary(u)?,
         })
     }
 }
@@ -148,6 +150,7 @@ impl<'a> Arbitrary<'a> for AppDescriptor {
             component_noun: Option::arbitrary(u)?,
             check_noun: Option::arbitrary(u)?,
             evidence_kinds: Vec::<String>::arbitrary(u)?,
+            findings: Option::arbitrary(u)?,
         })
     }
 }

--- a/rust/autoprover-sdk/src/outcome.rs
+++ b/rust/autoprover-sdk/src/outcome.rs
@@ -171,6 +171,10 @@ pub enum Outcome {
     Unknown,
 }
 
+/// Opaque grouping key for one finding that covers several checks. Compared as a string
+/// across the whole run; the host never reads into it.
+pub type FindingKey = String;
+
 /// One check's outcome (mirrors `composer…report.collect.Verdict`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -187,29 +191,17 @@ pub struct Verdict {
     /// to the report so a verdict is self-explaining (otherwise a bare `BAD` gives no clue why).
     #[serde(deserialize_with = "crate::required::present")]
     pub detail: Option<String>,
-    /// What the run behind this verdict cost and covered — its budget, its coverage, how far it
-    /// got. Present on a `GOOD` too, and mostly *only* there: a passing check's strength is
-    /// otherwise invisible, while a failure explains itself through `detail`.
-    ///
-    /// Separate from `detail` because they are separate claims. `detail` is evidence about the
-    /// program; this is evidence about how hard the run looked, and a reader asking for a
-    /// counterexample should not be handed run accounting inside one. The host composes both into
-    /// the report row's message and takes `detail` alone where the counterexample is what is wanted.
+    /// What the run spent and covered (budget, coverage, how far it got). Present on a `GOOD`
+    /// too. Kept apart from `detail`: that is evidence about the program; this is about the run.
+    /// The host copies them onto the report row as `message` and `accounting`.
     #[serde(deserialize_with = "crate::required::present")]
     pub accounting: Option<String>,
-    /// Which *finding* this verdict belongs to, when one piece of evidence condemns several checks
-    /// at once — an opaque key the host groups by and never interprets.
-    ///
-    /// A backend whose run can conclude something it cannot attribute to one check stamps the same
-    /// key on every verdict it fans that conclusion out to. The host writes those rows up once,
-    /// against the set, instead of once per row each guessing which check it was. The key is
-    /// compared across the whole run: the same string on two components merges them. Nothing else
-    /// recovers the relation: fanned-out verdicts are otherwise indistinguishable from several
-    /// checks that happened to fail the same way, which is a different fact about the program.
-    ///
-    /// `None` — the ordinary case — is a verdict standing on its own evidence.
+    /// Opaque key grouping several checks under one finding. The host compares it across the
+    /// whole run and never reads into it: the same string on two components merges them. Stamp
+    /// it when one conclusion covers several checks; do not infer it from matching evidence.
+    /// `None` means this verdict stands on its own.
     #[serde(deserialize_with = "crate::required::present")]
-    pub finding: Option<String>,
+    pub finding_key: Option<FindingKey>,
 }
 
 impl Verdict {
@@ -222,7 +214,7 @@ impl Verdict {
             unit_file: None,
             detail: None,
             accounting: None,
-            finding: None,
+            finding_key: None,
         }
     }
 
@@ -238,9 +230,8 @@ impl Verdict {
         Verdict { detail, ..self }
     }
 
-    /// This verdict with `note` added to its run accounting. Appends rather than sets: several
-    /// steps of one `validate` have something to say about what the run covered, and each should
-    /// add to the record instead of overwriting whatever the last one established.
+    /// Append `note` to this verdict's run accounting. Several steps of one `validate` may
+    /// each have something to add.
     pub fn noting(self, note: impl Into<String>) -> Self {
         let note = note.into();
         let accounting = Some(match self.accounting {
@@ -250,12 +241,10 @@ impl Verdict {
         Verdict { accounting, ..self }
     }
 
-    /// This verdict as one of several that share one finding — see [`Verdict::finding`].
+    /// This verdict as one of several that share a finding — see [`Verdict::finding_key`].
     ///
-    /// The key is compared across the whole run, not within one component: the same string on two
-    /// components merges those rows into one finding. It only has to separate this run's findings
-    /// from each other; the host never reads into it.
-    pub fn of_finding(self, finding: impl Into<String>) -> Self {
-        Verdict { finding: Some(finding.into()), ..self }
+    /// The key is compared across the whole run. The same string on two components merges them.
+    pub fn of_finding_key(self, finding_key: impl Into<FindingKey>) -> Self {
+        Verdict { finding_key: Some(finding_key.into()), ..self }
     }
 }

--- a/rust/autoprover-sdk/src/outcome.rs
+++ b/rust/autoprover-sdk/src/outcome.rs
@@ -202,7 +202,8 @@ pub struct Verdict {
     ///
     /// A backend whose run can conclude something it cannot attribute to one check stamps the same
     /// key on every verdict it fans that conclusion out to. The host writes those rows up once,
-    /// against the set, instead of once per row each guessing which check it was. Nothing else
+    /// against the set, instead of once per row each guessing which check it was. The key is
+    /// compared across the whole run: the same string on two components merges them. Nothing else
     /// recovers the relation: fanned-out verdicts are otherwise indistinguishable from several
     /// checks that happened to fail the same way, which is a different fact about the program.
     ///
@@ -249,8 +250,11 @@ impl Verdict {
         Verdict { accounting, ..self }
     }
 
-    /// This verdict as one of several that share one finding — see [`Verdict::finding`]. The key
-    /// only has to separate this run's findings from each other; the host never reads into it.
+    /// This verdict as one of several that share one finding — see [`Verdict::finding`].
+    ///
+    /// The key is compared across the whole run, not within one component: the same string on two
+    /// components merges those rows into one finding. It only has to separate this run's findings
+    /// from each other; the host never reads into it.
     pub fn of_finding(self, finding: impl Into<String>) -> Self {
         Verdict { finding: Some(finding.into()), ..self }
     }

--- a/rust/autoprover-sdk/src/outcome.rs
+++ b/rust/autoprover-sdk/src/outcome.rs
@@ -187,6 +187,28 @@ pub struct Verdict {
     /// to the report so a verdict is self-explaining (otherwise a bare `BAD` gives no clue why).
     #[serde(deserialize_with = "crate::required::present")]
     pub detail: Option<String>,
+    /// What the run behind this verdict cost and covered — its budget, its coverage, how far it
+    /// got. Present on a `GOOD` too, and mostly *only* there: a passing check's strength is
+    /// otherwise invisible, while a failure explains itself through `detail`.
+    ///
+    /// Separate from `detail` because they are separate claims. `detail` is evidence about the
+    /// program; this is evidence about how hard the run looked, and a reader asking for a
+    /// counterexample should not be handed run accounting inside one. The host composes both into
+    /// the report row's message and takes `detail` alone where the counterexample is what is wanted.
+    #[serde(deserialize_with = "crate::required::present")]
+    pub accounting: Option<String>,
+    /// Which *finding* this verdict belongs to, when one piece of evidence condemns several checks
+    /// at once — an opaque key the host groups by and never interprets.
+    ///
+    /// A backend whose run can conclude something it cannot attribute to one check stamps the same
+    /// key on every verdict it fans that conclusion out to. The host writes those rows up once,
+    /// against the set, instead of once per row each guessing which check it was. Nothing else
+    /// recovers the relation: fanned-out verdicts are otherwise indistinguishable from several
+    /// checks that happened to fail the same way, which is a different fact about the program.
+    ///
+    /// `None` — the ordinary case — is a verdict standing on its own evidence.
+    #[serde(deserialize_with = "crate::required::present")]
+    pub finding: Option<String>,
 }
 
 impl Verdict {
@@ -198,6 +220,8 @@ impl Verdict {
             duration_seconds: None,
             unit_file: None,
             detail: None,
+            accounting: None,
+            finding: None,
         }
     }
 
@@ -211,5 +235,23 @@ impl Verdict {
     /// tool output gives it, rather than one deciding between two constructors.
     pub fn with_detail(self, detail: Option<String>) -> Self {
         Verdict { detail, ..self }
+    }
+
+    /// This verdict with `note` added to its run accounting. Appends rather than sets: several
+    /// steps of one `validate` have something to say about what the run covered, and each should
+    /// add to the record instead of overwriting whatever the last one established.
+    pub fn noting(self, note: impl Into<String>) -> Self {
+        let note = note.into();
+        let accounting = Some(match self.accounting {
+            Some(prior) => format!("{prior}\n\n{note}"),
+            None => note,
+        });
+        Verdict { accounting, ..self }
+    }
+
+    /// This verdict as one of several that share one finding — see [`Verdict::finding`]. The key
+    /// only has to separate this run's findings from each other; the host never reads into it.
+    pub fn of_finding(self, finding: impl Into<String>) -> Self {
+        Verdict { finding: Some(finding.into()), ..self }
     }
 }

--- a/rust/example-app/src/lib.rs
+++ b/rust/example-app/src/lib.rs
@@ -68,6 +68,10 @@ impl Backend for EchoApp {
             // The demo authors `rule_<slug>` checks, so that is what its prompts should call them.
             check_noun: Some("rule".into()),
             evidence_kinds: default_evidence_kinds(),
+            // Reading the spec back is this demo's whole checker, so a refuted rule means the spec
+            // did not say what was asked — nothing about the program. There is no finding to write
+            // up, and declining is how a wheel says so.
+            findings: None,
         }
     }
 

--- a/rust/example-app/src/lib.rs
+++ b/rust/example-app/src/lib.rs
@@ -68,9 +68,8 @@ impl Backend for EchoApp {
             // The demo authors `rule_<slug>` checks, so that is what its prompts should call them.
             check_noun: Some("rule".into()),
             evidence_kinds: default_evidence_kinds(),
-            // Reading the spec back is this demo's whole checker, so a refuted rule means the spec
-            // did not say what was asked — nothing about the program. There is no finding to write
-            // up, and declining is how a wheel says so.
+            // This demo only reads the spec back, so a refuted rule is about the spec, not the
+            // program. None means no findings.
             findings: None,
         }
     }

--- a/template_manifest.json
+++ b/template_manifest.json
@@ -173,16 +173,22 @@
     "template_name": "harness_generation_prompt.j2",
     "ty_sort": "TypedTemplate"
   },
-  "composer.spec.source.report.findings:_FINDINGS_SYSTEM": {
-    "module": "composer.spec.source.report.findings",
-    "qualname": "_FINDINGS_SYSTEM",
-    "template_name": "autoprove_report_findings_system.j2",
+  "composer.spec.source.prover_findings:_PROVER_DOMAIN": {
+    "module": "composer.spec.source.prover_findings",
+    "qualname": "_PROVER_DOMAIN",
+    "template_name": "autoprove_report_findings_prover_domain.j2",
     "ty_sort": "TypedTemplate"
   },
-  "composer.spec.source.report.findings:_FINDINGS_PROMPT": {
-    "module": "composer.spec.source.report.findings",
-    "qualname": "_FINDINGS_PROMPT",
+  "composer.spec.source.prover_findings:_WRITE_UP_PROMPT": {
+    "module": "composer.spec.source.prover_findings",
+    "qualname": "_WRITE_UP_PROMPT",
     "template_name": "autoprove_report_findings_prompt.j2",
+    "ty_sort": "TypedTemplate"
+  },
+  "composer.spec.source.report.findings:_SYSTEM": {
+    "module": "composer.spec.source.report.findings",
+    "qualname": "_SYSTEM",
+    "template_name": "autoprove_report_findings_system.j2",
     "ty_sort": "TypedTemplate"
   },
   "composer.spec.source.report.render:_REPORT_TEMPLATE": {

--- a/template_manifest.json
+++ b/template_manifest.json
@@ -101,6 +101,12 @@
     "template_name": "code_explorer/soroban.j2",
     "ty_sort": "TypedTemplate"
   },
+  "composer.rustapp.findings:_WRITE_UP_PROMPT": {
+    "module": "composer.rustapp.findings",
+    "qualname": "_WRITE_UP_PROMPT",
+    "template_name": "autoprove_report_findings_rust_prompt.j2",
+    "ty_sort": "TypedTemplate"
+  },
   "composer.rustapp.session:ProtocolTemplate": {
     "module": "composer.rustapp.session",
     "qualname": "ProtocolTemplate",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,6 +431,11 @@ def wire_descriptor(**overrides: Any) -> dict[str, Any]:
         "component_noun": None,
         "check_noun": None,
         "evidence_kinds": ["build_failure", "check_output", "counterexample", "reasoned"],
+        # A findings declaration by default: most tests that reach the report want findings
+        # written, and the ones about a wheel that declines override it with None.
+        "findings": {
+            "domain": "The demo backend read the spec back and it did not say what was asked.",
+        },
         **overrides,
     }
 
@@ -444,7 +449,7 @@ def wire_verdict(outcome: str, **overrides: Any) -> dict[str, Any]:
     """One ``Verdict`` — every diagnostic field null unless ``overrides`` says otherwise."""
     return {
         "outcome": outcome, "line": None, "duration_seconds": None,
-        "unit_file": None, "detail": None, **overrides,
+        "unit_file": None, "detail": None, "accounting": None, "finding": None, **overrides,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,8 +431,7 @@ def wire_descriptor(**overrides: Any) -> dict[str, Any]:
         "component_noun": None,
         "check_noun": None,
         "evidence_kinds": ["build_failure", "check_output", "counterexample", "reasoned"],
-        # A findings declaration by default: most tests that reach the report want findings
-        # written, and the ones about a wheel that declines override it with None.
+        # Default is a findings declaration. Tests that opt out pass findings=None.
         "findings": {
             "domain": "The demo backend read the spec back and it did not say what was asked.",
         },
@@ -449,7 +448,7 @@ def wire_verdict(outcome: str, **overrides: Any) -> dict[str, Any]:
     """One ``Verdict`` — every diagnostic field null unless ``overrides`` says otherwise."""
     return {
         "outcome": outcome, "line": None, "duration_seconds": None,
-        "unit_file": None, "detail": None, "accounting": None, "finding": None, **overrides,
+        "unit_file": None, "detail": None, "accounting": None, "finding_key": None, **overrides,
     }
 
 

--- a/tests/test_autoprove_report.py
+++ b/tests/test_autoprove_report.py
@@ -28,8 +28,10 @@ from composer.pipeline.core import Curtailed, Delivered
 
 from composer.spec.source.artifacts import ProverArtifactStore
 from composer.spec.source.report import build
-from composer.spec.source.report.collect import ReportComponentInput, collect
+from composer.spec.source.report.collect import ReportComponentInput, RuleEvidence, collect
 from composer.spec.source.report.coverage import ValidationError, validate
+from composer.spec.source.prover_findings import prover_findings
+from composer.spec.source.report.findings import FindingDraft
 from composer.spec.source.report.grouping import (
     FALLBACK_SLUG, GroupingResult, PropertyGroupDraft, aggregate_status,
     build_fallback_grouping, build_groups,
@@ -37,12 +39,11 @@ from composer.spec.source.report.grouping import (
 from composer.spec.source.report.render import render_html
 from composer.spec.source.report.schema import (
     AutoProverReport, CoverageReport, CurtailedComponent, CurtailedSkip, DraftedProperty, Finding, FindingProvenance, FormalizedProperty,
-    GaveUpComponent, GroupStatus, ImpactLevel, IssueContent, LikelihoodLevel, Outcome,
-    PropertyGroup, RuleVerdict, SeverityTier, SkippedClaim,
+    GaveUpComponent, GroupStatus, ImpactLevel, IssueContent, LikelihoodLevel, Outcome, PropertyGroup,
+    RuleVerdict, SeverityTier,
+    SkippedClaim,
 )
 from composer.spec.source.report_prover import make_prover_fetcher
-from composer.spec.source.report.collect import RuleEvidence
-from composer.spec.source.report.findings import FindingDraft, build_findings
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.diagnostics.timing import RunSummary
 
@@ -692,21 +693,6 @@ async def test_build_all_curtailed_skips_the_grouping_call(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _draft(*, impact_level: ImpactLevel = "high", likelihood_level: LikelihoodLevel = "medium",
-           title: str = "Reentrancy drains vault") -> FindingDraft:
-    return FindingDraft(
-        title=title, impact_level=impact_level, likelihood_level=likelihood_level,
-        risk_reasoning="High impact (fund loss); medium likelihood (needs a specific state).",
-        summary="s", description="d", impact="funds at risk", attack_path="1..2..3",
-    )
-
-
-def _evidence(by_rule: dict[str, list[RuleEvidence]]):
-    async def fetch(rule_name):
-        return by_rule.get(rule_name, [])
-    return fetch
-
-
 def _finding(severity: SeverityTier = "high") -> Finding:
     return Finding(
         title="Reentrancy drains vault", severity=severity,
@@ -720,25 +706,28 @@ def _finding(severity: SeverityTier = "high") -> Finding:
     )
 
 
-def test_severity_for_matrix():
-    """Severity is computed from the impact × likelihood matrix, not chosen by the LLM."""
-    from composer.spec.source.report.findings import severity_for
-    assert severity_for("high", "high") == "critical"
-    assert severity_for("high", "medium") == "high"
-    assert severity_for("high", "low") == "medium"
-    assert severity_for("medium", "high") == "high"
-    assert severity_for("medium", "medium") == "medium"
-    assert severity_for("low", "high") == "low"    # low impact caps at low regardless of likelihood
-    assert severity_for("low", "low") == "low"
-    assert severity_for("none", "high") == "informational"   # no exploit path -> informational
-    assert severity_for("none", "low") == "informational"
+def _draft(impact_level: ImpactLevel = "high",
+           likelihood_level: LikelihoodLevel = "medium") -> FindingDraft:
+    return FindingDraft(
+        title="Reentrancy drains vault",
+        impact_level=impact_level, likelihood_level=likelihood_level,
+        risk_reasoning="High impact; medium likelihood.",
+        summary="s", description="d", impact="funds at risk", attack_path="1..2..3",
+    )
+
+
+def _policy(by_rule: dict[str, list[RuleEvidence]]):
+    """The prover's findings policy over a canned evidence store, keyed as the report keys rows."""
+    async def fetch(ref):
+        return by_rule.get(ref[1], [])
+    return prover_findings(fetch)
 
 
 @pytest.mark.asyncio
 async def test_build_report_synthesizes_one_finding_per_violation():
     """Only the violated rule becomes a finding; severity is computed from the model's impact/
     likelihood, the counterexample rides proof_of_concept, the run link is a reference, and provenance
-    traces back to the rule. No locations are produced at report time (submission builds those)."""
+    traces back to the rule."""
     gen = _gen({"p_good": ["r_ok"], "p_bad": ["r_bad"]})
     fetch = _fetcher({"L1": [
         _fake_check("r_ok", NodeStatus.VERIFIED, file="autospec_C.spec"),
@@ -746,14 +735,14 @@ async def test_build_report_synthesizes_one_finding_per_violation():
     ]})
     grouping = _StructuredStubModel(output=GroupingResult(groups=[PropertyGroupDraft(
         slug="g", title="G", description="gd", members=[("C", "p_good"), ("C", "p_bad")])]))
-    evidence = _evidence({"r_bad": [RuleEvidence(analysis="root cause X", counterexample="<cex/>")]})
+    synthesis = _policy({"r_bad": [RuleEvidence(analysis="root cause X", counterexample="<cex/>")]})
 
     report = await build.build_report(
         contract_name="Vault", backend="prover",
         components=[_input("C", "autospec_C.spec",
                            [_prop("p_good", "d"), _prop("p_bad", "d")], gen)],
         llm=grouping, fetch_verdicts=fetch,
-        findings_llm=_StructuredStubModel(output=_draft()), fetch_evidence=evidence,
+        findings_llm=_StructuredStubModel(output=_draft()), findings=synthesis,
     )
 
     assert len(report.findings) == 1
@@ -762,17 +751,15 @@ async def test_build_report_synthesizes_one_finding_per_violation():
     prov = f.provenance
     assert prov is not None
     assert prov.impact == "high" and prov.likelihood == "medium"
-    assert prov.risk_reasoning                             # the axis justification is captured
     assert prov.rule_name == "r_bad" and prov.outcome == Outcome.BAD
     assert prov.group_slugs == ["g"] and prov.spec_file == "autospec_C.spec"
-    assert not hasattr(f, "locations")  # locations are a submission-layer concern, not on the report
     assert f.content.proof_of_concept == "<cex/>"
     assert f.content.references == ["L1"]
 
 
 @pytest.mark.asyncio
 async def test_build_report_no_findings_without_findings_llm():
-    """The findings pass is opt-in: omitting ``findings_llm`` leaves findings empty (back-compat)."""
+    """The findings pass is opt-in: omitting ``findings_llm`` leaves findings empty."""
     gen = _gen({"p_bad": ["r_bad"]})
     fetch = _fetcher({"L1": [_fake_check("r_bad", NodeStatus.VIOLATED)]})
     grouping = _StructuredStubModel(output=GroupingResult(groups=[PropertyGroupDraft(
@@ -786,49 +773,24 @@ async def test_build_report_no_findings_without_findings_llm():
 
 
 @pytest.mark.asyncio
-async def test_build_findings_degrades_without_analysis():
-    """A violated rule whose evidence fetch yields nothing (fetcher present, no analysis for that rule)
-    still produces a finding from the property/group text; proof_of_concept is simply absent."""
-    rules = [_rv("c.spec", "r_bad", Outcome.BAD)]
-    props = [_fp("C", "p_bad", [("c.spec", "r_bad")], desc="balances stay solvent")]
-    groups = [_pg("g", [("C", "p_bad")], status=GroupStatus.BAD)]
-    findings = await build_findings(
-        contract_name="Vault", rules=rules, properties=props, groups=groups,
-        fetch_evidence=_evidence({}),  # fetcher present, but no evidence recorded for r_bad
-        llm=_StructuredStubModel(output=_draft(impact_level="medium", likelihood_level="medium")),
+async def test_a_failing_findings_pass_still_yields_a_report():
+    """A failing synthesis must not take the report down with it."""
+    gen = _gen({"p_bad": ["r_bad"]})
+    fetch = _fetcher({"L1": [_fake_check("r_bad", NodeStatus.VIOLATED)]})
+    grouping = _StructuredStubModel(output=GroupingResult(groups=[PropertyGroupDraft(
+        slug="g", title="G", description="d", members=[("C", "p_bad")])]))
+
+    async def _boom(_ref):
+        raise RuntimeError("evidence store exploded")
+
+    report = await build.build_report(
+        contract_name="C", backend="prover",
+        components=[_input("C", "autospec_C.spec", [_prop("p_bad", "d")], gen)],
+        llm=grouping, fetch_verdicts=fetch,
+        findings_llm=_StructuredStubModel(output=_draft()), findings=prover_findings(_boom),
     )
-    assert len(findings) == 1
-    assert findings[0].severity == "medium"               # medium × medium
-    assert findings[0].content.proof_of_concept is None
-    prov = findings[0].provenance
-    assert prov is not None and prov.spec_file == "c.spec"
-
-
-@pytest.mark.asyncio
-async def test_build_findings_empty_without_evidence_fetcher():
-    """Findings are produced only when the backend supplies an evidence fetcher — no backend-id
-    check. A backend that opts out (fetch_evidence is None) yields no findings."""
-    rules = [_rv("c.spec", "r_bad", Outcome.BAD)]
-    findings = await build_findings(
-        contract_name="V", rules=rules, properties=[], groups=[],
-        fetch_evidence=None, llm=_StructuredStubModel(output=_draft()),
-    )
-    assert findings == []
-
-
-def test_findings_prompt_lists_all_properties_a_rule_formalizes():
-    """A rule may jointly formalize several properties; the prompt presents ALL of them so the model
-    grounds the write-up in the one the counterexample actually breaks (not a pre-picked one)."""
-    from composer.templates.loader import load_jinja_template
-    user = load_jinja_template(
-        "autoprove_report_findings_prompt.j2",
-        contract_name="Vault", rule_name="allowDeposits_revert_characteristic",
-        properties=[_fp("C", "revert_on_non_admin", [], desc="reverts if caller is not an admin"),
-                    _fp("C", "revert_on_zero_actor", [], desc="reverts if allowedActor is address(0)")],
-        groups=[], instances=[RuleEvidence(analysis="the admin check is skipped", counterexample="<cex/>")],
-    )
-    assert "reverts if caller is not an admin" in user
-    assert "reverts if allowedActor is address(0)" in user
+    assert report.findings == []
+    assert report.rules  # the rest of the report is intact
 
 
 def test_render_html_findings_section():

--- a/tests/test_autoprove_report.py
+++ b/tests/test_autoprove_report.py
@@ -40,8 +40,7 @@ from composer.spec.source.report.render import render_html
 from composer.spec.source.report.schema import (
     AutoProverReport, CoverageReport, CurtailedComponent, CurtailedSkip, DraftedProperty, Finding, FindingProvenance, FormalizedProperty,
     GaveUpComponent, GroupStatus, ImpactLevel, IssueContent, LikelihoodLevel, Outcome, PropertyGroup,
-    RuleVerdict, SeverityTier,
-    SkippedClaim,
+    RuleVerdict, SeverityTier, SkippedClaim, UnreproducedExpectedFailure,
 )
 from composer.spec.source.report_prover import make_prover_fetcher
 from composer.spec.source.cex_capture import CexAnalysisStore
@@ -475,6 +474,43 @@ def test_render_html_shows_finding_message():
     assert "crash abc: deposit(5) - expected 105 got 100" in h
 
 
+def test_render_html_shows_accounting_apart_from_the_message():
+    p1 = _fp("C", "p_dep", [("c.spec", "c_deposit")], desc="deposit increases balance")
+    rules = [RuleVerdict(name="c_deposit", spec_file="c.spec", outcome=Outcome.BAD,
+                         message="crash abc", accounting="spent 41231 executions")]
+    groups = [PropertyGroup(slug="deposits", title="Deposits", description="d",
+                            status=GroupStatus.BAD, members=[("C", "p_dep")])]
+    cov = CoverageReport(total_properties=1, total_rules=1, total_groups=1,
+                         properties_per_group_min=1, properties_per_group_max=1,
+                         property_coverage_complete=True)
+    h = render_html(AutoProverReport(contract_name="Vault", backend="foundry",
+                                     properties=[p1], rules=rules, groups=groups,
+                                     skipped=[], coverage=cov))
+    assert 'class="finding"' in h and "crash abc" in h
+    assert 'class="accounting"' in h and "spent 41231 executions" in h
+
+
+def test_render_html_shows_an_unreproduced_expected_failure():
+    p1 = _fp("C", "p_dep", [("c.spec", "c_deposit")], desc="deposit increases balance")
+    rules = [RuleVerdict(
+        name="c_deposit", spec_file="c.spec", outcome=Outcome.BAD,
+        expected_failure=UnreproducedExpectedFailure(
+            reason="kill switch is a no-op", ran=Outcome.GOOD,
+        ),
+    )]
+    groups = [PropertyGroup(slug="deposits", title="Deposits", description="d",
+                            status=GroupStatus.BAD, members=[("C", "p_dep")])]
+    cov = CoverageReport(total_properties=1, total_rules=1, total_groups=1,
+                         properties_per_group_min=1, properties_per_group_max=1,
+                         property_coverage_complete=True)
+    h = render_html(AutoProverReport(contract_name="Vault", backend="foundry",
+                                     properties=[p1], rules=rules, groups=groups,
+                                     skipped=[], coverage=cov))
+    assert 'class="expected-failure"' in h
+    assert "kill switch is a no-op" in h
+    assert "Successful test" in h  # foundry label for GOOD
+
+
 def test_render_html_group_rows_and_edge_labels():
     h = render_html(_mini_report())
     assert "deposit-openness" in h and "Deposit is open" in h
@@ -725,9 +761,7 @@ def _policy(by_rule: dict[str, list[RuleEvidence]]):
 
 @pytest.mark.asyncio
 async def test_build_report_synthesizes_one_finding_per_violation():
-    """Only the violated rule becomes a finding; severity is computed from the model's impact/
-    likelihood, the counterexample rides proof_of_concept, the run link is a reference, and provenance
-    traces back to the rule."""
+    """One finding for the violated rule: computed severity, CEX as proof of concept, provenance back to the rule."""
     gen = _gen({"p_good": ["r_ok"], "p_bad": ["r_bad"]})
     fetch = _fetcher({"L1": [
         _fake_check("r_ok", NodeStatus.VERIFIED, file="autospec_C.spec"),

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -67,7 +67,7 @@ class _Formalizer:
         return _Result()
 
     def extra_report_inputs(self): return []
-    def findings_evidence(self): return None
+    def findings_policy(self, _outcomes): return None
     async def fetch_verdicts(self, _inp): return {}
     async def finalize(self, _outcomes, _run): return None
 

--- a/tests/test_prover_findings.py
+++ b/tests/test_prover_findings.py
@@ -173,7 +173,7 @@ async def test_stamped_rows_are_written_up_against_the_union():
         _pg("g_a", [("A", "prop_a")], status=GroupStatus.BAD),
         _pg("g_bc", [("B", "prop_b"), ("C", "prop_c")], status=GroupStatus.BAD),
     ]
-    ev = [RuleEvidence(counterexample="<cex/>", finding="one")]
+    ev = [RuleEvidence(counterexample="<cex/>", finding_key="one")]
     llm = _Capture(output=_draft())
     findings = await build_findings(
         contract_name="Vault", rules=rules, properties=props, groups=groups,
@@ -190,10 +190,7 @@ async def test_stamped_rows_are_written_up_against_the_union():
 
 
 def test_how_far_this_evidence_goes_is_the_domains_not_the_hosts():
-    """Axes and sections are the host's; a counterexample being a confirmed break is the Prover's.
-
-    Domain is prepended, so a shared closer that said 'rate only what a real actor could reach'
-    would overwrite it."""
+    """How far the evidence goes is the Prover domain's, not a shared closer after it."""
     from composer.templates.loader import load_jinja_template
 
     system = load_jinja_template(

--- a/tests/test_prover_findings.py
+++ b/tests/test_prover_findings.py
@@ -1,0 +1,158 @@
+"""Tests for the Certora Prover's findings write-up.
+
+The LLM is a stub with preset structured output, so the real call path
+(templates, isinstance check, severity matrix) still runs.
+"""
+from typing import Any
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.outputs import ChatResult
+from langchain_core.runnables import Runnable, RunnableLambda
+
+from composer.spec.types import PropertyType
+from composer.spec.source.report.collect import RuleEvidence
+from composer.spec.source.report.findings import FindingDraft, build_findings, severity_for
+from composer.spec.source.prover_findings import prover_findings
+from composer.spec.source.report.schema import (
+    FormalizedProperty, GroupStatus, ImpactLevel, LikelihoodLevel, Outcome, PropertyGroup,
+    RuleVerdict,
+)
+
+
+def _fp(component, title, refs, desc="d", sort: PropertyType = "safety_property") -> FormalizedProperty:
+    return FormalizedProperty(component=component, title=title,
+                              sort=sort, description=desc, rule_refs=refs)
+
+
+def _rv(spec, name, outcome=Outcome.GOOD, prover_link=None) -> RuleVerdict:
+    return RuleVerdict(name=name, spec_file=spec, outcome=outcome, prover_link=prover_link)
+
+
+def _pg(slug, members, status=GroupStatus.GOOD) -> PropertyGroup:
+    return PropertyGroup(slug=slug, title="T", description="d", status=status, members=members)
+
+
+class _StructuredStubModel(BaseChatModel):
+    """`BaseChatModel` stub: structured output is preset; no live model."""
+    output: Any
+
+    def with_structured_output(self, schema, **kwargs) -> Runnable:  # type: ignore[override]
+        out = self.output
+        return RunnableLambda(lambda _messages: out)
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        raise NotImplementedError("stub is structured-output only")
+
+    @property
+    def _llm_type(self) -> str:
+        return "structured-stub"
+
+
+def _draft(*, impact_level: ImpactLevel = "high", likelihood_level: LikelihoodLevel = "medium",
+           title: str = "Reentrancy drains vault") -> FindingDraft:
+    return FindingDraft(
+        title=title, impact_level=impact_level, likelihood_level=likelihood_level,
+        risk_reasoning="High impact (fund loss); medium likelihood (needs a specific state).",
+        summary="s", description="d", impact="funds at risk", attack_path="1..2..3",
+    )
+
+
+def _policy(by_rule: dict[str, list[RuleEvidence]]):
+    async def fetch(ref):
+        return by_rule.get(ref[1], [])
+    return prover_findings(fetch)
+
+
+def test_severity_for_matrix():
+    """Severity comes from the impact × likelihood matrix, not from the LLM."""
+    assert severity_for("high", "high") == "critical"
+    assert severity_for("high", "medium") == "high"
+    assert severity_for("high", "low") == "medium"
+    assert severity_for("medium", "high") == "high"
+    assert severity_for("medium", "medium") == "medium"
+    assert severity_for("low", "high") == "low"    # low impact caps at low regardless of likelihood
+    assert severity_for("low", "low") == "low"
+    assert severity_for("none", "high") == "informational"   # no exploit path -> informational
+    assert severity_for("none", "low") == "informational"
+
+
+@pytest.mark.asyncio
+async def test_one_finding_per_violation():
+    """One finding per BAD rule: computed severity, CEX as proof of concept, provenance back to the rule."""
+    rules = [_rv("autospec_C.spec", "r_ok"),
+             _rv("autospec_C.spec", "r_bad", Outcome.BAD, prover_link="L1")]
+    props = [_fp("C", "p_good", [("autospec_C.spec", "r_ok")]),
+             _fp("C", "p_bad", [("autospec_C.spec", "r_bad")])]
+    groups = [_pg("g", [("C", "p_good"), ("C", "p_bad")], status=GroupStatus.BAD)]
+
+    findings = await build_findings(
+        contract_name="Vault", rules=rules, properties=props, groups=groups,
+        policy=_policy({"r_bad": [RuleEvidence(analysis="root cause X",
+                                                         counterexample="<cex/>")]}),
+        llm=_StructuredStubModel(output=_draft()),
+    )
+
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.severity == "high"                            # computed: impact high × likelihood medium
+    prov = f.provenance
+    assert prov is not None
+    assert prov.impact == "high" and prov.likelihood == "medium"
+    assert prov.risk_reasoning                             # the axis justification is captured
+    assert prov.rule_name == "r_bad" and prov.outcome == Outcome.BAD
+    assert prov.group_slugs == ["g"] and prov.spec_file == "autospec_C.spec"
+    assert not hasattr(f, "locations")  # locations are a submission-layer concern, not on the report
+    assert f.content.proof_of_concept == "<cex/>"
+    assert f.content.references == ["L1"]
+
+
+@pytest.mark.asyncio
+async def test_degrades_without_analysis():
+    """A violation with no captured evidence still becomes a finding; proof of concept is absent."""
+    findings = await build_findings(
+        contract_name="Vault", rules=[_rv("c.spec", "r_bad", Outcome.BAD)],
+        properties=[_fp("C", "p_bad", [("c.spec", "r_bad")], desc="balances stay solvent")],
+        groups=[_pg("g", [("C", "p_bad")], status=GroupStatus.BAD)],
+        policy=_policy({}),  # policy present, but no evidence recorded for r_bad
+        llm=_StructuredStubModel(output=_draft(impact_level="medium", likelihood_level="medium")),
+    )
+    assert len(findings) == 1
+    assert findings[0].severity == "medium"               # medium × medium
+    assert findings[0].content.proof_of_concept is None
+    prov = findings[0].provenance
+    assert prov is not None and prov.spec_file == "c.spec"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_synthesis_drops_only_that_finding():
+    """One failed write-up must not drop the others."""
+    class _HalfBroken(_StructuredStubModel):
+        def with_structured_output(self, schema, **kwargs) -> Runnable:  # type: ignore[override]
+            def _run(messages):
+                if "r_boom" in messages[-1].content:
+                    raise RuntimeError("model refused")
+                return _draft()
+            return RunnableLambda(_run)
+
+    rules = [_rv("c.spec", "r_boom", Outcome.BAD), _rv("c.spec", "r_bad", Outcome.BAD)]
+    props = [_fp("C", "p_boom", [("c.spec", "r_boom")]), _fp("C", "p_bad", [("c.spec", "r_bad")])]
+    findings = await build_findings(
+        contract_name="Vault", rules=rules, properties=props, groups=[],
+        policy=_policy({}), llm=_HalfBroken(output=_draft()),
+    )
+    assert [f.provenance.rule_name for f in findings if f.provenance] == ["r_bad"]
+
+
+def test_prompt_lists_all_properties_a_rule_formalizes():
+    """The prompt lists every property a rule formalizes, not a pre-picked one."""
+    from composer.templates.loader import load_jinja_template
+    user = load_jinja_template(
+        "autoprove_report_findings_prompt.j2",
+        contract_name="Vault", rule_name="allowDeposits_revert_characteristic",
+        properties=[_fp("C", "revert_on_non_admin", [], desc="reverts if caller is not an admin"),
+                    _fp("C", "revert_on_zero_actor", [], desc="reverts if allowedActor is address(0)")],
+        groups=[], instances=[RuleEvidence(analysis="the admin check is skipped", counterexample="<cex/>")],
+    )
+    assert "reverts if caller is not an admin" in user
+    assert "reverts if allowedActor is address(0)" in user

--- a/tests/test_prover_findings.py
+++ b/tests/test_prover_findings.py
@@ -102,6 +102,7 @@ async def test_one_finding_per_violation():
     assert prov.risk_reasoning                             # the axis justification is captured
     assert prov.rule_name == "r_bad" and prov.outcome == Outcome.BAD
     assert prov.group_slugs == ["g"] and prov.spec_file == "autospec_C.spec"
+    assert prov.covers == []
     assert not hasattr(f, "locations")  # locations are a submission-layer concern, not on the report
     assert f.content.proof_of_concept == "<cex/>"
     assert f.content.references == ["L1"]
@@ -144,15 +145,80 @@ async def test_a_failed_synthesis_drops_only_that_finding():
     assert [f.provenance.rule_name for f in findings if f.provenance] == ["r_bad"]
 
 
+@pytest.mark.asyncio
+async def test_stamped_rows_are_written_up_against_the_union():
+    """One finding key, one write-up: every covered row's properties and groups, recorded on the finding."""
+    class _Capture(_StructuredStubModel):
+        prompt: str = ""
+
+        def with_structured_output(self, schema, **kwargs) -> Runnable:  # type: ignore[override]
+            capture = self
+
+            def _run(messages):
+                capture.prompt = messages[-1].content
+                return _draft()
+            return RunnableLambda(_run)
+
+    rules = [
+        _rv("a.spec", "r_a", Outcome.BAD),
+        _rv("b.spec", "r_b", Outcome.BAD),
+        _rv("c.spec", "r_c", Outcome.BAD),
+    ]
+    props = [
+        _fp("A", "prop_a", [("a.spec", "r_a")], desc="a holds"),
+        _fp("B", "prop_b", [("b.spec", "r_b")], desc="b holds"),
+        _fp("C", "prop_c", [("c.spec", "r_c")], desc="c holds"),
+    ]
+    groups = [
+        _pg("g_a", [("A", "prop_a")], status=GroupStatus.BAD),
+        _pg("g_bc", [("B", "prop_b"), ("C", "prop_c")], status=GroupStatus.BAD),
+    ]
+    ev = [RuleEvidence(counterexample="<cex/>", finding="one")]
+    llm = _Capture(output=_draft())
+    findings = await build_findings(
+        contract_name="Vault", rules=rules, properties=props, groups=groups,
+        policy=_policy({"r_a": ev, "r_b": ev, "r_c": ev}), llm=llm,
+    )
+
+    assert len(findings) == 1
+    assert "a holds" in llm.prompt and "b holds" in llm.prompt and "c holds" in llm.prompt
+    prov = findings[0].provenance
+    assert prov is not None
+    assert prov.covers == [("a.spec", "r_a"), ("b.spec", "r_b"), ("c.spec", "r_c")]
+    assert prov.group_slugs == ["g_a", "g_bc"]
+    assert findings[0].content.proof_of_concept == "<cex/>"
+
+
+def test_how_far_this_evidence_goes_is_the_domains_not_the_hosts():
+    """Axes and sections are the host's; a counterexample being a confirmed break is the Prover's.
+
+    Domain is prepended, so a shared closer that said 'rate only what a real actor could reach'
+    would overwrite it."""
+    from composer.templates.loader import load_jinja_template
+
+    system = load_jinja_template(
+        "autoprove_report_findings_system.j2", domain=_policy({}).domain,
+    )
+    assert "do not rate a genuine break as impact" in system
+    assert system.index("do not rate a genuine break") < system.index("HOW SEVERITY IS REACHED")
+    assert "worst thing the code could conceivably do" not in system
+    assert "assuming the worst" not in system
+
+
 def test_prompt_lists_all_properties_a_rule_formalizes():
-    """The prompt lists every property a rule formalizes, not a pre-picked one."""
+    """The prompt lists every property a rule formalizes, not a pre-picked one, and the
+    evidence that rule produced."""
     from composer.templates.loader import load_jinja_template
     user = load_jinja_template(
         "autoprove_report_findings_prompt.j2",
         contract_name="Vault", rule_name="allowDeposits_revert_characteristic",
         properties=[_fp("C", "revert_on_non_admin", [], desc="reverts if caller is not an admin"),
                     _fp("C", "revert_on_zero_actor", [], desc="reverts if allowedActor is address(0)")],
-        groups=[], instances=[RuleEvidence(analysis="the admin check is skipped", counterexample="<cex/>")],
+        groups=[], also_covers=[],
+        evidence=[RuleEvidence(analysis="the admin check is skipped", counterexample="<cex/>")],
     )
     assert "reverts if caller is not an admin" in user
     assert "reverts if allowedActor is address(0)" in user
+    assert "the admin check is skipped" in user
+    assert "<cex/>" in user
+    assert "No counterexample evidence was captured" not in user

--- a/tests/test_rustapp.py
+++ b/tests/test_rustapp.py
@@ -138,7 +138,7 @@ def test_result_round_trips_through_cache_serialization():
         verdicts={"rule_p": Verdict(outcome=Outcome.BAD, line=7, detail="counterexample",
                                     duration_seconds=None, unit_file=None,
                                     accounting="campaign spent 41231 executions",
-                                    finding=None)},
+                                    finding_key=None)},
     )
     reloaded = RustFormalResult.model_validate_json(res.model_dump_json())
     assert reloaded.property_checks() == [("p", ["rule_p"])]

--- a/tests/test_rustapp.py
+++ b/tests/test_rustapp.py
@@ -136,7 +136,9 @@ def test_result_round_trips_through_cache_serialization():
         skipped=[SkippedProperty(property_title="q", reason="n/a")],
         output_link="local://x",
         verdicts={"rule_p": Verdict(outcome=Outcome.BAD, line=7, detail="counterexample",
-                                    duration_seconds=None, unit_file=None)},
+                                    duration_seconds=None, unit_file=None,
+                                    accounting="campaign spent 41231 executions",
+                                    finding=None)},
     )
     reloaded = RustFormalResult.model_validate_json(res.model_dump_json())
     assert reloaded.property_checks() == [("p", ["rule_p"])]

--- a/tests/test_rustapp_findings.py
+++ b/tests/test_rustapp_findings.py
@@ -1,18 +1,12 @@
-"""The declaration fold: what a Rust backend reports for a check its author declared broken.
+"""What a Rust backend reports for a check its author declared broken.
 
-A check marked ``expect_check_failure`` must report BAD either way: reproduced findings carry
-their counterexample; unreproduced ones have no proof of concept and say so. Stamps on
-``Verdict.finding`` collapse those rows to one write-up. A wheel with ``findings=None`` produces
-no findings.
+An ``expect_check_failure`` check reports BAD either way: reproduced findings keep their
+counterexample; unreproduced ones have no proof of concept. Stamps on ``Verdict.finding_key``
+collapse those rows to one write-up. ``findings=None`` produces no findings.
 
-``expect_check_failure`` is how an author says "the failure here IS the finding". The publish
-gate accepts such a check as clean without requiring the run to reproduce it, so the fold is
-what stands between a documented finding and a green report row.
-
-The declaration is the author's and the outcome is the wheel's; they meet on
-``RustFormalResult``, and the first group below pins that meeting down for both consumers
-of it — the HTML report and the console rollup, which must not disagree about whether a
-run found something.
+The publish gate accepts an expected-to-fail check without requiring a repro, so this fold
+is what keeps a documented finding off a green report row. Report and console both read
+``reported_verdicts``, so they cannot disagree.
 """
 
 import pathlib
@@ -36,8 +30,9 @@ from composer.spec.source.report.findings import FindingDraft, build_findings
 from composer.templates.loader import load_jinja_template
 from composer.spec.source.report.schema import (
     Finding, ImpactLevel, LikelihoodLevel, Outcome,
+    ReproducedExpectedFailure, UnreproducedExpectedFailure,
 )
-from composer.spec.types import PropertyFormulation
+from composer.spec.types import FindingKey, PropertyFormulation
 from tests.conftest import wire_descriptor
 
 #: Sample counterexample text a wheel might put on ``Verdict.detail``.
@@ -52,20 +47,20 @@ REASON = "UpdateBlockPriceUsage only mark_stale()s, so PRICE_USAGE_ALLOWED survi
 
 
 def _verdict(outcome: Outcome, detail: str | None = None, accounting: str | None = None,
-             finding: str | None = None) -> Verdict:
+             finding_key: FindingKey | None = None) -> Verdict:
     return Verdict(outcome=outcome, line=None, duration_seconds=None, unit_file=None,
-                   detail=detail, accounting=accounting, finding=finding)
+                   detail=detail, accounting=accounting, finding_key=finding_key)
 
 
 def _result(
     verdicts: dict[str, Verdict],
-    declared: dict[str, str],
+    expected_failures: dict[str, str],
     checks: list[tuple[str, list[str]]] | None = None,
 ) -> RustFormalResult:
     return RustFormalResult(
         checks=checks if checks is not None else [(f"{name}_prop", [name]) for name in verdicts],
         verdicts=verdicts,
-        expected_failures=declared,
+        expected_failures=expected_failures,
     )
 
 
@@ -74,29 +69,26 @@ def _result(
 # ---------------------------------------------------------------------------
 
 def test_a_declared_finding_the_run_reproduced_reports_bad_with_its_counterexample():
-    reported = _result(
+    result = _result(
         {"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE)}, {"c_ts": REASON}
-    ).reported_verdicts()
+    )
+    reported = result.reported_verdicts()
 
     assert reported["c_ts"].outcome is Outcome.BAD
-    detail = reported["c_ts"].detail or ""
-    # Declaration and counterexample both have to survive the fold.
-    assert REASON in detail
-    assert COUNTEREXAMPLE in detail
+    assert reported["c_ts"].detail == COUNTEREXAMPLE
+    assert result.expected_failure("c_ts") == ReproducedExpectedFailure(reason=REASON)
 
 
 def test_a_declared_finding_the_run_did_not_reproduce_still_reports_as_a_finding():
     # Wheel said GOOD; the declaration still makes it a finding.
-    reported = _result(
+    result = _result(
         {"c_kill": _verdict(Outcome.GOOD)}, {"c_kill": REASON}
-    ).reported_verdicts()
+    )
+    reported = result.reported_verdicts()
 
     assert reported["c_kill"].outcome is Outcome.BAD, "a documented finding must not read as a pass"
-    detail = reported["c_kill"].detail or ""
-    assert REASON in detail
-    # Weaker claim: say so, and name the outcome the run actually reached.
-    assert "NOT REPRODUCED" in detail
-    assert "GOOD" in detail, "the run's own outcome is what makes the claim weaker; name it"
+    assert reported["c_kill"].detail is None
+    assert result.expected_failure("c_kill") == UnreproducedExpectedFailure(reason=REASON, ran=Outcome.GOOD)
 
 
 def test_an_undeclared_check_is_left_exactly_as_the_wheel_reported_it():
@@ -111,14 +103,16 @@ def test_an_undeclared_check_is_left_exactly_as_the_wheel_reported_it():
 
 def test_a_declared_check_whose_run_errored_keeps_the_error_text():
     # Keep the error text so the row still explains what happened.
-    reported = _result(
+    result = _result(
         {"c_kill": _verdict(Outcome.ERROR, "harness build timed out")}, {"c_kill": REASON}
-    ).reported_verdicts()
+    )
+    reported = result.reported_verdicts()
 
     assert reported["c_kill"].outcome is Outcome.BAD
-    detail = reported["c_kill"].detail or ""
-    assert "NOT REPRODUCED" in detail and "ERROR" in detail
-    assert "harness build timed out" in detail
+    assert reported["c_kill"].detail == "harness build timed out"
+    assert result.expected_failure("c_kill") == UnreproducedExpectedFailure(
+        reason=REASON, ran=Outcome.ERROR,
+    )
 
 
 def test_a_declaration_naming_a_check_that_did_not_run_adds_no_row():
@@ -153,9 +147,13 @@ async def test_the_report_gets_the_declared_finding():
     verdicts = await formalizer.fetch_verdicts(cast(Any, _Formalized(result)))
 
     assert verdicts["c_kill"].outcome is Outcome.BAD
-    assert REASON in (verdicts["c_kill"].message or "")
-    # Only the declared check changes.
+    assert verdicts["c_kill"].message is None
+    assert verdicts["c_kill"].expected_failure == UnreproducedExpectedFailure(
+        reason=REASON, ran=Outcome.GOOD,
+    )
+    # Only the expected-to-fail check changes.
     assert verdicts["c_plain"].outcome is Outcome.GOOD
+    assert verdicts["c_plain"].expected_failure is None
 
 
 @dataclass
@@ -190,12 +188,7 @@ def test_the_console_rollup_agrees_with_the_report():
 
 @pytest.mark.asyncio
 async def test_a_wheels_own_file_beats_the_components_fallback():
-    """A verdict that names its own file keeps it; otherwise use the component artifact.
-
-    The report keys a row by ``(file, name)``. A callout-mode wheel delivers one
-    artifact, so every component would share that fallback — two same-named checks
-    would collapse. The wheel's ``unit_file`` is what keeps them apart.
-    """
+    """A verdict that names its own file keeps it; otherwise use the component artifact."""
     formalizer = adapter.RustFormalizer(
         cast(Any, object()), AppDescriptor.model_validate(wire_descriptor())
     )
@@ -282,7 +275,7 @@ async def test_a_reproduced_crash_is_the_proof_of_concept():
 
 @pytest.mark.asyncio
 async def test_an_unreproduced_declared_finding_claims_no_counterexample():
-    """Its only ground is the author's reading, and the finding has to say so rather than show one."""
+    """An unreproduced declared finding has no proof of concept."""
     result = _result({"c_kill": _verdict(Outcome.GOOD, "campaign spent 41231 executions")},
                      {"c_kill": REASON})
     findings = await _written(_outcome(result))
@@ -293,8 +286,7 @@ async def test_an_unreproduced_declared_finding_claims_no_counterexample():
 
 @pytest.mark.asyncio
 async def test_a_fuzz_finding_is_rated_like_any_other():
-    """The axes are the model's and the tier is the matrix's, so a reader can re-derive the severity
-    from what the write-up actually said rather than taking it on trust."""
+    """Severity comes from the model's axes through the matrix, not from the backend."""
     result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE)}, {})
     f = (await _written(_outcome(result)))[0]
 
@@ -306,10 +298,7 @@ async def test_a_fuzz_finding_is_rated_like_any_other():
 
 @pytest.mark.asyncio
 async def test_two_sections_naming_one_check_keep_their_own_crash():
-    """Two authors given the same property title write the same check name, and the report keys a
-    row by ``(file, name)`` — the section file is the only thing keeping the two rows apart. The
-    evidence is keyed the same way, so a section's finding must carry that section's reproducer.
-    """
+    """Same check name in two files is two rows; each finding carries that file's reproducer."""
     left = _result({"c_auth": _verdict(Outcome.BAD, "crash A")}, {})
     right = _result({"c_auth": _verdict(Outcome.BAD, "crash B")}, {})
     for res, section in ((left, "c_vault_initialization.rs"), (right, "c_lamport_custody.rs")):
@@ -326,11 +315,7 @@ async def test_two_sections_naming_one_check_keep_their_own_crash():
 
 @pytest.mark.asyncio
 async def test_a_finding_on_a_collapsed_row_reads_the_run_that_row_came_from():
-    """Without a section file the two rows do collapse — the finding must follow the row.
-
-    ``collect`` keeps the first run naming a ``(file, name)``; the evidence has to keep the same
-    one, or the row's message and its finding's proof of concept describe different runs.
-    """
+    """Without a section file the two rows collapse; the finding must follow the surviving row."""
     first = _result({"c_auth": _verdict(Outcome.BAD, "crash A")}, {})
     second = _result({"c_auth": _verdict(Outcome.BAD, "crash B")}, {})
 
@@ -341,12 +326,13 @@ async def test_a_finding_on_a_collapsed_row_reads_the_run_that_row_came_from():
 
 
 def test_the_prompt_offers_no_counterexample_for_a_finding_the_run_did_not_reproduce():
-    """The prompt is where a model could be led to invent one, so the distinction lives there too."""
+    """An unreproduced finding's prompt must not invite a counterexample."""
     user = load_jinja_template(
         "autoprove_report_findings_rust_prompt.j2",
         contract_name="klend", rule_name="c_kill", properties=[], groups=[], also_covers=[],
         evidence=[RuleEvidence(label="Oracle", ran=Outcome.GOOD,
-                               accounting="campaign spent 41231 executions", declared=REASON)],
+                               accounting="campaign spent 41231 executions",
+                               expected_failure_reason=REASON)],
     )
 
     assert "did NOT reproduce" in user and REASON in user
@@ -366,7 +352,7 @@ ACCOUNTING = (
 
 @pytest.mark.asyncio
 async def test_a_proof_of_concept_is_the_crash_and_not_what_the_campaign_spent():
-    """Run accounting inside a proof of concept leaves a reader unable to see where evidence ends."""
+    """A proof of concept is the reproducer, not the run accounting."""
     result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE, ACCOUNTING)}, {})
     f = (await _written(_outcome(result)))[0]
 
@@ -376,11 +362,7 @@ async def test_a_proof_of_concept_is_the_crash_and_not_what_the_campaign_spent()
 
 @pytest.mark.asyncio
 async def test_a_green_row_still_says_what_the_campaign_cost():
-    """The split must not cost the report the accounting a passing row is supposed to carry.
-
-    The report has one ``message`` per row, so `fetch_verdicts` rejoins the halves — evidence
-    first, because a BAD row's first line is what a reader is looking for.
-    """
+    """A green row still carries its accounting; a BAD row keeps evidence and accounting apart."""
     result = _result({"c_ok": _verdict(Outcome.GOOD, None, ACCOUNTING),
                       "c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE, ACCOUNTING)}, {})
     fz = adapter.RustFormalizer(
@@ -388,9 +370,9 @@ async def test_a_green_row_still_says_what_the_campaign_cost():
     )
     rows = await fz.fetch_verdicts(cast(Any, _Formalized(result)))
 
-    assert rows["c_ok"].message == ACCOUNTING, "a green row's whole worth is its accounting"
-    bad = rows["c_ts"].message or ""
-    assert bad.startswith(COUNTEREXAMPLE) and bad.endswith(ACCOUNTING)
+    assert rows["c_ok"].message is None and rows["c_ok"].accounting == ACCOUNTING
+    assert rows["c_ts"].message == COUNTEREXAMPLE
+    assert rows["c_ts"].accounting == ACCOUNTING
 
 
 def test_the_prompt_keeps_the_accounting_out_of_the_evidence():
@@ -476,20 +458,14 @@ def test_an_unattributed_write_up_lists_every_covered_check_and_none_as_the_subj
 
 @pytest.mark.asyncio
 async def test_a_crash_the_campaign_could_not_place_is_written_up_once():
-    """A wheel that cannot attribute one conclusion to one check stamps the fan-out as one
-    finding (`Verdict.finding`).
+    """A stamp on ``Verdict.finding_key`` writes several BAD rows up once.
 
-    Condemning every covered check is right for the verdict table — hiding a real failure would
-    be worse — but it is one finding, not one per row. Writing it up per row spends a heavy
-    model on each and publishes N accounts of the same evidence, each guessing a different check.
-
-    The key is the wheel's, and nothing here infers it: rows fanned out from one conclusion are
-    otherwise indistinguishable from several checks that failed identically, which is a different
-    fact about the program.
+    The key is the wheel's. Matching evidence is not enough to merge: several checks that
+    failed the same way are a different fact.
     """
     checks = [f"c_{i}" for i in range(6)]
     result = _result(
-        {c: _verdict(Outcome.BAD, UNPLACEABLE, ACCOUNTING, finding="c_vault") for c in checks}, {})
+        {c: _verdict(Outcome.BAD, UNPLACEABLE, ACCOUNTING, finding_key="c_vault") for c in checks}, {})
     model = _CountingModel(output=_draft(), calls=[], systems=[])
 
     findings = await _written_by(model, _outcome(result))
@@ -508,9 +484,7 @@ async def test_a_crash_the_campaign_could_not_place_is_written_up_once():
 
 @pytest.mark.asyncio
 async def test_the_loop_binds_this_runs_evidence_into_the_write_up_prompt():
-    """The host binds the prompt now, not the backend, so nothing backend-side would catch it
-    binding the wrong thing — and a write-up rendered against absent evidence still produces a
-    plausible finding rather than an error."""
+    """The host binds the write-up prompt, so the run's own evidence has to reach the model."""
     result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE, ACCOUNTING)}, {})
     model = _CountingModel(output=_draft(), calls=[], systems=[])
 
@@ -535,12 +509,7 @@ async def test_distinct_crashes_stay_distinct_findings():
 
 @pytest.mark.asyncio
 async def test_two_unreproduced_declarations_are_two_findings():
-    """An unstamped row stands on its own, so each declaration is its own claim.
-
-    Worth pinning because these two rows are otherwise as alike as rows get: no counterexample, and
-    the same accounting. Nothing about that similarity may merge two findings the author made
-    separately.
-    """
+    """Unstamped rows stay separate, even when they look alike (no counterexample, same accounting)."""
     result = _result({"c_kill": _verdict(Outcome.GOOD, None, ACCOUNTING),
                       "c_stale": _verdict(Outcome.GOOD, None, ACCOUNTING)},
                      {"c_kill": REASON, "c_stale": "a different documented bug"})
@@ -560,11 +529,7 @@ async def test_two_unreproduced_declarations_are_two_findings():
 # ---------------------------------------------------------------------------
 
 def test_a_wheel_that_declares_no_findings_policy_produces_none():
-    """No policy, no findings — not findings written from a default the host made up.
-
-    A write-up asserts what the evidence behind it is, and the host cannot know: it has verdicts,
-    not a claim about what produced them. A wheel that reports outcomes without saying what they
-    establish is coherent, and its report carries the verdict rows and nothing else."""
+    """No FindingsDeclaration means no findings, not a host-invented write-up."""
     fz = adapter.RustFormalizer(
         cast(Any, object()),
         AppDescriptor.model_validate(wire_descriptor(findings=None)),
@@ -576,12 +541,7 @@ def test_a_wheel_that_declares_no_findings_policy_produces_none():
 
 @pytest.mark.asyncio
 async def test_the_write_up_is_told_what_this_wheels_evidence_is():
-    """The wheel's own prose leads the system prompt, and the host's contract follows it.
-
-    The two halves are separable for the same reason `judge` splits them: what the evidence *is* is
-    the backend's claim, and how severity is reached and which sections come back is the host's, so
-    neither restates the other. The CVL backend's prompt is the same template with its own domain.
-    """
+    """The wheel's domain leads the system prompt; the host's severity contract follows it."""
     result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE)}, {})
     model = _CountingModel(output=_draft(), calls=[], systems=[])
 

--- a/tests/test_rustapp_findings.py
+++ b/tests/test_rustapp_findings.py
@@ -1,0 +1,584 @@
+"""The declaration fold: what a Rust backend reports for a check its author declared broken.
+
+A check marked ``expect_check_failure`` must report as a finding even if this run
+did not reproduce it. Reproduced and unreproduced findings must stay distinguishable.
+
+``expect_check_failure`` is how an author says "the failure here IS the finding". The
+publish gate accepts such a check as clean and nothing downstream ever asked the run to
+reproduce it, so on the klend run of 2026-08-10 four declared findings reached
+``report.html``: one as a violation (its campaign happened to hit it first) and three as
+**"No counterexample"** — including ``block_price_usage_kill_switch_effective``, which the
+author had reproduced at iteration 11619 and whose commentary documents the reproducing
+sequence.
+
+The declaration is the author's and the outcome is the wheel's; they meet on
+``RustFormalResult``, and the first group below pins that meeting down for both consumers
+of it — the HTML report and the console rollup, which must not disagree about whether a
+run found something.
+"""
+
+import pathlib
+from dataclasses import dataclass
+from typing import Any, cast
+from typing import Any, cast
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.outputs import ChatResult
+from langchain_core.runnables import Runnable, RunnableLambda
+
+from composer.pipeline.core import CorePipelineResult, Delivered
+from composer.pipeline.ptypes import ComponentOutcome
+from composer.rustapp import adapter
+from composer.rustapp.descriptor import AppDescriptor
+from composer.rustapp.result import RustFormalResult
+from composer.rustapp.results import summarize_verdicts
+from composer.rustapp.wire import Verdict
+from composer.spec.source.report.collect import ReportComponentInput, RuleEvidence, collect
+from composer.spec.source.report.findings import FindingDraft, build_findings
+from composer.templates.loader import load_jinja_template
+from composer.spec.source.report.schema import (
+    Finding, ImpactLevel, LikelihoodLevel, Outcome,
+)
+from composer.spec.types import PropertyFormulation
+from tests.conftest import wire_descriptor
+
+#: Crash text from a real Crucible hit, trimmed.
+COUNTEREXAMPLE = (
+    "crash crash_93d45d29a130d36f: [stored_price_timestamp_not_in_future] reserve 8J5W stored "
+    "market_price_last_updated_ts=2 which is ahead of the current unix timestamp 0\n"
+    "reproducing sequence (iteration 11, 3 action(s)):\n  1. refresh_reserves_batch -> OK"
+)
+
+#: Author's reason for a check this run did not hit.
+REASON = "UpdateBlockPriceUsage only mark_stale()s, so PRICE_USAGE_ALLOWED survives the kill switch"
+
+
+def _verdict(outcome: Outcome, detail: str | None = None, accounting: str | None = None,
+             finding: str | None = None) -> Verdict:
+    return Verdict(outcome=outcome, line=None, duration_seconds=None, unit_file=None,
+                   detail=detail, accounting=accounting, finding=finding)
+
+
+def _result(
+    verdicts: dict[str, Verdict],
+    declared: dict[str, str],
+    checks: list[tuple[str, list[str]]] | None = None,
+) -> RustFormalResult:
+    return RustFormalResult(
+        checks=checks if checks is not None else [(f"{name}_prop", [name]) for name in verdicts],
+        verdicts=verdicts,
+        expected_failures=declared,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The declaration fold
+# ---------------------------------------------------------------------------
+
+def test_a_declared_finding_the_run_reproduced_reports_bad_with_its_counterexample():
+    reported = _result(
+        {"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE)}, {"c_ts": REASON}
+    ).reported_verdicts()
+
+    assert reported["c_ts"].outcome is Outcome.BAD
+    detail = reported["c_ts"].detail or ""
+    # Declaration and counterexample both have to survive the fold.
+    assert REASON in detail
+    assert COUNTEREXAMPLE in detail
+
+
+def test_a_declared_finding_the_run_did_not_reproduce_still_reports_as_a_finding():
+    # Wheel said GOOD; the declaration still makes it a finding.
+    reported = _result(
+        {"c_kill": _verdict(Outcome.GOOD)}, {"c_kill": REASON}
+    ).reported_verdicts()
+
+    assert reported["c_kill"].outcome is Outcome.BAD, "a documented finding must not read as a pass"
+    detail = reported["c_kill"].detail or ""
+    assert REASON in detail
+    # Weaker claim: say so, and name the outcome the run actually reached.
+    assert "NOT REPRODUCED" in detail
+    assert "GOOD" in detail, "the run's own outcome is what makes the claim weaker; name it"
+
+
+def test_an_undeclared_check_is_left_exactly_as_the_wheel_reported_it():
+    # No declaration: leave the wheel's verdicts untouched.
+    verdicts = {
+        "c_good": _verdict(Outcome.GOOD),
+        "c_bad": _verdict(Outcome.BAD, COUNTEREXAMPLE),
+        "c_err": _verdict(Outcome.ERROR, "linker died"),
+    }
+    assert _result(verdicts, {}).reported_verdicts() == verdicts
+
+
+def test_a_declared_check_whose_run_errored_keeps_the_error_text():
+    # Keep the error text so the row still explains what happened.
+    reported = _result(
+        {"c_kill": _verdict(Outcome.ERROR, "harness build timed out")}, {"c_kill": REASON}
+    ).reported_verdicts()
+
+    assert reported["c_kill"].outcome is Outcome.BAD
+    detail = reported["c_kill"].detail or ""
+    assert "NOT REPRODUCED" in detail and "ERROR" in detail
+    assert "harness build timed out" in detail
+
+
+def test_a_declaration_naming_a_check_that_did_not_run_adds_no_row():
+    # A declaration for a check that never ran must not invent a row.
+    reported = _result({"c_good": _verdict(Outcome.GOOD)}, {"c_gone": REASON}).reported_verdicts()
+
+    assert list(reported) == ["c_good"]
+    assert reported["c_good"].outcome is Outcome.GOOD
+
+
+# ---------------------------------------------------------------------------
+# Both consumers of the fold
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _Formalized:
+    """The ``Formalized`` protocol the report's collector reads."""
+
+    result: RustFormalResult
+    unit_file: str = "main.rs"
+    run_link: str | None = None
+
+
+@pytest.mark.asyncio
+async def test_the_report_gets_the_declared_finding():
+    formalizer = adapter.RustFormalizer(
+        cast(Any, object()), AppDescriptor.model_validate(wire_descriptor())
+    )
+    result = _result(
+        {"c_kill": _verdict(Outcome.GOOD), "c_plain": _verdict(Outcome.GOOD)}, {"c_kill": REASON}
+    )
+    verdicts = await formalizer.fetch_verdicts(cast(Any, _Formalized(result)))
+
+    assert verdicts["c_kill"].outcome is Outcome.BAD
+    assert REASON in (verdicts["c_kill"].message or "")
+    # Only the declared check changes.
+    assert verdicts["c_plain"].outcome is Outcome.GOOD
+
+
+@dataclass
+class _Feat:
+    display_name: str
+    slug: str = "oracle"
+
+
+def test_the_console_rollup_agrees_with_the_report():
+    # Report and console must agree on whether the run found something.
+    result = _result(
+        {"c_kill": _verdict(Outcome.GOOD), "c_plain": _verdict(Outcome.GOOD)}, {"c_kill": REASON}
+    )
+    summary = summarize_verdicts(
+        CorePipelineResult(
+            n_components=1, n_properties=0, failures=[],
+            outcomes=[
+                ComponentOutcome(
+                    cast(Any, _Feat("Oracle-Driven Refresh")), [],
+                    Delivered(result, pathlib.Path("main.rs")),
+                )
+            ],
+        ),
+        "prover",
+    )
+
+    assert [(v.name, v.outcome) for v in summary.verdicts] == [
+        ("c_kill_prop", Outcome.BAD),
+        ("c_plain_prop", Outcome.GOOD),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_wheels_own_file_beats_the_components_fallback():
+    """A verdict that names its own file keeps it; otherwise use the component artifact.
+
+    The report keys a row by ``(file, name)``. A callout-mode wheel delivers one
+    artifact, so every component would share that fallback — two same-named checks
+    would collapse. The wheel's ``unit_file`` is what keeps them apart.
+    """
+    formalizer = adapter.RustFormalizer(
+        cast(Any, object()), AppDescriptor.model_validate(wire_descriptor())
+    )
+    located = _verdict(Outcome.BAD)
+    located.unit_file = "c_lamport_custody.rs"
+    result = _result({"c_authority_immutable": located, "c_unplaced": _verdict(Outcome.GOOD)}, {})
+    verdicts = await formalizer.fetch_verdicts(cast(Any, _Formalized(result)))
+    assert verdicts["c_authority_immutable"].unit_file == "c_lamport_custody.rs"
+    assert verdicts["c_unplaced"].unit_file == "main.rs"
+
+
+# ---------------------------------------------------------------------------
+# Report rows -> written findings
+# ---------------------------------------------------------------------------
+
+class _StubModel(BaseChatModel):
+    """Structured output is preset, so the real path (prompt render, assess, compose) still runs."""
+    output: Any
+
+    def with_structured_output(self, schema, **kwargs) -> Runnable:  # type: ignore[override]
+        out = self.output
+        return RunnableLambda(lambda _messages: out)
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        raise NotImplementedError("stub is structured-output only")
+
+    @property
+    def _llm_type(self) -> str:
+        return "stub"
+
+
+def _draft(impact: ImpactLevel = "medium", likelihood: LikelihoodLevel = "low") -> FindingDraft:
+    return FindingDraft(
+        title="Initialization is accepted without the authority's signature",
+        summary="s", description="d", impact="the authority guarantee is lost",
+        impact_level=impact, likelihood_level=likelihood,
+        risk_reasoning="the run reached it from a state the harness set up",
+    )
+
+
+def _outcome(result: RustFormalResult, unit_file: str = "harness.rs",
+             component: str = "Vault Initialization") -> ComponentOutcome:
+    return ComponentOutcome(
+        cast(Any, _Feat(component)), [], Delivered(result, pathlib.Path(unit_file))
+    )
+
+
+async def _written(*outcomes: ComponentOutcome) -> list[Finding]:
+    """The findings the report would carry, through the real collector and the real loop."""
+    fz = adapter.RustFormalizer(
+        cast(Any, object()), AppDescriptor.model_validate(wire_descriptor())
+    )
+    _, rules, *_ = await collect(
+        [
+            ReportComponentInput(
+                name=cast(Any, o.feat.display_name),
+                props=[
+                    PropertyFormulation(title=t, sort="invariant", description="d")
+                    for t, _ in cast(Delivered, o.result).result.checks
+                ],
+                formalized=cast(Any, _Formalized(cast(Delivered, o.result).result,
+                                                 cast(Delivered, o.result).deliverable.name)),
+            )
+            for o in outcomes
+        ],
+        fetch_verdicts=fz.fetch_verdicts,
+    )
+    return await build_findings(
+        contract_name="klend", rules=rules, properties=[], groups=[],
+        policy=fz.findings_policy(list(outcomes)), llm=_StubModel(output=_draft()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_reproduced_crash_is_the_proof_of_concept():
+    result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE)}, {})
+    findings = await _written(_outcome(result))
+
+    assert len(findings) == 1
+    assert findings[0].content.proof_of_concept == COUNTEREXAMPLE
+    # The model wrote the prose; the campaign text is evidence, not the description.
+    assert findings[0].content.description == "d"
+
+
+@pytest.mark.asyncio
+async def test_an_unreproduced_declared_finding_claims_no_counterexample():
+    """Its only ground is the author's reading, and the finding has to say so rather than show one."""
+    result = _result({"c_kill": _verdict(Outcome.GOOD, "campaign spent 41231 executions")},
+                     {"c_kill": REASON})
+    findings = await _written(_outcome(result))
+
+    assert len(findings) == 1
+    assert findings[0].content.proof_of_concept is None, "no crash means no proof of concept"
+
+
+@pytest.mark.asyncio
+async def test_a_fuzz_finding_is_rated_like_any_other():
+    """The axes are the model's and the tier is the matrix's, so a reader can re-derive the severity
+    from what the write-up actually said rather than taking it on trust."""
+    result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE)}, {})
+    f = (await _written(_outcome(result)))[0]
+
+    prov = f.provenance
+    assert prov is not None
+    assert (prov.impact, prov.likelihood) == ("medium", "low")
+    assert f.severity == "low", "the matrix maps medium x low, and nothing else assigns a tier"
+
+
+@pytest.mark.asyncio
+async def test_two_sections_naming_one_check_keep_their_own_crash():
+    """Crucible delivers one crate, so `validate` files each verdict under its section's file.
+
+    Two authors given the same property title write the same check name, and the report keys a row
+    by ``(file, name)`` — the section file is the only thing keeping the two rows apart. The
+    evidence is keyed the same way, so a section's finding must carry that section's crash.
+    """
+    left = _result({"c_auth": _verdict(Outcome.BAD, "crash A")}, {})
+    right = _result({"c_auth": _verdict(Outcome.BAD, "crash B")}, {})
+    for res, section in ((left, "c_vault_initialization.rs"), (right, "c_lamport_custody.rs")):
+        res.verdicts["c_auth"].unit_file = section
+
+    findings = await _written(_outcome(left, component="Vault Initialization"),
+                              _outcome(right, component="Lamport Custody"))
+
+    assert len(findings) == 2, "one row per section, so one finding per section"
+    by_section = {f.provenance.spec_file: f for f in findings if f.provenance}
+    assert by_section["c_vault_initialization.rs"].content.proof_of_concept == "crash A"
+    assert by_section["c_lamport_custody.rs"].content.proof_of_concept == "crash B"
+
+
+@pytest.mark.asyncio
+async def test_a_finding_on_a_collapsed_row_reads_the_run_that_row_came_from():
+    """Without a section file the two rows do collapse — the finding must follow the row.
+
+    ``collect`` keeps the first run naming a ``(file, name)``; the evidence has to keep the same
+    one, or the row's message and its finding's proof of concept describe different runs.
+    """
+    first = _result({"c_auth": _verdict(Outcome.BAD, "crash A")}, {})
+    second = _result({"c_auth": _verdict(Outcome.BAD, "crash B")}, {})
+
+    findings = await _written(_outcome(first), _outcome(second, component="Lamport Custody"))
+
+    assert len(findings) == 1
+    assert findings[0].content.proof_of_concept == "crash A"
+
+
+def test_the_prompt_offers_no_counterexample_for_a_finding_the_run_did_not_reproduce():
+    """The prompt is where a model could be led to invent one, so the distinction lives there too."""
+    user = load_jinja_template(
+        "autoprove_report_findings_rust_prompt.j2",
+        contract_name="klend", rule_name="c_kill", properties=[], groups=[], also_covers=[],
+        evidence=[RuleEvidence(label="Oracle", ran=Outcome.GOOD,
+                               accounting="campaign spent 41231 executions", declared=REASON)],
+    )
+
+    assert "did NOT reproduce" in user and REASON in user
+    assert "Do not describe a counterexample" in user
+
+
+# ---------------------------------------------------------------------------
+# Evidence about the program vs evidence about the run
+# ---------------------------------------------------------------------------
+
+#: What `campaign.rs` puts on every verdict, green ones included.
+ACCOUNTING = (
+    "[Vault Initialization] campaign spent 67798 executions in 597s of a 600s budget; reached "
+    "6.1% of edges and 10.7% of branches, and got 44/92 of the harness's actions to succeed"
+)
+
+
+@pytest.mark.asyncio
+async def test_a_proof_of_concept_is_the_crash_and_not_what_the_campaign_spent():
+    """Run accounting inside a proof of concept leaves a reader unable to see where evidence ends."""
+    result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE, ACCOUNTING)}, {})
+    f = (await _written(_outcome(result)))[0]
+
+    assert f.content.proof_of_concept == COUNTEREXAMPLE
+    assert "campaign spent" not in (f.content.proof_of_concept or "")
+
+
+@pytest.mark.asyncio
+async def test_a_green_row_still_says_what_the_campaign_cost():
+    """The split must not cost the report what `campaign.rs` exists to put on a passing row.
+
+    The report has one ``message`` per row, so `fetch_verdicts` rejoins the halves — evidence
+    first, because a BAD row's first line is what a reader is looking for.
+    """
+    result = _result({"c_ok": _verdict(Outcome.GOOD, None, ACCOUNTING),
+                      "c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE, ACCOUNTING)}, {})
+    fz = adapter.RustFormalizer(
+        cast(Any, object()), AppDescriptor.model_validate(wire_descriptor())
+    )
+    rows = await fz.fetch_verdicts(cast(Any, _Formalized(result)))
+
+    assert rows["c_ok"].message == ACCOUNTING, "a green row's whole worth is its accounting"
+    bad = rows["c_ts"].message or ""
+    assert bad.startswith(COUNTEREXAMPLE) and bad.endswith(ACCOUNTING)
+
+
+def test_the_prompt_keeps_the_accounting_out_of_the_evidence():
+    """The model is shown both, told which is which, and told what each is for."""
+    user = load_jinja_template(
+        "autoprove_report_findings_rust_prompt.j2",
+        contract_name="klend", rule_name="c_ts", properties=[], groups=[], also_covers=[],
+        evidence=[RuleEvidence(label="Vault Initialization", ran=Outcome.BAD,
+                               counterexample=COUNTEREXAMPLE, accounting=ACCOUNTING)],
+    )
+
+    crash_at, spent_at = user.index(COUNTEREXAMPLE), user.index(ACCOUNTING)
+    assert crash_at < spent_at, "the evidence leads"
+    # The accounting is introduced as what it is, not appended to the crash.
+    assert "with whatever reproduces it:" in user
+    assert "spent and covered" in user
+
+
+# ---------------------------------------------------------------------------
+# One crash the campaign could not place — which the WHEEL says, not this host
+# ---------------------------------------------------------------------------
+
+class _CountingModel(_StubModel):
+    """Counts the write-ups actually asked for, and keeps both messages of each."""
+    calls: list[str] = []
+    systems: list[str] = []
+
+    def with_structured_output(self, schema, **kwargs) -> Runnable:  # type: ignore[override]
+        out, calls, systems = self.output, self.calls, self.systems
+
+        def _invoke(messages):
+            systems.append(messages[0].content)
+            calls.append(messages[-1].content)
+            return out
+        return RunnableLambda(_invoke)
+
+
+UNPLACEABLE = (
+    "crash crash_7f2a: [ledger_total_conserved] sum drifted by 3\n"
+    "reproducing sequence (iteration 88, 1 action(s)):\n  1. sweep_fees -> OK"
+)
+
+
+async def _written_by(model: _CountingModel, *outcomes: ComponentOutcome,
+                      descriptor: dict[str, Any] | None = None) -> list[Finding]:
+    fz = adapter.RustFormalizer(
+        cast(Any, object()), AppDescriptor.model_validate(descriptor or wire_descriptor())
+    )
+    _, rules, *_ = await collect(
+        [
+            ReportComponentInput(
+                name=cast(Any, o.feat.display_name),
+                props=[
+                    PropertyFormulation(title=t, sort="invariant", description="d")
+                    for t, _ in cast(Delivered, o.result).result.checks
+                ],
+                formalized=cast(Any, _Formalized(cast(Delivered, o.result).result,
+                                                 cast(Delivered, o.result).deliverable.name)),
+            )
+            for o in outcomes
+        ],
+        fetch_verdicts=fz.fetch_verdicts,
+    )
+    return await build_findings(
+        contract_name="klend", rules=rules, properties=[], groups=[],
+        policy=fz.findings_policy(list(outcomes)), llm=model,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_crash_the_campaign_could_not_place_is_written_up_once():
+    """`attribute_findings` condemns every check a campaign covered when it cannot place a crash,
+    and stamps the fan-out as one finding (`Verdict.finding`).
+
+    Condemning them all is right for the verdict table — the counterexample is real and hiding it
+    would be worse — but it is one finding, not one per row. Writing it up per row spends a heavy
+    model on each and publishes N accounts of the same crash, each guessing a different check it
+    might have been.
+
+    The key is the wheel's, and nothing here infers it: rows fanned out from one conclusion are
+    otherwise indistinguishable from several checks that failed identically, which is a different
+    fact about the program.
+    """
+    checks = [f"c_{i}" for i in range(6)]
+    result = _result(
+        {c: _verdict(Outcome.BAD, UNPLACEABLE, ACCOUNTING, finding="c_vault") for c in checks}, {})
+    model = _CountingModel(output=_draft(), calls=[], systems=[])
+
+    findings = await _written_by(model, _outcome(result))
+
+    assert len(model.calls) == 1, f"one crash, one write-up; asked for {len(model.calls)}"
+    assert len(findings) == 1
+    # The write-up is told it covers the others, so it cannot pick one and pin the crash on it.
+    prompt = model.calls[0]
+    assert "COULD NOT BE ATTRIBUTED" in prompt
+    for c in checks[1:]:
+        assert c in prompt, f"{c} is one of the rows this finding answers for"
+
+
+@pytest.mark.asyncio
+async def test_the_loop_binds_this_runs_evidence_into_the_write_up_prompt():
+    """The host binds the prompt now, not the backend, so nothing backend-side would catch it
+    binding the wrong thing — and a write-up rendered against absent evidence still produces a
+    plausible finding rather than an error."""
+    result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE, ACCOUNTING)}, {})
+    model = _CountingModel(output=_draft(), calls=[], systems=[])
+
+    await _written_by(model, _outcome(result))
+
+    prompt = model.calls[0]
+    assert COUNTEREXAMPLE in prompt, "the run's own evidence has to reach the model"
+    assert "c_ts" in prompt and "Vault Initialization" in prompt
+
+
+@pytest.mark.asyncio
+async def test_distinct_crashes_stay_distinct_findings():
+    """Two crashes the wheel *could* place carry no key, so they stay two findings."""
+    result = _result({"c_a": _verdict(Outcome.BAD, "crash A", ACCOUNTING),
+                      "c_b": _verdict(Outcome.BAD, "crash B", ACCOUNTING)}, {})
+    model = _CountingModel(output=_draft(), calls=[], systems=[])
+
+    findings = await _written_by(model, _outcome(result))
+
+    assert len(model.calls) == 2 and len(findings) == 2
+
+
+@pytest.mark.asyncio
+async def test_two_unreproduced_declarations_are_two_findings():
+    """An unstamped row stands on its own, so each declaration is its own claim.
+
+    Worth pinning because these two rows are otherwise as alike as rows get: no counterexample, and
+    the same accounting, since it is the same campaign. Nothing about that similarity may merge two
+    findings the author made separately.
+    """
+    result = _result({"c_kill": _verdict(Outcome.GOOD, None, ACCOUNTING),
+                      "c_stale": _verdict(Outcome.GOOD, None, ACCOUNTING)},
+                     {"c_kill": REASON, "c_stale": "a different documented bug"})
+    model = _CountingModel(output=_draft(), calls=[], systems=[])
+
+    findings = await _written_by(model, _outcome(result))
+
+    assert len(findings) == 2, "two declarations are two findings"
+    # Each is written up against its own declaration — the reason is what makes them two claims.
+    assert len(model.calls) == 2
+    assert {REASON in c for c in model.calls} == {True, False}
+    assert {"a different documented bug" in c for c in model.calls} == {True, False}
+
+
+# ---------------------------------------------------------------------------
+# What the wheel declares, and what a wheel that declares nothing gets
+# ---------------------------------------------------------------------------
+
+def test_a_wheel_that_declares_no_findings_policy_produces_none():
+    """No policy, no findings — not findings written from a default the host made up.
+
+    A write-up asserts what the evidence behind it is, and the host cannot know: it has verdicts,
+    not a claim about what produced them. A wheel that reports outcomes without saying what they
+    establish is coherent, and its report carries the verdict rows and nothing else."""
+    fz = adapter.RustFormalizer(
+        cast(Any, object()),
+        AppDescriptor.model_validate(wire_descriptor(findings=None)),
+    )
+    result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE)}, {})
+
+    assert fz.findings_policy([_outcome(result)]) is None
+
+
+@pytest.mark.asyncio
+async def test_the_write_up_is_told_what_this_wheels_evidence_is():
+    """The wheel's own prose leads the system prompt, and the host's contract follows it.
+
+    The two halves are separable for the same reason `judge` splits them: what the evidence *is* is
+    the backend's claim, and how severity is reached and which sections come back is the host's, so
+    neither restates the other. The CVL backend's prompt is the same template with its own domain.
+    """
+    result = _result({"c_ts": _verdict(Outcome.BAD, COUNTEREXAMPLE)}, {})
+    model = _CountingModel(output=_draft(), calls=[], systems=[])
+
+    await _written_by(model, _outcome(result), descriptor=wire_descriptor(findings={
+        "domain": "MARKER: this backend reads tea leaves.",
+    }))
+
+    system = model.systems[0]
+    assert system.startswith("MARKER: this backend reads tea leaves.")
+    assert system.index("MARKER") < system.index("HOW SEVERITY IS REACHED") < system.index(
+        "WHAT TO PRODUCE"), "the wheel's claim leads; the host's contract follows it"

--- a/tests/test_rustapp_findings.py
+++ b/tests/test_rustapp_findings.py
@@ -1,15 +1,13 @@
 """The declaration fold: what a Rust backend reports for a check its author declared broken.
 
-A check marked ``expect_check_failure`` must report as a finding even if this run
-did not reproduce it. Reproduced and unreproduced findings must stay distinguishable.
+A check marked ``expect_check_failure`` must report BAD either way: reproduced findings carry
+their counterexample; unreproduced ones have no proof of concept and say so. Stamps on
+``Verdict.finding`` collapse those rows to one write-up. A wheel with ``findings=None`` produces
+no findings.
 
-``expect_check_failure`` is how an author says "the failure here IS the finding". The
-publish gate accepts such a check as clean and nothing downstream ever asked the run to
-reproduce it, so on the klend run of 2026-08-10 four declared findings reached
-``report.html``: one as a violation (its campaign happened to hit it first) and three as
-**"No counterexample"** — including ``block_price_usage_kill_switch_effective``, which the
-author had reproduced at iteration 11619 and whose commentary documents the reproducing
-sequence.
+``expect_check_failure`` is how an author says "the failure here IS the finding". The publish
+gate accepts such a check as clean without requiring the run to reproduce it, so the fold is
+what stands between a documented finding and a green report row.
 
 The declaration is the author's and the outcome is the wheel's; they meet on
 ``RustFormalResult``, and the first group below pins that meeting down for both consumers
@@ -19,7 +17,6 @@ run found something.
 
 import pathlib
 from dataclasses import dataclass
-from typing import Any, cast
 from typing import Any, cast
 
 import pytest
@@ -43,7 +40,7 @@ from composer.spec.source.report.schema import (
 from composer.spec.types import PropertyFormulation
 from tests.conftest import wire_descriptor
 
-#: Crash text from a real Crucible hit, trimmed.
+#: Sample counterexample text a wheel might put on ``Verdict.detail``.
 COUNTEREXAMPLE = (
     "crash crash_93d45d29a130d36f: [stored_price_timestamp_not_in_future] reserve 8J5W stored "
     "market_price_last_updated_ts=2 which is ahead of the current unix timestamp 0\n"
@@ -251,7 +248,7 @@ async def _written(*outcomes: ComponentOutcome) -> list[Finding]:
     fz = adapter.RustFormalizer(
         cast(Any, object()), AppDescriptor.model_validate(wire_descriptor())
     )
-    _, rules, *_ = await collect(
+    properties, rules, *_ = await collect(
         [
             ReportComponentInput(
                 name=cast(Any, o.feat.display_name),
@@ -267,7 +264,7 @@ async def _written(*outcomes: ComponentOutcome) -> list[Finding]:
         fetch_verdicts=fz.fetch_verdicts,
     )
     return await build_findings(
-        contract_name="klend", rules=rules, properties=[], groups=[],
+        contract_name="klend", rules=rules, properties=properties, groups=[],
         policy=fz.findings_policy(list(outcomes)), llm=_StubModel(output=_draft()),
     )
 
@@ -279,7 +276,7 @@ async def test_a_reproduced_crash_is_the_proof_of_concept():
 
     assert len(findings) == 1
     assert findings[0].content.proof_of_concept == COUNTEREXAMPLE
-    # The model wrote the prose; the campaign text is evidence, not the description.
+    # The model wrote the prose; the run's text is evidence, not the description.
     assert findings[0].content.description == "d"
 
 
@@ -309,11 +306,9 @@ async def test_a_fuzz_finding_is_rated_like_any_other():
 
 @pytest.mark.asyncio
 async def test_two_sections_naming_one_check_keep_their_own_crash():
-    """Crucible delivers one crate, so `validate` files each verdict under its section's file.
-
-    Two authors given the same property title write the same check name, and the report keys a row
-    by ``(file, name)`` — the section file is the only thing keeping the two rows apart. The
-    evidence is keyed the same way, so a section's finding must carry that section's crash.
+    """Two authors given the same property title write the same check name, and the report keys a
+    row by ``(file, name)`` — the section file is the only thing keeping the two rows apart. The
+    evidence is keyed the same way, so a section's finding must carry that section's reproducer.
     """
     left = _result({"c_auth": _verdict(Outcome.BAD, "crash A")}, {})
     right = _result({"c_auth": _verdict(Outcome.BAD, "crash B")}, {})
@@ -362,7 +357,7 @@ def test_the_prompt_offers_no_counterexample_for_a_finding_the_run_did_not_repro
 # Evidence about the program vs evidence about the run
 # ---------------------------------------------------------------------------
 
-#: What `campaign.rs` puts on every verdict, green ones included.
+#: Sample run accounting a wheel might put on every verdict, green ones included.
 ACCOUNTING = (
     "[Vault Initialization] campaign spent 67798 executions in 597s of a 600s budget; reached "
     "6.1% of edges and 10.7% of branches, and got 44/92 of the harness's actions to succeed"
@@ -381,7 +376,7 @@ async def test_a_proof_of_concept_is_the_crash_and_not_what_the_campaign_spent()
 
 @pytest.mark.asyncio
 async def test_a_green_row_still_says_what_the_campaign_cost():
-    """The split must not cost the report what `campaign.rs` exists to put on a passing row.
+    """The split must not cost the report the accounting a passing row is supposed to carry.
 
     The report has one ``message`` per row, so `fetch_verdicts` rejoins the halves — evidence
     first, because a BAD row's first line is what a reader is looking for.
@@ -415,7 +410,7 @@ def test_the_prompt_keeps_the_accounting_out_of_the_evidence():
 
 
 # ---------------------------------------------------------------------------
-# One crash the campaign could not place — which the WHEEL says, not this host
+# One conclusion the wheel could not attribute to one check — which the WHEEL says, not this host
 # ---------------------------------------------------------------------------
 
 class _CountingModel(_StubModel):
@@ -444,7 +439,7 @@ async def _written_by(model: _CountingModel, *outcomes: ComponentOutcome,
     fz = adapter.RustFormalizer(
         cast(Any, object()), AppDescriptor.model_validate(descriptor or wire_descriptor())
     )
-    _, rules, *_ = await collect(
+    properties, rules, *_ = await collect(
         [
             ReportComponentInput(
                 name=cast(Any, o.feat.display_name),
@@ -460,20 +455,33 @@ async def _written_by(model: _CountingModel, *outcomes: ComponentOutcome,
         fetch_verdicts=fz.fetch_verdicts,
     )
     return await build_findings(
-        contract_name="klend", rules=rules, properties=[], groups=[],
+        contract_name="klend", rules=rules, properties=properties, groups=[],
         policy=fz.findings_policy(list(outcomes)), llm=model,
     )
 
 
+def test_an_unattributed_write_up_lists_every_covered_check_and_none_as_the_subject():
+    """The first row is one of the set, not the failing check the others hang off."""
+    user = load_jinja_template(
+        "autoprove_report_findings_rust_prompt.j2",
+        contract_name="klend", rule_name="c_0", properties=[], groups=[],
+        also_covers=["c_0", "c_1", "c_2"],
+        evidence=[RuleEvidence(label="Vault", ran=Outcome.BAD, counterexample=UNPLACEABLE)],
+    )
+    assert "Failing check:" not in user
+    for c in ("c_0", "c_1", "c_2"):
+        assert f"- {c}" in user
+    assert "do not pick one of them" in user
+
+
 @pytest.mark.asyncio
 async def test_a_crash_the_campaign_could_not_place_is_written_up_once():
-    """`attribute_findings` condemns every check a campaign covered when it cannot place a crash,
-    and stamps the fan-out as one finding (`Verdict.finding`).
+    """A wheel that cannot attribute one conclusion to one check stamps the fan-out as one
+    finding (`Verdict.finding`).
 
-    Condemning them all is right for the verdict table — the counterexample is real and hiding it
-    would be worse — but it is one finding, not one per row. Writing it up per row spends a heavy
-    model on each and publishes N accounts of the same crash, each guessing a different check it
-    might have been.
+    Condemning every covered check is right for the verdict table — hiding a real failure would
+    be worse — but it is one finding, not one per row. Writing it up per row spends a heavy
+    model on each and publishes N accounts of the same evidence, each guessing a different check.
 
     The key is the wheel's, and nothing here infers it: rows fanned out from one conclusion are
     otherwise indistinguishable from several checks that failed identically, which is a different
@@ -488,11 +496,14 @@ async def test_a_crash_the_campaign_could_not_place_is_written_up_once():
 
     assert len(model.calls) == 1, f"one crash, one write-up; asked for {len(model.calls)}"
     assert len(findings) == 1
-    # The write-up is told it covers the others, so it cannot pick one and pin the crash on it.
     prompt = model.calls[0]
     assert "COULD NOT BE ATTRIBUTED" in prompt
-    for c in checks[1:]:
-        assert c in prompt, f"{c} is one of the rows this finding answers for"
+    assert "Failing check:" not in prompt
+    for c in checks:
+        assert f"- {c}" in prompt, f"{c} is one of the rows this finding answers for"
+    prov = findings[0].provenance
+    assert prov is not None
+    assert prov.covers == [("harness.rs", c) for c in checks]
 
 
 @pytest.mark.asyncio
@@ -507,7 +518,7 @@ async def test_the_loop_binds_this_runs_evidence_into_the_write_up_prompt():
 
     prompt = model.calls[0]
     assert COUNTEREXAMPLE in prompt, "the run's own evidence has to reach the model"
-    assert "c_ts" in prompt and "Vault Initialization" in prompt
+    assert "Failing check: c_ts" in prompt and "Vault Initialization" in prompt
 
 
 @pytest.mark.asyncio
@@ -527,8 +538,8 @@ async def test_two_unreproduced_declarations_are_two_findings():
     """An unstamped row stands on its own, so each declaration is its own claim.
 
     Worth pinning because these two rows are otherwise as alike as rows get: no counterexample, and
-    the same accounting, since it is the same campaign. Nothing about that similarity may merge two
-    findings the author made separately.
+    the same accounting. Nothing about that similarity may merge two findings the author made
+    separately.
     """
     result = _result({"c_kill": _verdict(Outcome.GOOD, None, ACCOUNTING),
                       "c_stale": _verdict(Outcome.GOOD, None, ACCOUNTING)},

--- a/tests/test_rustapp_gate.py
+++ b/tests/test_rustapp_gate.py
@@ -53,7 +53,7 @@ def _mapped(**by_title: list[str]) -> list[PropertyCheckMapping]:
 
 def _verdict(outcome: Outcome, detail: str | None = None) -> Verdict:
     return Verdict(outcome=outcome, line=None, duration_seconds=None, unit_file=None,
-                   detail=detail, accounting=None, finding=None)
+                   detail=detail, accounting=None, finding_key=None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rustapp_gate.py
+++ b/tests/test_rustapp_gate.py
@@ -52,7 +52,8 @@ def _mapped(**by_title: list[str]) -> list[PropertyCheckMapping]:
 
 
 def _verdict(outcome: Outcome, detail: str | None = None) -> Verdict:
-    return Verdict(outcome=outcome, line=None, duration_seconds=None, unit_file=None, detail=detail)
+    return Verdict(outcome=outcome, line=None, duration_seconds=None, unit_file=None,
+                   detail=detail, accounting=None, finding=None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rustapp_validate_target.py
+++ b/tests/test_rustapp_validate_target.py
@@ -307,9 +307,7 @@ async def test_the_result_carries_the_targets_the_gating_run_covered(monkeypatch
 
 @pytest.mark.asyncio
 async def test_the_result_carries_the_authors_expected_failure_declarations(monkeypatch, tmp_path):
-    # The wheel reports what its run observed; that a failure IS the finding is the author's, and
-    # the session is the only place that knows it. Dropping it here is what let a documented klend
-    # finding reach report.html as "No counterexample" (tests/test_rustapp_findings.py).
+    # expected_failures comes from the session; the wheel never sees it.
     async def fake_session(**_kw):
         return SessionResult(
             commentary="done", spec=SPEC, skipped=[],
@@ -333,7 +331,6 @@ async def test_the_result_carries_the_authors_expected_failure_declarations(monk
 
     assert isinstance(result, adapter.RustFormalResult)
     assert result.expected_failures == {"c_stake": "klend makes no such guarantee"}
-    # The wheel's own answer is kept verbatim beside it — the declaration is applied on the way out
-    # (``reported_verdicts``), not folded into the record of what ran.
+    # verdicts stay as the run observed; reported_verdicts applies the declaration.
     assert result.verdicts["c_stake"].outcome is Outcome.GOOD
     assert result.reported_verdicts()["c_stake"].outcome is Outcome.BAD

--- a/tests/test_rustapp_validate_target.py
+++ b/tests/test_rustapp_validate_target.py
@@ -25,7 +25,7 @@ from composer.rustapp.session import (
     VALIDATE_KEY, CheckVocab, GateDeps, PropertyCheckMapping, RustSessionState, SessionResult,
     _validate_tool,
 )
-from composer.rustapp.wire import Target, Check, ValidateCoverageError
+from composer.rustapp.wire import Target, Check, ValidateCoverageError, Verdict
 from composer.spec.source.report.schema import Outcome
 from composer.spec.types import PropertyFormulation
 from tests.conftest import wire_descriptor, wire_verdict
@@ -303,3 +303,37 @@ async def test_the_result_carries_the_targets_the_gating_run_covered(monkeypatch
     assert [c.name for c in result.targets[0].checks] == ["c_stake", "c_dbl"]
     assert [s.property_title for s in result.skipped] == ["fees capped"]
     assert dict(result.checks) == {"stake matches": ["c_stake"], "no double stake": ["c_dbl"]}
+
+
+@pytest.mark.asyncio
+async def test_the_result_carries_the_authors_expected_failure_declarations(monkeypatch, tmp_path):
+    # The wheel reports what its run observed; that a failure IS the finding is the author's, and
+    # the session is the only place that knows it. Dropping it here is what let a documented klend
+    # finding reach report.html as "No counterexample" (tests/test_rustapp_findings.py).
+    async def fake_session(**_kw):
+        return SessionResult(
+            commentary="done", spec=SPEC, skipped=[],
+            property_checks=[("stake matches", ["c_stake"])],
+            verdicts={"c_stake": Verdict.with_outcome(Outcome.GOOD)},
+            ran=[Target(name="c_farms", checks=[
+                Check(name="c_stake", properties=["stake matches"], target="c_farms"),
+            ])],
+            expected_failures={"c_stake": "klend makes no such guarantee"},
+        )
+
+    monkeypatch.setattr(adapter, "run_session", fake_session)
+    formalizer = adapter.RustFormalizer(
+        cast(Any, _Wheel()), AppDescriptor.model_validate(wire_descriptor())
+    )
+    result = await formalizer.formalize(
+        "Farms", cast(Any, _Feat()),
+        [PropertyFormulation(title="stake matches", sort="invariant", description="d")],
+        cast(Any, _Ctx()), cast(Any, _Run(_Source(str(tmp_path)), _Ctx())), cast(Any, None),
+    )
+
+    assert isinstance(result, adapter.RustFormalResult)
+    assert result.expected_failures == {"c_stake": "klend makes no such guarantee"}
+    # The wheel's own answer is kept verbatim beside it — the declaration is applied on the way out
+    # (``reported_verdicts``), not folded into the record of what ran.
+    assert result.verdicts["c_stake"].outcome is Outcome.GOOD
+    assert result.reported_verdicts()["c_stake"].outcome is Outcome.BAD


### PR DESCRIPTION
## What this is

The report's Findings section existed, but the only way to fill it was an evidence fetcher that
meant "run the Certora Prover write-up". Returning a fetcher opted you into a heavy-model pass
whose prompt asserts *the Certora Prover found a concrete counterexample*. Foundry and the Rust
host returned `None` to opt out of code that could never have served them.

This generalizes that seam so any backend — including a Rust-authored one — can answer *what did
this run find* in its own terms. The write-up loop stays in one place.

## The seam

`Formalizer.findings_policy(outcomes) -> FindingsPolicy | None`. `None` means the backend produces
no findings and never starts the heavy model.

A `FindingsPolicy` is three fields, and only the first is a function:

| Field | Role |
| --- | --- |
| `fetch_evidence` | Keyed by `RuleRef` — `(file, name)`, how the report already identifies a row. A check name alone does not: one deliverable can hold several components' checks. The only hook, because it is the only one that does I/O. |
| `domain` | What this backend's evidence *is*. True of one backend and false of another. A Rust-authored backend ships this string as `FindingsDeclaration.domain`. |
| `prompt` | A `TypedTemplate[FindingsPromptParams]`. The Prover supplies its own; every Rust-authored backend shares one host template. The loop binds the same fields either way. |

Everything else is shared in `report/findings.py`: walking the BAD rows, resolving properties and
audit groups, collapsing rows that share one finding, the proof of concept, composing the
`Finding`. A failure there costs the findings, never the report.

## Evidence has one shape

Every backend hands back the same `RuleEvidence`. Backends differ in what they can *fill*, not in
the shape. Absence always means "this run recorded nothing of that kind".

| Field | |
| --- | --- |
| `label` | Which instance, where a rule can fail more than once |
| `analysis` | Why the check failed, when the backend produces a root-cause account |
| `counterexample` | What reproduces it |
| `ran` | The run's own outcome, before any expected-to-fail mark is folded in |
| `accounting` | What the run spent and covered |
| `expected_failure_reason` | Why the author marked this check expected to fail, when they did |
| `finding_key` | Opaque grouping key, when one conclusion covers several checks |

## One system prompt, one severity rule

A findings system prompt splits the same way for every backend: what this evidence *is* (and how
far it goes) is the backend's `domain`; how severity is reached and which sections come back is
the host's contract (`autoprove_report_findings_system.j2`).

The model rates impact and likelihood; `severity_for` maps the pair through a fixed matrix. No
backend picks a tier.

## Report rows keep evidence, accounting, and expected-failure apart

The report `Verdict` / `RuleVerdict` carry three optional fields:

- `message` — the counterexample or error (`detail` on the rust wire)
- `accounting` — what the run spent (`None` for backends that do not report it)
- `expected_failure` — `ReproducedExpectedFailure` or `UnreproducedExpectedFailure` (reason +,
  when unreproduced, the outcome the run actually reached)

HTML shows them as separate blocks. The findings write-up reads the same split off
`RuleEvidence`, so a proof of concept is never padded with accounting or declaration prose.

## Rust-authored backends

In this repo, a Rust-authored backend is a *wheel*: compiled Rust that the Python host drives
through an FFI. Three wire additions, all `deny_unknown_fields` + `required::present`:

- **`AppDescriptor.findings: Option<FindingsDeclaration>`** — opt-in. The domain string is what
  the evidence is. Default is `None` (no findings). The example app opts out.
- **`Verdict.accounting`** — what the run spent and covered, kept apart from `detail`.
- **`Verdict.finding_key: Option<FindingKey>`** — an opaque, run-global key for a conclusion the
  wheel could not attribute to one check. Rows stamped alike are written up once, against the
  union of their properties and groups. `provenance.covers` names every row the write-up answers
  for. Stamped and never inferred.

`composer/rustapp/findings.py` maps wire fields into `RuleEvidence` and leaves `analysis` unset.

## Expected-to-fail checks still report as findings

A check marked `expect_check_failure` is a documented finding even if this run did not hit it.
The publish gate accepts such a check as clean without requiring a repro.

`expected_failures` rides `RustFormalResult`. `reported_verdicts()` folds the **outcome** to
`BAD` and leaves `detail` as the run reported it. `expected_failure()` builds the tagged union
for the report row. The console rollup reads the same outcome fold, so the terminal and
`report.html` cannot disagree about whether the run found something.

## Docs

`formalization-abstraction.md` §4.6 covers the hook and the evidence table.
`rust-applications.md` §4.5 covers the wheel's side, and §5/§6 the `expect_check_failure` fold.

## Validation

Cheap suite and `pyright` clean. The first commit stands alone (the suite passes there with no
rustapp participation).
