### PR TITLE
Parse an import alias emitted by solc before 0.6

### DIFF
--- a/certora_autosetup/solidity_ast/declarations.py
+++ b/certora_autosetup/solidity_ast/declarations.py
@@ -188,11 +188,16 @@ class FunctionDefinition(SolcNode):
 
 
 class SymbolAlias(BaseModel):
-    """One ``{symbol as local}`` entry of an ImportDirective's symbolAliases."""
+    """One ``{symbol as local}`` entry of an ImportDirective's symbolAliases.
+
+    solc writes ``foreign`` as an Identifier node from 0.6.1 on. Through
+    0.5.16 it writes the referenced declaration's id there instead, which the
+    vendored schema does not cover because that schema unions solc >= 0.6.
+    """
 
     model_config = ConfigDict(extra="allow")
 
-    foreign: "Identifier"
+    foreign: "Identifier | int"
     local: str | None = None
     nameLocation: str | None = None
 

--- a/tests/solidity_ast/test_lenient_parsing.py
+++ b/tests/solidity_ast/test_lenient_parsing.py
@@ -11,6 +11,8 @@ from certora_autosetup.solidity_ast import (
     ContractDefinition,
     EventDefinition,
     FunctionDefinition,
+    Identifier,
+    ImportDirective,
     Return,
     SourceUnit,
     VariableDeclaration,
@@ -118,3 +120,40 @@ def test_file_level_event_definition_is_typed() -> None:
     )
     [event] = unit.nodes
     assert isinstance(event, EventDefinition)
+
+
+def test_pre_06_symbol_alias_foreign_is_a_bare_declaration_id() -> None:
+    # solc writes an Identifier node from 0.6.1 on; 0.4 and 0.5 write the id of
+    # the declaration being imported. Whole compilation units used to fall back
+    # to an untyped AST over this one field.
+    directive = ImportDirective.model_validate(
+        {
+            "id": 4, "src": "0:30:0", "nodeType": "ImportDirective",
+            "absolutePath": "contracts/B.sol", "file": "./B.sol",
+            "scope": 20, "sourceUnit": 19, "unitAlias": "",
+            "symbolAliases": [{"foreign": 3, "local": None}],
+        }
+    )
+    assert directive.symbolAliases[0].foreign == 3
+
+
+def test_symbol_alias_foreign_is_still_typed_from_06_on() -> None:
+    directive = ImportDirective.model_validate(
+        {
+            "id": 4, "src": "0:30:0", "nodeType": "ImportDirective",
+            "absolutePath": "contracts/B.sol", "file": "./B.sol",
+            "scope": 20, "sourceUnit": 19, "unitAlias": "",
+            "symbolAliases": [
+                {
+                    "foreign": {
+                        "id": 3, "src": "9:1:0", "nodeType": "Identifier",
+                        "name": "B", "overloadedDeclarations": [],
+                        "typeDescriptions": {},
+                    },
+                    "nameLocation": "-1:-1:-1",
+                }
+            ],
+        }
+    )
+    foreign = directive.symbolAliases[0].foreign
+    assert isinstance(foreign, Identifier) and foreign.name == "B"


### PR DESCRIPTION
## What solc changes

`ImportDirective.symbolAliases[].foreign` is an `Identifier` node from solc 0.6.1 on. Through
0.5.16 it is the bare id of the declaration being imported. Measured on a two-file import across
the cvt-executables builds:

| solc | `foreign` |
|---|---|
| 0.4.24, 0.5.16 | `2` |
| 0.6.1 … 0.8.30 | `{"id": 2, "name": "B", "nodeType": "Identifier", …}` |

The vendored OpenZeppelin schema unions solc >= 0.6, so it only describes the second shape, and
`SymbolAlias.foreign` was typed to match.

## Why it is worth widening

A single failed field takes the whole compilation unit down to an untyped fallback:

```
falling back to raw AST for <a 0.4.24 source>: 1 validation error(s):
{'loc': ('nodes', 1, 'ImportDirective', 'symbolAliases', 0, 'foreign'),
 'msg': 'Input should be a valid dictionary or instance of Identifier', 'input': 6362}
```

Consumers that work from typed nodes then have nothing for the contracts those units define. That
is the difference between supporting a codebase that mixes an old compiler with a current one and
not supporting it at all, and mixed-compiler scenes are common in older protocols.

Nothing in the package reads `.foreign`, so widening it to `Identifier | int` breaks no caller.
Tests pin both shapes.
