### PR TITLE
Recover from CVL type-check failures, and fix a deadlock in the same path

### DIFF
--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -449,6 +449,40 @@ async def run_prover_inner(
         run_result = cast(ProverResult, json.load(output_file))
         return run_result, stdout
 
+# How much of a failed compile to hand back. Trimmed from the end because the errors come last.
+_COMPILE_OUTPUT_TAIL_CHARS = 8_000
+
+
+class SpecCompilationError(Exception):
+    """The spec did not compile.
+
+    Carries the compiler's own output, which names the offending lines. An authoring
+    agent can repair a spec from that, so callers driving one should surface
+    ``output`` rather than treat this as a run-ending fault."""
+
+    def __init__(self, output: str) -> None:
+        super().__init__(output or "no output captured")
+        self.output = output
+
+
+async def _run_captured(*argv: str, cwd: Path) -> tuple[int, str]:
+    """Run ``argv``, returning its exit code and combined output.
+
+    ``communicate`` rather than ``wait``: the pipes have to be drained, or a child
+    that outfills the buffer blocks forever waiting for someone to read it."""
+    proc = await asyncio.subprocess.create_subprocess_exec(
+        *argv,
+        cwd=str(cwd),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    output = b"".join(part for part in (stdout, stderr) if part).decode(
+        "utf-8", errors="replace"
+    )
+    return proc.returncode or 0, output[-_COMPILE_OUTPUT_TAIL_CHARS:]
+
+
 async def declared_rules_list(
     folder: Path,
     args: list[str]
@@ -459,22 +493,18 @@ async def declared_rules_list(
     the generated build dir, and then manually invoke the typechecker with `-listRules`
     ourselves against that build dir.
 
-    Not great, obviously, but lets us work on this AP feature while waiting for support for this to 
+    Not great, obviously, but lets us work on this AP feature while waiting for support for this to
     land upstream in certora-cli and the pip distribution channels.
     """
     if any(m == "--msg" for m in args):
         raise ValueError("This unholy black magic only works if you don't pass msg")
     tc_key = uuid.uuid4().hex
-    proc = await asyncio.subprocess.create_subprocess_exec(
+    rc, output = await _run_captured(
         "certoraRun", *args, "--msg", tc_key, "--compilation_steps_only",
-        cwd=str(folder),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE
+        cwd=folder,
     )
-
-    rc = await proc.wait()
     if rc != 0:
-        raise ValueError("Type check failed?")
+        raise SpecCompilationError(output)
     from importlib.resources import files
 
     tc_jar = files("certora_jars") / "Typechecker.jar"
@@ -502,15 +532,13 @@ async def declared_rules_list(
     if found is None:
         raise ValueError("Couldn't find build dir")
     with tempfile.NamedTemporaryFile("r") as f:
-        proc = await asyncio.subprocess.create_subprocess_exec(
-            "java", "-jar", str(tc_jar), "-buildDirectory", str(found), "-typeCheck", "true", "-listRules", f.name,
-            cwd=str(folder),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
+        tc_rc, tc_output = await _run_captured(
+            "java", "-jar", str(tc_jar), "-buildDirectory", str(found),
+            "-typeCheck", "true", "-listRules", f.name,
+            cwd=folder,
         )
-        tc_rc = await proc.wait()
         if tc_rc != 0:
-            raise ValueError("Nope, no dice")
+            raise SpecCompilationError(tc_output)
         all_rules = f.read()
     return [s for r in all_rules.split() if (s := r.strip()) and s != "envfreeFuncsStaticCheck"]
 

--- a/composer/prover/core.py
+++ b/composer/prover/core.py
@@ -449,9 +449,6 @@ async def run_prover_inner(
         run_result = cast(ProverResult, json.load(output_file))
         return run_result, stdout
 
-# How much of a failed compile to hand back. Trimmed from the end because the errors come last.
-_COMPILE_OUTPUT_TAIL_CHARS = 8_000
-
 
 class SpecCompilationError(Exception):
     """The spec did not compile.
@@ -480,7 +477,7 @@ async def _run_captured(*argv: str, cwd: Path) -> tuple[int, str]:
     output = b"".join(part for part in (stdout, stderr) if part).decode(
         "utf-8", errors="replace"
     )
-    return proc.returncode or 0, output[-_COMPILE_OUTPUT_TAIL_CHARS:]
+    return proc.returncode or 0, output
 
 
 async def declared_rules_list(

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -35,7 +35,8 @@ from composer.prover.ptypes import RuleResult, RulePath
 from graphcore.graph import LLM
 
 from composer.prover.core import (
-    ProverOptions, declared_rules_list, run_prover, DefaultCexHandler
+    ProverOptions, SpecCompilationError, declared_rules_list, run_prover,
+    DefaultCexHandler
 )
 from composer.prover.callbacks import ProverEventCallbacks
 from composer.prover.ptypes import StatusCodes
@@ -529,11 +530,11 @@ def get_prover_tool(
 
         if rules is not None and exclude_rules is not None:
             return "Cannot invoke the prover with both `rules` and `exclude_rules` set to non-none"
-        
+
         spec = state["curr_spec"]
         if spec is None:
             return "Specification not yet put on VFS"
-        
+
         spec_hash = string_hash(
             spec
         )
@@ -574,10 +575,13 @@ def get_prover_tool(
                 exclude_rule=None,
                 msg=""
             ) as (config_path, _ignored):
-                all_rules = await declared_rules_list(
-                    folder=Path(run_root),
-                    args=[config_path]
-                )
+                try:
+                    all_rules = await declared_rules_list(
+                        folder=Path(run_root),
+                        args=[config_path]
+                    )
+                except SpecCompilationError as exc:
+                    return f"The spec failed to compile:\n{exc.output}"
             with setup_prover_config_in(
                 working_dir=run_root,
                 main_contract=main_contract,
@@ -630,7 +634,7 @@ def get_prover_tool(
                 curr_status=prover_results,
                 all_rules=all_rules
             )
-            
+
             prover_update : list[ProverHistoryItem] = [
                 ProverRunLog(
                     tool_call_id=tool_call_id,
@@ -644,7 +648,7 @@ def get_prover_tool(
                 )
             ]
             nag_channel = {
-                
+
             }
             if len(to_warn) > 0:
                 prover_update.append(NagMarker(

--- a/tests/test_rules_striping.py
+++ b/tests/test_rules_striping.py
@@ -15,6 +15,7 @@ Covers:
 The prover core is mocked throughout (the ``certora_prover`` fixture's seams:
 ``run_prover`` + ``declared_rules_list``); no prover jobs run.
 """
+import asyncio
 import json
 from pathlib import Path
 from typing import Annotated
@@ -25,7 +26,9 @@ from langchain_core.tools import InjectedToolCallId, tool
 from langgraph.types import Command
 
 from composer.authoring.state import check_completion, spec_digest
-from composer.prover.core import ProverReport, declared_rules_list
+from composer.prover.core import (
+    ProverReport, SpecCompilationError, declared_rules_list
+)
 from composer.prover.ptypes import RulePath, StatusCodes
 from composer.spec.cvl_generation import PropertyRuleMapping, validate_property_rules
 from composer.spec.source.author import ExpectRuleFailure
@@ -193,11 +196,12 @@ class TestCompletionHistory:
 
 
 class _FakeProc:
-    def __init__(self, rc: int):
-        self._rc = rc
+    def __init__(self, rc: int, stdout: bytes = b"", stderr: bytes = b""):
+        self.returncode = rc
+        self._streams = (stdout, stderr)
 
-    async def wait(self) -> int:
-        return self._rc
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._streams
 
 
 def _install_fake_prover_procs(
@@ -207,6 +211,8 @@ def _install_fake_prover_procs(
     java_rc: int = 0,
     rules_text: str = "a\nb\n",
     conf_msg: str | None = None,
+    certora_output: bytes = b"",
+    java_output: bytes = b"",
 ):
     """Fake the two subprocesses of ``declared_rules_list``: certoraRun materializes a
     build-mirror dir whose run.conf carries the ``--msg`` key it was passed (or
@@ -224,10 +230,10 @@ def _install_fake_prover_procs(
             (build / "run.conf").write_text(
                 json.dumps({"msg": conf_msg if conf_msg is not None else key})
             )
-            return _FakeProc(certora_rc)
+            return _FakeProc(certora_rc, stderr=certora_output)
         assert argv[0] == "java"
         Path(argv[argv.index("-listRules") + 1]).write_text(rules_text)
-        return _FakeProc(java_rc)
+        return _FakeProc(java_rc, stderr=java_output)
 
     monkeypatch.setattr("asyncio.subprocess.create_subprocess_exec", fake_exec)
 
@@ -244,20 +250,56 @@ class TestDeclaredRulesList:
         with pytest.raises(ValueError, match="msg"):
             await declared_rules_list(tmp_path, ["x.conf", "--msg", "hello"])
 
-    async def test_build_failure_raises(self, tmp_path, monkeypatch):
-        _install_fake_prover_procs(monkeypatch, certora_rc=1)
-        with pytest.raises(ValueError):
+    async def test_build_failure_carries_the_compiler_output(
+        self, tmp_path, monkeypatch
+    ):
+        """The output is the whole point: it names the file and line, which is what
+        an authoring agent needs to repair the spec."""
+        _install_fake_prover_procs(
+            monkeypatch, certora_rc=1,
+            certora_output=b'Error in spec file (invariants.spec:34:5): could not '
+                           b'type expression "sdai.pot()"',
+        )
+        with pytest.raises(SpecCompilationError) as caught:
             await declared_rules_list(tmp_path, ["x.conf"])
+        assert "invariants.spec:34:5" in caught.value.output
 
-    async def test_typechecker_failure_raises(self, tmp_path, monkeypatch):
-        _install_fake_prover_procs(monkeypatch, java_rc=1)
-        with pytest.raises(ValueError):
+    async def test_typechecker_failure_carries_the_compiler_output(
+        self, tmp_path, monkeypatch
+    ):
+        _install_fake_prover_procs(
+            monkeypatch, java_rc=1, java_output=b"rule 'foo' is not well typed",
+        )
+        with pytest.raises(SpecCompilationError) as caught:
             await declared_rules_list(tmp_path, ["x.conf"])
+        assert "not well typed" in caught.value.output
 
     async def test_unmatched_build_dir_raises(self, tmp_path, monkeypatch):
         _install_fake_prover_procs(monkeypatch, conf_msg="someone else's run")
         with pytest.raises(ValueError, match="build dir"):
             await declared_rules_list(tmp_path, ["x.conf"])
+
+    async def test_a_chatty_child_does_not_deadlock(self, tmp_path, monkeypatch):
+        """Real subprocess, real pipes: a child that outfills the ~64KB pipe buffer
+        blocks forever if nobody drains it, so this is the one case the fakes above
+        cannot cover."""
+        import sys
+
+        from composer.prover.core import _run_captured
+
+        rc, output = await asyncio.wait_for(
+            _run_captured(
+                sys.executable, "-c",
+                "import sys; sys.stdout.write('o' * 200_000); "
+                "sys.stderr.write('e' * 200_000); sys.exit(3)",
+                cwd=tmp_path,
+            ),
+            timeout=30,
+        )
+        assert rc == 3
+        assert output  # drained, not lost
+        assert len(output) <= 8_000  # and tail-trimmed
+
 
     async def test_discovery_ignores_decoy_entries(self, tmp_path, monkeypatch):
         # Pre-existing .certora_internal clutter: a plain file, a dir without a
@@ -380,6 +422,35 @@ def _is_result_rejection(st: StateWithSkips) -> bool:
 
 @pytest.mark.asyncio
 class TestStripedVerification:
+    async def test_a_spec_that_does_not_compile_comes_back_to_the_agent(
+        self, certora_prover: ProverMock, monkeypatch
+    ):
+        """The rule-listing pre-pass runs the compiler before the prover. A spec that
+        fails to compile is the author agent's to fix and the compiler says exactly
+        where, so it has to arrive as a tool result — raising past the agent ends the
+        whole run over a repairable mistake."""
+        async def failing(**_kwargs):
+            raise SpecCompilationError(
+                'Error in spec file (invariants.spec:34:5): could not type '
+                'expression "sdai.pot()", message: Missing environment parameter '
+                'to non-envfree function SavingsDai.pot()'
+            )
+
+        monkeypatch.setattr(
+            "composer.spec.source.prover.declared_rules_list", failing
+        )
+        msg = await _scenario(
+            certora_prover, curr_spec=_spec_decls("a", "b"),
+        ).turn(
+            _verify()
+        ).run_last_single_tool(_PROVER)
+        assert "failed to compile" in msg
+        assert "invariants.spec:34:5" in msg
+        assert "non-envfree" in msg
+        # The prover is never reached — there is nothing to verify.
+        assert certora_prover.calls == []
+
+
     async def test_rules_and_exclude_rules_mutually_exclusive(self, certora_prover: ProverMock):
         msg = await _scenario(
             certora_prover, curr_spec=_spec_decls("a", "b"),

--- a/tests/test_rules_striping.py
+++ b/tests/test_rules_striping.py
@@ -298,7 +298,6 @@ class TestDeclaredRulesList:
         )
         assert rc == 3
         assert output  # drained, not lost
-        assert len(output) <= 8_000  # and tail-trimmed
 
 
     async def test_discovery_ignores_decoy_entries(self, tmp_path, monkeypatch):


### PR DESCRIPTION
`declared_rules_list` (added in #177) runs `certoraRun --compilation_steps_only` before every prover call. Two defects in it:

It killed the run on a repairable error. The subprocess output was discarded and a bare `ValueError("Type check failed?")` raised — a type not in graph.py's handle_tool_errors, so langgraph re-raised it. That regressed behavior `run_prover` still has fifteen lines below: return the compiler's complaints as the tool result so the author agent can repair the spec.

It could hang forever. Both streams were piped with nobody draining them, so a child outfilling the ~64KB buffer blocked on write while we blocked on `wait()`.