### PR TITLE
Add a prioritized run mode

### DIFF
--- a/composer/authoring/tools.py
+++ b/composer/authoring/tools.py
@@ -11,16 +11,18 @@ What varies on skip and give-up is LLM-facing text, so those are
 instantiate time. Unskip does not vary.
 """
 
-from typing import Callable, Sequence, override
+from dataclasses import dataclass
+from typing import Callable, Literal, Sequence, override
 
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.types import Command
 from pydantic import Field
 
 from graphcore.graph import tool_state_update
 from graphcore.tools.schemas import (
-    ToolFamilyParams, WithAsyncDependencies, WithImplementation, WithInjectedId, tool_family,
+    ToolFamilyParams, WithAsyncDependencies, WithImplementation, WithInjectedId,
+    WithInjectedState, tool_family,
 )
 
 from composer.authoring.state import SkippedProperty
@@ -38,6 +40,19 @@ def _as_titles(titles: Titles | Sequence[PropertyTitle]) -> Titles:
         return titles
     snapshot = titles
     return lambda: snapshot
+
+
+@dataclass(frozen=True)
+class SkipScope:
+    """What ``record_skip`` is allowed to retire: the batch's titles, and the subset it must
+    refuse.
+
+    ``protected`` is a thunk, not a set, because the answer changes during a session — the
+    budget monitor's wrap-up order tells the agent to skip everything that does not work, so a
+    protection that outlived that order would deadlock the session it was meant to curtail.
+    A backend with nothing to protect passes a thunk returning ``()``."""
+    titles: Titles
+    protected: Titles
 
 
 # ---------------------------------------------------------------------------
@@ -61,7 +76,7 @@ def _skip_result(
 
 @tool_family_display(_skip_label, _skip_result)
 @tool_family(SkipParams)
-class RecordSkip(WithInjectedId, WithAsyncDependencies[Command, Titles]):
+class RecordSkip(WithInjectedId, WithAsyncDependencies[Command, SkipScope]):
     """{description}"""
     property_title: PropertyTitle = Field(
         description="The snake_case title of the property from the batch listing"
@@ -70,13 +85,21 @@ class RecordSkip(WithInjectedId, WithAsyncDependencies[Command, Titles]):
 
     @override
     async def run(self) -> Command:
-        with self.tool_deps() as titles:
-            known = titles()
+        with self.tool_deps() as scope:
+            known = scope.titles()
+            protected = scope.protected()
         if self.property_title not in known:
             return tool_state_update(
                 self.tool_call_id,
                 f"Unknown property title {self.property_title!r}. Must be one "
                 f"of: {', '.join(known)}.",
+            )
+        if self.property_title in protected:
+            return tool_state_update(
+                self.tool_call_id,
+                f"Property {self.property_title!r} is the focus of this run and cannot be "
+                "skipped. Decompose it into lemmas, strengthen the harness, or formalize a "
+                "weaker core of it and say so in your commentary — but do not retire it.",
             )
         if not self.reason.strip():
             return tool_state_update(
@@ -122,12 +145,18 @@ def skip_tools(
     *,
     skip_description: str,
     skip_reason: str,
+    protected: Titles | Sequence[PropertyTitle] = (),
 ) -> list[BaseTool]:
-    """The skip / unskip pair, bound to the batch's property titles."""
+    """The skip / unskip pair, bound to the batch's property titles.
+
+    ``protected`` names titles ``record_skip`` must refuse — the focus of a prioritized run,
+    whose whole point is that it is pursued rather than retired. Unskip is deliberately not
+    constrained: un-retiring a property is always allowed."""
     get = _as_titles(titles)
+    scope = SkipScope(titles=get, protected=_as_titles(protected))
     return [
         RecordSkip.with_template(description=skip_description, reason=skip_reason)
-        .bind(get)
+        .bind(scope)
         .as_tool("record_skip"),
         Unskip.bind(get).as_tool("unskip_property"),
     ]
@@ -180,3 +209,92 @@ def give_up_tool(
         reason=reason_description,
         label=label,
     ).as_tool(name)
+
+
+# ---------------------------------------------------------------------------
+# Give up, behind an escalation gate
+# ---------------------------------------------------------------------------
+
+def _gated_give_up_label(p: dict, *, description: str, reason: str, label: str) -> str:
+    return f"Giving up on {label}: {p['reason']}"
+
+
+def _verify_attempts(state: dict) -> int:
+    """How many times this session has put a spec in front of the prover.
+
+    Counted from the message history rather than from ``prover_history``: that list only grows
+    when the prover returns a *report*, and the failures worth escalating through — a spec that
+    will not type-check, a toolchain that will not run — return early without one. Counting
+    calls counts attempts, which is what the gate is about. The same walk over ``messages`` is
+    how the prover tool identifies its own prior calls."""
+    return sum(
+        1
+        for msg in state.get("messages", [])
+        if isinstance(msg, AIMessage)
+        for call in msg.tool_calls
+        if call["name"] == "verify_spec"
+    )
+
+
+@tool_family_display(_gated_give_up_label, None)
+@tool_family(GiveUpParams)
+class GatedGiveUp(
+    WithInjectedId,
+    WithInjectedState[dict],
+    WithAsyncDependencies[Command, int],
+):
+    """{description}"""
+    sort: Literal["environment", "exhausted"] = Field(
+        description="Why you are stopping. 'environment' means the toolchain itself is unusable "
+        "— the prover or compiler is missing or broken — and nothing you could write would "
+        "succeed. 'exhausted' means you have tried to verify this and cannot find a way."
+    )
+    reason: str = Field(description="{reason}")
+    attempts: list[str] = Field(
+        min_length=1,
+        description="One entry per distinct approach you actually tried, saying what you "
+        "attempted and how it failed.",
+    )
+
+    @override
+    async def run(self) -> Command:
+        with self.tool_deps() as floor:
+            if self.sort == "exhausted" and (ran := _verify_attempts(self.state)) < floor:
+                return tool_state_update(
+                    self.tool_call_id,
+                    f"Rejected: you have run the prover {ran} time(s) on this task, and this run "
+                    f"requires at least {floor} before a property may be abandoned. This is the "
+                    "one property the run exists to establish. Decompose it into lemmas, add or "
+                    "strengthen a harness, or formalize a weaker core of it and state the gap — "
+                    "then verify. If the toolchain itself is broken, stop with "
+                    "sort='environment' instead.",
+                )
+        return tool_state_update(
+            self.tool_call_id,
+            "Accepted",
+            failed=True,
+            result=self.reason,
+        )
+
+
+def gated_give_up_tool(
+    *,
+    name: str,
+    description: str,
+    label: str,
+    min_attempts: int,
+    reason_description: str = "The reason for giving up on your task",
+) -> BaseTool:
+    """:func:`give_up_tool` with a floor under it: an ``exhausted`` surrender is refused until
+    the session has actually put a spec in front of the prover ``min_attempts`` times, and the
+    reason must enumerate what was tried.
+
+    For a run that has staked itself on one property, where an early surrender is the whole run.
+    The ``environment`` escape is not optional: a missing prover or compiler produces no prover
+    run at all, so a bare attempt floor would be unsatisfiable and would hold the agent against
+    its recursion limit instead of letting it report a broken toolchain."""
+    return GatedGiveUp.with_template(
+        description=description,
+        reason=reason_description,
+        label=label,
+    ).bind(min_attempts).as_tool(name)

--- a/composer/authoring/tools.py
+++ b/composer/authoring/tools.py
@@ -14,6 +14,8 @@ instantiate time. Unskip does not vary.
 from dataclasses import dataclass
 from typing import Callable, Literal, NotRequired, Sequence, override
 
+from typing_extensions import ReadOnly
+
 from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.graph import MessagesState
@@ -233,10 +235,15 @@ def _gated_give_up_label(p: dict, *, description: str, reason: str, label: str) 
 
 
 class GatedGiveUpState(MessagesState):
-    """The authoring state :class:`GatedGiveUp` reads and writes: the message history it counts
-    prover attempts from, and the two fields a surrender records."""
-    result: NotRequired[str]
-    failed: NotRequired[bool]
+    """What a session must carry for :class:`GatedGiveUp` to run on it: the message history the
+    gate counts prover attempts from, and the two fields a surrender records.
+
+    ``result`` and ``failed`` are ``ReadOnly`` because the tool never writes them through the
+    state object; it returns a ``Command`` and the graph applies it. Declaring them anyway is
+    what makes the dependency visible, so a session missing them fails to typecheck rather than
+    at runtime."""
+    result: ReadOnly[NotRequired[str]]
+    failed: ReadOnly[bool | None]
 
 
 def _verify_attempts(state: GatedGiveUpState) -> int:
@@ -258,9 +265,9 @@ def _verify_attempts(state: GatedGiveUpState) -> int:
 
 @tool_family_display(_gated_give_up_label, None)
 @tool_family(GiveUpParams)
-class GatedGiveUp(
+class GatedGiveUp[S: GatedGiveUpState](
     WithInjectedId,
-    WithInjectedState[GatedGiveUpState],
+    WithInjectedState[S],
     WithAsyncDependencies[str | Command, int],
 ):
     """{description}"""
@@ -297,12 +304,13 @@ class GatedGiveUp(
         )
 
 
-def gated_give_up_tool(
+def gated_give_up_tool[S: GatedGiveUpState](
     *,
     name: str,
     description: str,
     label: str,
     min_attempts: int,
+    state_ty: type[S],
     reason_description: str = "The reason for giving up on your task",
 ) -> BaseTool:
     """:func:`give_up_tool` with a floor under it: an ``exhausted`` surrender is refused until
@@ -313,8 +321,12 @@ def gated_give_up_tool(
     The ``environment`` escape is not optional: a missing prover or compiler produces no prover
     run at all, so a bare attempt floor would be unsatisfiable and would hold the agent against
     its recursion limit instead of letting it report a broken toolchain."""
+    # The subscript comes after the render, not before: the family decorator hands back an
+    # already-specialized type, so ``GatedGiveUp[state_ty]`` is not a thing but
+    # ``GatedGiveUp.with_template(...)[state_ty]`` is. Naming the session's own state type here
+    # means the fields this tool reads are checked against the state it actually runs on.
     return GatedGiveUp.with_template(
         description=description,
         reason=reason_description,
         label=label,
-    ).bind(min_attempts).as_tool(name)
+    )[state_ty].bind(min_attempts).as_tool(name)

--- a/composer/authoring/tools.py
+++ b/composer/authoring/tools.py
@@ -12,10 +12,11 @@ instantiate time. Unskip does not vary.
 """
 
 from dataclasses import dataclass
-from typing import Callable, Literal, Sequence, override
+from typing import Callable, Literal, NotRequired, Sequence, override
 
 from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
 from langchain_core.tools import BaseTool
+from langgraph.graph import MessagesState
 from langgraph.types import Command
 from pydantic import Field
 
@@ -42,17 +43,28 @@ def _as_titles(titles: Titles | Sequence[PropertyTitle]) -> Titles:
     return lambda: snapshot
 
 
+class CurtailableState(MessagesState):
+    """The authoring state :class:`RecordSkip` reads.
+
+    ``budget_curtailed`` is where the budget monitor records its wrap-up order, and the focus
+    protection stands down when it is set. Optional because only the prover and foundry authors
+    have a budget to be curtailed by; the natspec and rustapp sessions share this tool and carry
+    no such field, and absent reads as "still trying"."""
+    budget_curtailed: NotRequired[bool]
+
+
 @dataclass(frozen=True)
 class SkipScope:
     """What ``record_skip`` is allowed to retire: the batch's titles, and the subset it must
     refuse.
 
-    ``protected`` is a thunk, not a set, because the answer changes during a session — the
-    budget monitor's wrap-up order tells the agent to skip everything that does not work, so a
-    protection that outlived that order would deadlock the session it was meant to curtail.
-    A backend with nothing to protect passes a thunk returning ``()``."""
+    The protection is unconditional only while the run is still trying. Once the budget monitor
+    orders a wrap-up it tells the agent to skip everything that does not work, so a protection
+    that outlived that order would deadlock the session it was meant to curtail. That state lives
+    in ``budget_curtailed``, which is where the tool reads it — not in a flag on this object,
+    which would not survive a checkpoint and could disagree with the state it shadows."""
     titles: Titles
-    protected: Titles
+    protected: frozenset[PropertyTitle] = frozenset()
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +88,11 @@ def _skip_result(
 
 @tool_family_display(_skip_label, _skip_result)
 @tool_family(SkipParams)
-class RecordSkip(WithInjectedId, WithAsyncDependencies[Command, SkipScope]):
+class RecordSkip(
+    WithInjectedId,
+    WithInjectedState[CurtailableState],
+    WithAsyncDependencies[str | Command, SkipScope],
+):
     """{description}"""
     property_title: PropertyTitle = Field(
         description="The snake_case title of the property from the batch listing"
@@ -84,28 +100,24 @@ class RecordSkip(WithInjectedId, WithAsyncDependencies[Command, SkipScope]):
     reason: str = Field(description="{reason}")
 
     @override
-    async def run(self) -> Command:
+    async def run(self) -> str | Command:
         with self.tool_deps() as scope:
             known = scope.titles()
-            protected = scope.protected()
+            protected = scope.protected
         if self.property_title not in known:
-            return tool_state_update(
-                self.tool_call_id,
+            return (
                 f"Unknown property title {self.property_title!r}. Must be one "
-                f"of: {', '.join(known)}.",
+                f"of: {', '.join(known)}."
             )
-        if self.property_title in protected:
-            return tool_state_update(
-                self.tool_call_id,
+        if self.property_title in protected and not self.state.get("budget_curtailed"):
+            return (
                 f"Property {self.property_title!r} is the focus of this run and cannot be "
-                "skipped. Decompose it into lemmas, strengthen the harness, or formalize a "
-                "weaker core of it and say so in your commentary — but do not retire it.",
+                "skipped. Prove a smaller statement it is built out of, or formalize the "
+                "strongest version of it that holds and say what you could not prove — but do "
+                "not retire it."
             )
         if not self.reason.strip():
-            return tool_state_update(
-                self.tool_call_id,
-                "A non-empty justification is required when skipping a property.",
-            )
+            return "A non-empty justification is required when skipping a property."
         return tool_state_update(
             self.tool_call_id,
             f"Recorded skip for property {self.property_title}.",
@@ -145,15 +157,16 @@ def skip_tools(
     *,
     skip_description: str,
     skip_reason: str,
-    protected: Titles | Sequence[PropertyTitle] = (),
+    protected: Sequence[PropertyTitle] = (),
 ) -> list[BaseTool]:
     """The skip / unskip pair, bound to the batch's property titles.
 
     ``protected`` names titles ``record_skip`` must refuse — the focus of a prioritized run,
-    whose whole point is that it is pursued rather than retired. Unskip is deliberately not
-    constrained: un-retiring a property is always allowed."""
+    whose whole point is that it is pursued rather than retired. The refusal lifts on its own
+    once the run is budget-curtailed. Unskip is deliberately not constrained: un-retiring a
+    property is always allowed."""
     get = _as_titles(titles)
-    scope = SkipScope(titles=get, protected=_as_titles(protected))
+    scope = SkipScope(titles=get, protected=frozenset(protected))
     return [
         RecordSkip.with_template(description=skip_description, reason=skip_reason)
         .bind(scope)
@@ -219,7 +232,14 @@ def _gated_give_up_label(p: dict, *, description: str, reason: str, label: str) 
     return f"Giving up on {label}: {p['reason']}"
 
 
-def _verify_attempts(state: dict) -> int:
+class GatedGiveUpState(MessagesState):
+    """The authoring state :class:`GatedGiveUp` reads and writes: the message history it counts
+    prover attempts from, and the two fields a surrender records."""
+    result: NotRequired[str]
+    failed: NotRequired[bool]
+
+
+def _verify_attempts(state: GatedGiveUpState) -> int:
     """How many times this session has put a spec in front of the prover.
 
     Counted from the message history rather than from ``prover_history``: that list only grows
@@ -240,8 +260,8 @@ def _verify_attempts(state: dict) -> int:
 @tool_family(GiveUpParams)
 class GatedGiveUp(
     WithInjectedId,
-    WithInjectedState[dict],
-    WithAsyncDependencies[Command, int],
+    WithInjectedState[GatedGiveUpState],
+    WithAsyncDependencies[str | Command, int],
 ):
     """{description}"""
     sort: Literal["environment", "exhausted"] = Field(
@@ -257,17 +277,17 @@ class GatedGiveUp(
     )
 
     @override
-    async def run(self) -> Command:
+    async def run(self) -> str | Command:
         with self.tool_deps() as floor:
             if self.sort == "exhausted" and (ran := _verify_attempts(self.state)) < floor:
-                return tool_state_update(
-                    self.tool_call_id,
+                return (
                     f"Rejected: you have run the prover {ran} time(s) on this task, and this run "
                     f"requires at least {floor} before a property may be abandoned. This is the "
-                    "one property the run exists to establish. Decompose it into lemmas, add or "
-                    "strengthen a harness, or formalize a weaker core of it and state the gap — "
-                    "then verify. If the toolchain itself is broken, stop with "
-                    "sort='environment' instead.",
+                    "property the run exists to establish. Prove a smaller statement it is built "
+                    "out of, or formalize the strongest version of it that holds and state what "
+                    "you could not prove — then verify. Do not reach a passing rule by assuming "
+                    "away the states where the property is interesting. If the toolchain itself "
+                    "is broken, stop with sort='environment' instead."
                 )
         return tool_state_update(
             self.tool_call_id,

--- a/composer/cli/cache_autoprove.py
+++ b/composer/cli/cache_autoprove.py
@@ -44,9 +44,11 @@ from composer.spec.source.harness import (
 from composer.pipeline.cli import root_cache_key, user_ns
 from composer.pipeline.keys import (
     AGENT_RESULT_KEY, AGENT_ROUND_KEY, BUG_ANALYSIS_KEY,
-    COMMON_SYSTEM_CACHE_KEY, COMPONENT_KEY, FORMALIZATION_KEY,
+    COMMON_SYSTEM_CACHE_KEY, COMPONENT_KEY, FINAL_PROPERTIES_KEY, FORMALIZATION_KEY,
     PRE_PROPERTY_KEY, PROPERTIES_KEY, SYSTEM_ANALYSIS_KEY,
 )
+from composer.pipeline.ptypes import FinalProperties
+from composer.spec.types import PropertyFormulation
 from composer.pipeline.plugins import applicable_plugin_manifest, manifest_digest
 from composer.pipeline.run_tags import AutoProveCacheTags, CACHE_ROOT_RECORD
 from composer.core.user import get_uid
@@ -191,6 +193,34 @@ async def _resolve_bug_key(
     )
 
 
+async def _resolve_formalization_key(
+    feat_ctx: WorkflowContext,
+    tags: AutoProveCacheTags,
+    bug_items: list[PropertyFormulation],
+) -> CacheKey:
+    """The formalization edge, rebuilt the way the driver derived it.
+
+    ``FinalProperties`` exists for exactly this: it records the batch as it entered
+    formalization, after any post-inference plugin rewrote it and after a prioritized run pruned
+    it, together with the plugin ids that suffix the key. Reconstructing from the raw
+    property-inference output instead misses all three, and lands on a namespace that holds
+    nothing.
+
+    Falls back to the inference output for records written before that entry existed."""
+    xc_digest = combine_digests(tags.extra_context_digests)
+    final = await feat_ctx.child(
+        FINAL_PROPERTIES_KEY(
+            tags.threat_model_digest,
+            bool(tags.interactive),
+            xc_digest,
+            tags.run_mode or "comprehensive",
+        )
+    ).cache_get(FinalProperties)
+    if final is not None:
+        return FORMALIZATION_KEY(GeneratedCVL, final.items, final.tool_plugins)
+    return FORMALIZATION_KEY(GeneratedCVL, bug_items)
+
+
 async def _build_cvl_gen_nodes(
     ctx: WorkflowContext[CVLGeneration],
 ) -> AsyncGenerator[CacheTreeNode[AutoProveCachedValue], None]:
@@ -235,7 +265,7 @@ async def _build_component_nodes(
         bug_cache = await feat_ctx.child(bug_key).cache_get(_BugAnalysisCache)
         if bug_cache is None:
             return
-        batch_key = FORMALIZATION_KEY(GeneratedCVL, bug_cache.items)
+        batch_key = await _resolve_formalization_key(feat_ctx, tags, bug_cache.items)
         async with node_for(feat_ctx, batch_key, "CVL Generation", GeneratedCVL) as cvl_ctx:
             async for n in _build_cvl_gen_nodes(cvl_ctx.abstract(CVLGeneration)):
                 yield n

--- a/composer/cli/cache_autoprove.py
+++ b/composer/cli/cache_autoprove.py
@@ -48,6 +48,7 @@ from composer.pipeline.keys import (
     PRE_PROPERTY_KEY, PROPERTIES_KEY, SYSTEM_ANALYSIS_KEY,
 )
 from composer.pipeline.ptypes import FinalProperties
+from composer.pipeline.run_mode import run_mode_name
 from composer.spec.types import PropertyFormulation
 from composer.pipeline.plugins import applicable_plugin_manifest, manifest_digest
 from composer.pipeline.run_tags import AutoProveCacheTags, CACHE_ROOT_RECORD
@@ -213,7 +214,7 @@ async def _resolve_formalization_key(
             tags.threat_model_digest,
             bool(tags.interactive),
             xc_digest,
-            tags.run_mode or "comprehensive",
+            run_mode_name(tags.run_mode),
         )
     ).cache_get(FinalProperties)
     if final is not None:

--- a/composer/cli/console_autoprove.py
+++ b/composer/cli/console_autoprove.py
@@ -19,8 +19,13 @@ async def _main() -> int:
         result = await run(AutoProveConsoleHandler().make_handler)
         print(f"\n{'=' * 60}")
         print(summary.format())
-        print(f"\n  Components:  {result.n_components}")
+        print(f"\n  Run mode:    {result.run_mode.value}")
+        print(f"  Components:  {result.n_components}")
         print(f"  Properties:  {result.n_properties}")
+        if result.n_deprioritized:
+            # Say it on stdout, not only in report.json: the number that matters about a
+            # prioritized run is the one it did NOT look at.
+            print(f"  Deprioritized: {result.n_deprioritized} (not examined)")
         if result.failures:
             print(f"  Failures:    {len(result.failures)}")
             for f in result.failures:

--- a/composer/foundry/entry.py
+++ b/composer/foundry/entry.py
@@ -37,6 +37,7 @@ from composer.foundry.pipeline import (
     FoundryPhase, FoundryPipelineResult, backend
 )
 from composer.pipeline.cli import cli_pipeline, user_ns, AtExit
+from composer.pipeline.run_mode import RunMode
 from composer.pipeline.ptypes import DEFAULT_MAX_CPU_TASKS
 from composer.pipeline.ecosystem import EVM
 
@@ -107,8 +108,11 @@ def _usage_exit_logger(summary: RunSummary) -> AtExit:
         except Exception:
             _log.exception("failed to log foundry usage to run data")
         try:
+            # The foundry entry point does not expose --run-mode: the focus protections
+            # live in the CVL author, so a pruned foundry batch would get the narrowing
+            # without the discipline. It is always comprehensive.
             FoundryArtifactStore(run.project_root).write_job_info(
-                summary, user_id=get_uid()
+                summary, user_id=get_uid(), run_mode=RunMode.COMPREHENSIVE.value
             )
         except Exception:
             _log.exception("failed to dump foundry job info")

--- a/composer/pipeline/cli.py
+++ b/composer/pipeline/cli.py
@@ -32,6 +32,7 @@ from composer.spec.service_host import ModelProvider
 from composer.spec.types import SourceIdentifier
 from composer.pipeline.ecosystem import Ecosystem
 from .core import PipelineBackend, run_pipeline
+from .run_mode import RunMode
 from .plugins import applicable_plugin_manifest
 from .run_tags import AutoProveCacheTags, CACHE_ROOT_RECORD
 from composer.io.multi_job import HandlerFactory, run_task, TaskInfo
@@ -229,6 +230,7 @@ async def cli_pipeline[P: enum.Enum, H](
     task_handler: HandlerFactory[P, H],
     design_doc_phase: P,
     at_exit: AtExit | None = None,
+    run_mode: RunMode = RunMode.COMPREHENSIVE,
     **metadata
 ) -> AsyncIterator[tuple[StagedPipeline, Continuation[P, H]]]:
     project_root = pathlib.Path(args.project_root).resolve()
@@ -378,6 +380,7 @@ async def cli_pipeline[P: enum.Enum, H](
                     threat_model_digest=threat_model.to_digest() if threat_model is not None else None,
                     extra_context_digests=[d.to_digest() for d in extra_context],
                     interactive=args.interactive,
+                    run_mode=run_mode.value,
                 ).model_dump())
                 full_ctx = WorkflowContext.create(
                     services=conns.memory,
@@ -391,6 +394,7 @@ async def cli_pipeline[P: enum.Enum, H](
                     ctx=full_ctx,
                     source=full_source,
                     env=env,
+                    run_mode=run_mode,
                     _agent_semaphore=semaphore,
                     _cpu_semaphore=cpu_semaphore,
                     _handler_factory=task_handler

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -50,6 +50,9 @@ from composer.spec.system_model import (
 from composer.spec.util import combine_digests
 from composer.spec.types import PropertyFormulation, ArtifactIdentifier, VerificationArtifact
 from composer.spec.system_analysis import run_component_analysis
+from composer.spec.prioritize import (
+    Candidate, PropertyRanking, Selection, build_candidates, rank_properties, select,
+)
 from composer.spec.prop_inference import (
     run_property_inference, AnyPropertyGenerationInput, CacheablePropertyGenerationInput,
 )
@@ -58,18 +61,20 @@ from composer.input.files import Document
 from composer.spec.source.report.build import build_report
 from composer.spec.source.report.collect import ReportComponentInput, Verdict, EvidenceFetcher, Formalized
 from composer.spec.source.report.schema import (
-    AutoProverReport, RuleName, ReportBackend, SourceEditRecord, VerificationArtifactRecord,
+    AutoProverReport, DeprioritizedProperty, RuleName, ReportBackend, SourceEditRecord,
+    VerificationArtifactRecord,
 )
 from composer.spec.source.report import build as report_build
 from composer.spec.source.task_ids import SYSTEM_ANALYSIS_TASK_ID, REPORT_TASK_ID
 from composer.pipeline.ecosystem import Ecosystem
 from .keys import (
     COMPONENT_KEY, FINAL_PROPERTIES_KEY, FORMALIZATION_KEY, PLUGIN_ARTIFACTS_KEY,
-    POST_PROPERTY_KEY, PRE_PROPERTY_KEY, PROPERTIES_KEY, SYSTEM_ANALYSIS_KEY,
-    PLUGIN_FORMALIZATION_KEY
+    POST_PROPERTY_KEY, PRE_PROPERTY_KEY, PRIORITIZATION_KEY, PROPERTIES_KEY,
+    SYSTEM_ANALYSIS_KEY, PLUGIN_FORMALIZATION_KEY, candidates_digest
 )
 from composer.diagnostics.budget import total_budget, named_budget_or_nop, time_budget
 
+from .run_mode import RunMode
 from .ptypes import (
     DEFAULT_MAX_CPU_TASKS,
     BackendJob, BackendResult, ComponentOutcome, CorePhases, CorePipelineResult,
@@ -548,6 +553,20 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
     if not batches:
         raise ValueError("No properties extracted from any component.")
 
+    # 3b. Prioritized runs formalize one property, not every component's. Ranking happens
+    #     here because this is the first and only point where every component's candidates
+    #     exist together — inference never sees more than the unit it was given, and the
+    #     per-component plugin hook cannot compare across units either. Pruning before
+    #     ``begin`` also means a backend that authors a shared artifact from the batches
+    #     authors it from the focus.
+    deprioritized: list[DeprioritizedProperty] = []
+    if run.run_mode is RunMode.PRIORITIZED:
+        with named_budget_or_nop("property_extraction"):
+            batches, deprioritized = await _prioritize(
+                backend.analysis_spec.properties_key, backend.artifact_store,
+                batches, run, phases["extraction"], threat_model, extra_context,
+            )
+
     # 4. A backend whose units share an artifact handed back a ``StagedFormalizer`` instead of a
     #    formalizer: the artifact is authored HERE — once, from every unit's properties — and the
     #    formalizer it yields is the only one that exists (see :class:`StagedFormalizer`).
@@ -592,6 +611,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                 threat_model.to_digest() if threat_model is not None else None,
                 interactive,
                 combine_digests([d.to_digest() for d in extra_context]),
+                run.run_mode.value,
             )
         ).cache_put(FinalProperties(items=batch.props, tool_plugins=contributing_plugins))
 
@@ -706,7 +726,8 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                 # Findings only when the backend supplies evidence — skip the heavy model otherwise.
                 findings_llm=run.env.llm_heavy() if findings_evidence else None,
                 fetch_evidence=findings_evidence,
-
+                run_mode=run.run_mode.value,
+                deprioritized=deprioritized,
             )
         report = await run.runner(
             job=_report,
@@ -718,7 +739,94 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
             raise
         _log.warning("report phase failed (continuing)", exc_info=True)
 
-    return _tally(outcomes)
+    return _tally(outcomes, run.run_mode, len(deprioritized))
+
+
+#: The driver-owned task id for the ranking step. Backend-agnostic, like the per-unit
+#: ``extract-{i}`` / ``formalize-{i}`` ids, so it lives here rather than in a backend's registry.
+PRIORITIZE_TASK_ID = "prioritize"
+
+
+async def _prioritize[P: enum.Enum, H, U: FeatureUnit](
+    prop_key: str,
+    store: ArtifactStore,
+    batches: list[_Batch[U]],
+    run: PipelineRun[P, H],
+    phase: P,
+    threat_model: Document | None,
+    extra_context: Sequence[Document],
+) -> tuple[list[_Batch[U]], list[DeprioritizedProperty]]:
+    """Rank every extracted property and cut the run down to one component's focus.
+
+    Returns the surviving batch list — always exactly one entry, so the driver's
+    "no properties extracted" guard cannot fire on our account — alongside every candidate it
+    set aside, which the report carries so a reader can see what this run did not look at.
+
+    The winning batch keeps its own ``feat`` and ``feat_ctx``: unit identity, task ids and
+    the artifact-store stem are all unchanged, so only ``FORMALIZATION_KEY`` — which is
+    derived from the property list — forks away from a comprehensive run's cache. The
+    extraction subtree is shared, and a prioritized run replays it.
+
+    An unusable ranking raises. Quietly widening back to every component would spend the
+    budget this mode exists to save, on a run that asked to be cheap.
+    """
+    candidates: list[Candidate] = build_candidates(
+        [(b.feat.unit_index, b.feat.display_name, b.props) for b in batches]
+    )
+    tm_digest = threat_model.to_digest() if threat_model is not None else None
+    xc_digest = combine_digests([d.to_digest() for d in extra_context]) or None
+    ctx = run.ctx.child(PROPERTIES_KEY(prop_key)).child(
+        PRIORITIZATION_KEY(
+            candidates_digest([(b.feat, b.props) for b in batches]), tm_digest, xc_digest,
+        )
+    )
+
+    ranking = await ctx.cache_get(PropertyRanking)
+    if ranking is None:
+        ranking = await run.runner(
+            TaskInfo(PRIORITIZE_TASK_ID, "Property Prioritization", phase),
+            lambda: rank_properties(
+                llm=run.env.llm_heavy(),
+                contract_name=run.source.contract_name,
+                candidates=candidates,
+                design_doc=run.source.content,
+                threat_model=threat_model,
+                extra_context=extra_context,
+            ),
+        )
+        await ctx.cache_put(ranking)
+
+    store.write_ranking(ranking)
+
+    selection: Selection = select(candidates, ranking)
+    chosen = next(b for b in batches if b.feat.unit_index == selection.unit_index)
+    by_title = {p.title: p for p in chosen.props}
+    props = [by_title[t] for t in selection.titles]
+
+    pursued = {(c.label, t) for c in candidates if c.unit_index == selection.unit_index
+               for t in selection.titles}
+    detail = {(c.label, p.title): p for c in candidates for p in c.props}
+    deprioritized = [
+        DeprioritizedProperty(
+            component=rp.key[0],
+            title=rp.key[1],
+            sort=detail[rp.key].sort,
+            description=detail[rp.key].description,
+            score=rp.score,
+            rationale=rp.rationale,
+        )
+        for rp in ranking.ranked
+        if rp.key not in pursued
+    ]
+
+    _log.info(
+        "prioritized: %s / %s (+%d supporting); %d propert(ies) across %d other component(s) "
+        "deprioritized",
+        chosen.feat.display_name, props[0].title, len(props) - 1,
+        len(deprioritized), len(batches) - 1,
+    )
+    return [_Batch(chosen.feat, props, chosen.feat_ctx)], deprioritized
+
 
 async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
     prop_key: str,
@@ -816,7 +924,9 @@ async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
 
 
 def _tally[FormT: BackendResult, U: FeatureUnit](
-    outcomes: list[ComponentOutcome[FormT, U]]
+    outcomes: list[ComponentOutcome[FormT, U]],
+    run_mode: RunMode = RunMode.COMPREHENSIVE,
+    n_deprioritized: int = 0,
 ) -> CorePipelineResult[FormT]:
     failures: list[str] = []
     for o in outcomes:
@@ -836,4 +946,5 @@ def _tally[FormT: BackendResult, U: FeatureUnit](
     return CorePipelineResult(
         len(outcomes), sum(len(o.props) for o in outcomes),
         cast(list[ComponentOutcome[FormT, FeatureUnit]], outcomes), failures,
+        run_mode, n_deprioritized,
     )

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -549,23 +549,32 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
             phases.get("extraction_plugin") or phases["extraction"],
         )
     )
-    staged = await staged_task
-    if not batches:
-        raise ValueError("No properties extracted from any component.")
-
-    # 3b. Prioritized runs formalize one property, not every component's. Ranking happens
-    #     here because this is the first and only point where every component's candidates
-    #     exist together — inference never sees more than the unit it was given, and the
-    #     per-component plugin hook cannot compare across units either. Pruning before
-    #     ``begin`` also means a backend that authors a shared artifact from the batches
-    #     authors it from the focus.
+    # 3b. Prioritized runs formalize one property, not every component's. This is the first
+    #     point where every component's candidates exist together — inference never sees more
+    #     than the unit it was given, and the per-component plugin hook cannot compare across
+    #     units either.
+    #
+    #     It sits *before* the ``staged_task`` await rather than after because the ranking
+    #     reads nothing that pre-formalization produces: it needs the extracted batches and
+    #     the guidance documents, both of which are already in hand. Awaiting the setup first
+    #     would queue the run's cheapest decision behind its most expensive step — on a real
+    #     contract that is hours during which the focus is knowable but unknown. It also puts
+    #     the focus in hand earlier than the setup finishes, which is what a pre-formalization
+    #     step would need in order to aim at it.
+    #     The empty-batch check deliberately stays *after* the await below rather than moving
+    #     up here to guard this: a setup that failed is the more useful error than "nothing was
+    #     extracted", and raising early would mask it.
     deprioritized: list[DeprioritizedProperty] = []
-    if run.run_mode is RunMode.PRIORITIZED:
+    if batches and run.run_mode is RunMode.PRIORITIZED:
         with named_budget_or_nop("property_extraction"):
             batches, deprioritized = await _prioritize(
                 backend.analysis_spec.properties_key, backend.artifact_store,
                 batches, run, phases["extraction"], threat_model, extra_context,
             )
+
+    staged = await staged_task
+    if not batches:
+        raise ValueError("No properties extracted from any component.")
 
     # 4. A backend whose units share an artifact handed back a ``StagedFormalizer`` instead of a
     #    formalizer: the artifact is authored HERE — once, from every unit's properties — and the

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -621,6 +621,23 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
         )
         artifacts_ctx = child.child(PLUGIN_ARTIFACTS_KEY)
         cached_result: FormT | None = await child.cache_get(formalizer.formalized_type)
+        # A prioritized batch is usually a strict subset, so it usually forks this key — but not
+        # when the focus happens to be the component's whole list (a single-property component
+        # always). There the hit may be a comprehensive result that retired the very property this
+        # run exists to establish, and a replay never runs the author's tools, so none of the
+        # protections around the focus apply to it. Re-formalize instead; the fresh result
+        # overwrites the stale entry. This cannot loop: the live tools refuse to retire the focus,
+        # and the one path that overrides them (a budget wrap-up) yields a Curtailed, never cached.
+        if (
+            cached_result is not None
+            and run.run_mode is RunMode.PRIORITIZED
+            and not _focus_satisfied(cached_result, batch.props)
+        ):
+            _log.info(
+                "%s: cached formalization does not establish the focus; re-running",
+                batch.feat.display_name,
+            )
+            cached_result = None
         result : FormT | Curtailed[FormT] | GaveUp
         if cached_result is None:
             label = f"{batch.feat.display_name} ({len(batch.props)} properties)"
@@ -744,6 +761,17 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
 
 #: The driver-owned task id for the ranking step. Backend-agnostic, like the per-unit
 #: ``extract-{i}`` / ``formalize-{i}`` ids, so it lives here rather than in a backend's registry.
+def _focus_satisfied(result: BackendResult, props: Sequence[PropertyFormulation]) -> bool:
+    """Does this formalization actually establish every property of a prioritized batch?
+
+    Backend-agnostic: ``BackendResult`` carries the skip declarations and the property->checks
+    mapping, and an author excuses a property from that mapping precisely by skipping it. So
+    "mapped to at least one check, and not retired" is the whole test."""
+    checks = {title: names for title, names in result.property_checks()}
+    retired = {s.property_title for s in result.skipped}
+    return all(p.title not in retired and checks.get(p.title) for p in props)
+
+
 PRIORITIZE_TASK_ID = "prioritize"
 
 

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -74,7 +74,7 @@ from .keys import (
 )
 from composer.diagnostics.budget import total_budget, named_budget_or_nop, time_budget
 
-from .run_mode import RunMode
+from .run_mode import RunMode, run_mode_name
 from .ptypes import (
     DEFAULT_MAX_CPU_TASKS,
     BackendJob, BackendResult, ComponentOutcome, CorePhases, CorePipelineResult,
@@ -620,7 +620,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                 threat_model.to_digest() if threat_model is not None else None,
                 interactive,
                 combine_digests([d.to_digest() for d in extra_context]),
-                run.run_mode.value,
+                run_mode_name(run.run_mode.value),
             )
         ).cache_put(FinalProperties(items=batch.props, tool_plugins=contributing_plugins))
 
@@ -793,7 +793,7 @@ async def _prioritize[P: enum.Enum, H, U: FeatureUnit](
     threat_model: Document | None,
     extra_context: Sequence[Document],
 ) -> tuple[list[_Batch[U]], list[DeprioritizedProperty]]:
-    """Rank every extracted property and cut the run down to one component's focus.
+    """Rank every extracted property and cut the run down to one claim's worth of them.
 
     Returns the surviving batch list — always exactly one entry, so the driver's
     "no properties extracted" guard cannot fire on our account — alongside every candidate it
@@ -857,9 +857,9 @@ async def _prioritize[P: enum.Enum, H, U: FeatureUnit](
     ]
 
     _log.info(
-        "prioritized: %s / %s (+%d supporting); %d propert(ies) across %d other component(s) "
-        "deprioritized",
-        chosen.feat.display_name, props[0].title, len(props) - 1,
+        "prioritized: %s — %r, stated by %d propert(ies); %d propert(ies) across %d other "
+        "component(s) deprioritized",
+        chosen.feat.display_name, selection.claim, len(props),
         len(deprioritized), len(batches) - 1,
     )
     return [_Batch(chosen.feat, props, chosen.feat_ctx)], deprioritized

--- a/composer/pipeline/keys.py
+++ b/composer/pipeline/keys.py
@@ -16,7 +16,9 @@ traverses below the run root, in tree order::
         │   └── {props digest}                 FORMALIZATION_KEY    → backend result (FormT)
         │       └── plugin-artifacts           PLUGIN_ARTIFACTS_KEY → RegisteredArtifacts
         ├── {unit digest}-{plugin}-pre         PRE_PROPERTY_KEY     → PrePropertyInference
-        └── {unit digest}-{plugin}-{props}     POST_PROPERTY_KEY    → PostPropertyInference
+        ├── {unit digest}-{plugin}-{props}     POST_PROPERTY_KEY    → PostPropertyInference
+        └── prioritization-{all props}[-tm-…][-xc-…]
+                                               PRIORITIZATION_KEY   → PropertyRanking
 
 The extraction-layer families (bug analysis, agent rounds) are declared
 in ``composer.spec.prop_inference`` beside their cache models and
@@ -30,6 +32,7 @@ from typing import Any
 from composer.pipeline.ptypes import FinalProperties, RegisteredArtifacts
 from composer.spec.context import CacheKey, ComponentGroup, Properties
 from composer.spec.key_family import KeyFamily, PolyKeyFamily
+from composer.spec.prioritize import PropertyRanking
 from composer.spec.prop_inference import (
     AGENT_RESULT_KEY, AGENT_ROUND_KEY, BUG_ANALYSIS_KEY,
 )
@@ -49,6 +52,7 @@ __all__ = [
     "FORMALIZATION_KEY",
     "PLUGIN_ARTIFACTS_KEY",
     "POST_PROPERTY_KEY",
+    "PRIORITIZATION_KEY",
     "PRE_PROPERTY_KEY",
     "PROPERTIES_KEY",
     "SYSTEM_ANALYSIS_KEY",
@@ -99,6 +103,7 @@ def _final_properties_key(
     threat_model_digest: str | None,
     with_refinement: bool,
     extra_context_digest: str | None = None,
+    run_mode: str = "comprehensive",
 ) -> str:
     # Parameterized exactly like BUG_ANALYSIS_KEY: the component namespace is
     # shared across runs, so the entry must be keyed by what distinguishes one
@@ -111,6 +116,12 @@ def _final_properties_key(
         base_key += "-tm-" + threat_model_digest
     if extra_context_digest is not None:
         base_key += "-xc-" + extra_context_digest
+    if run_mode != "comprehensive":
+        # A prioritized run writes a *pruned* batch under this component. Without the mode
+        # in the key it would overwrite the comprehensive record at the same fixed leaf, and
+        # an offline walker reconstructing the formalization edge would read a one-property
+        # batch as if it were everything inference found.
+        base_key += "-mode-" + run_mode
     return base_key
 
 #: The property batch as it left the property pipeline (post-inference plugin
@@ -158,3 +169,33 @@ def _post_property_key(
 #: list entering the hook (each plugin in the post chain sees — and is keyed
 #: by — its predecessor's output).
 POST_PROPERTY_KEY = KeyFamily(Properties, PostPropertyInference, _post_property_key)
+
+
+def _prioritization_key(
+    candidates_digest: str,
+    threat_model_digest: str | None = None,
+    extra_context_digest: str | None = None,
+) -> str:
+    # Parameterized like the extraction leaves: the properties namespace is shared across
+    # runs, so the entry must be keyed by everything the ranker saw, or two runs over the
+    # same project with different guidance documents would be last-write-wins.
+    base_key = "prioritization-" + candidates_digest
+    if threat_model_digest is not None:
+        base_key += "-tm-" + threat_model_digest
+    if extra_context_digest is not None:
+        base_key += "-xc-" + extra_context_digest
+    return base_key
+
+
+def candidates_digest(batches: list[tuple[FeatureUnit, list[PropertyFormulation]]]) -> str:
+    """The ranker's whole input, as one digest: every unit paired with the properties it
+    contributed, in driver order."""
+    return string_hash(
+        "|".join(f"{component_digest(feat)}:{_props_digest(props)}" for feat, props in batches)
+    )
+
+
+#: The run-wide property ranking, a sibling of the per-unit extraction subtrees: it is the
+#: one step that sees every component at once, so it hangs off ``Properties`` rather than off
+#: any single component.
+PRIORITIZATION_KEY = KeyFamily(Properties, PropertyRanking, _prioritization_key)

--- a/composer/pipeline/keys.py
+++ b/composer/pipeline/keys.py
@@ -32,6 +32,7 @@ from typing import Any
 from composer.pipeline.ptypes import FinalProperties, RegisteredArtifacts
 from composer.spec.context import CacheKey, ComponentGroup, Properties
 from composer.spec.key_family import KeyFamily, PolyKeyFamily
+from composer.pipeline.run_mode import RunModeName
 from composer.spec.prioritize import PropertyRanking
 from composer.spec.prop_inference import (
     AGENT_RESULT_KEY, AGENT_ROUND_KEY, BUG_ANALYSIS_KEY,
@@ -102,8 +103,8 @@ COMPONENT_KEY = KeyFamily(Properties, ComponentGroup, _component_key)
 def _final_properties_key(
     threat_model_digest: str | None,
     with_refinement: bool,
-    extra_context_digest: str | None = None,
-    run_mode: str = "comprehensive",
+    extra_context_digest: str | None,
+    run_mode: RunModeName,
 ) -> str:
     # Parameterized exactly like BUG_ANALYSIS_KEY: the component namespace is
     # shared across runs, so the entry must be keyed by what distinguishes one

--- a/composer/pipeline/keys.py
+++ b/composer/pipeline/keys.py
@@ -127,7 +127,7 @@ def _final_properties_key(
 #: The property batch as it left the property pipeline (post-inference plugin
 #: rewrites applied) plus the tool-contributing plugin ids — the exact
 #: derivation inputs of the FORMALIZATION_KEY sibling. Written by the driver;
-#: read by offline walkers (``composer.meta.run``) to reconstruct that edge.
+#: read by the offline cache walker (``composer.cli.cache_autoprove``) to reconstruct that edge.
 FINAL_PROPERTIES_KEY = KeyFamily(ComponentGroup, FinalProperties, _final_properties_key)
 
 

--- a/composer/pipeline/ptypes.py
+++ b/composer/pipeline/ptypes.py
@@ -19,6 +19,7 @@ from composer.spec.types import (
     Curtailed, PropertyFormulation, FormalResult, VerificationArtifact,
 )
 from composer.spec.source.report.collect import ReportableResult
+from .run_mode import RunMode
 
 
 class BackendResult(FormalResult, ReportableResult, Protocol):
@@ -81,6 +82,11 @@ class TaskRunnerHost[P: enum.Enum, H, S: SourceFields, C]:
 @dataclass
 class PipelineRun[P: enum.Enum, H](TaskRunnerHost[P, H, SourceCode, None]):
     env: ServiceHost
+    #: How much of the inferred property set this run pursues. It rides here rather than
+    #: through the driver's signature because it is read in two places on opposite sides of
+    #: the backend seam — the driver, which prunes the batches, and the author, whose exits
+    #: tighten — and this object already reaches both.
+    run_mode: RunMode = RunMode.COMPREHENSIVE
 
 
 class CorePhases[P: enum.Enum](TypedDict):
@@ -181,6 +187,10 @@ class CorePipelineResult[FormT: BackendResult]:
     n_properties: int
     outcomes: list[ComponentOutcome[FormT, FeatureUnit]]
     failures: list[str]
+    run_mode: RunMode = RunMode.COMPREHENSIVE
+    #: How many inferred properties the run chose not to pursue. Non-zero only under
+    #: ``PRIORITIZED``; ``n_properties`` counts only the ones it did.
+    n_deprioritized: int = 0
 
     @property
     def n_delivered(self) -> int:

--- a/composer/pipeline/ptypes.py
+++ b/composer/pipeline/ptypes.py
@@ -122,7 +122,7 @@ class FinalProperties(BaseModel):
     every post-inference plugin rewrite — plus the tool-contributing plugin
     ids the driver gated in. Together these are exactly the inputs
     ``FORMALIZATION_KEY`` is derived from, so an offline walker
-    (``composer.meta.run``) can reconstruct the formalization edge without
+    (``composer.cli.cache_autoprove``) can reconstruct the formalization edge without
     sniffing the store. Written by the driver at formalization time; the
     pre-rewrite batch remains ``_BugAnalysisCache``."""
     items: list[PropertyFormulation]

--- a/composer/pipeline/run_mode.py
+++ b/composer/pipeline/run_mode.py
@@ -15,6 +15,12 @@ takes into ``composer.prover.core``.
 
 import enum
 import os
+from typing import Literal
+
+
+type RunModeName = Literal["comprehensive", "prioritized"]
+"""The mode's wire form: what a cache key, a report field or an env var carries. Spelled as a
+closed literal so a key family cannot be handed an arbitrary string."""
 
 
 class RunMode(enum.StrEnum):
@@ -44,3 +50,11 @@ def resolve_run_mode(cli: str | None) -> RunMode:
         raise ValueError(
             f"Unknown run mode {raw!r} from {source}. Expected one of: {valid}."
         ) from None
+
+
+def run_mode_name(raw: str | None) -> RunModeName:
+    """Narrow a stored mode tag to the closed set.
+
+    Anything unrecognised, ``None`` included, reads as comprehensive: records written before the
+    mode existed carry no tag, and they were all comprehensive runs."""
+    return "prioritized" if raw == RunMode.PRIORITIZED.value else "comprehensive"

--- a/composer/pipeline/run_mode.py
+++ b/composer/pipeline/run_mode.py
@@ -1,0 +1,46 @@
+"""How much of the inferred property set a run pursues.
+
+``comprehensive`` formalizes every property every component's inference produced —
+the shape the pipeline has always had. ``prioritized`` ranks the whole candidate set
+once, keeps the highest-contribution property plus the properties needed to support
+it, and spends the formalization phase on that alone. The rest of the run (analysis,
+harness, autosetup, structural invariants, property inference) is identical either
+way; only the batches reaching formalization differ.
+
+The mode is settable from the environment as well as the command line so the cloud
+can turn it on by adding one variable to the Batch job, without a code change on
+either side of the wrapper — the same route ``AUTOPROVER_GLOBAL_PROVER_TIMEOUT``
+takes into ``composer.prover.core``.
+"""
+
+import enum
+import os
+
+
+class RunMode(enum.StrEnum):
+    COMPREHENSIVE = "comprehensive"
+    PRIORITIZED = "prioritized"
+
+
+RUN_MODE_ENV = "AUTOPROVER_RUN_MODE"
+
+
+def resolve_run_mode(cli: str | None) -> RunMode:
+    """The run's mode: an explicit ``--run-mode`` wins, else ``AUTOPROVER_RUN_MODE``,
+    else comprehensive.
+
+    Resolution is deliberately *not* an argparse default: the entry points resolve it
+    beside ``parse_budget_file`` so an unrecognised value fails the run before any
+    service spins up, and so no flag's help text claims a default that came from the
+    environment."""
+    raw = cli if cli is not None else os.environ.get(RUN_MODE_ENV)
+    if raw is None or not raw.strip():
+        return RunMode.COMPREHENSIVE
+    try:
+        return RunMode(raw.strip().lower())
+    except ValueError:
+        valid = ", ".join(m.value for m in RunMode)
+        source = "--run-mode" if cli is not None else RUN_MODE_ENV
+        raise ValueError(
+            f"Unknown run mode {raw!r} from {source}. Expected one of: {valid}."
+        ) from None

--- a/composer/pipeline/run_tags.py
+++ b/composer/pipeline/run_tags.py
@@ -44,3 +44,9 @@ class AutoProveCacheTags(BaseModel):
     """Whether the run used interactive refinement (selects the ``|refine``
     bug-analysis key variant). ``None`` on records written before this
     field existed — readers must probe both variants."""
+
+    run_mode: str | None = None
+    """The run's :class:`~composer.pipeline.run_mode.RunMode` value. A prioritized run
+    suffixes its ``final_props`` leaf with the mode, so a reader needs this to know which
+    variant to look under. ``None`` on records written before this field existed, which
+    are all comprehensive."""

--- a/composer/spec/artifacts.py
+++ b/composer/spec/artifacts.py
@@ -16,6 +16,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TypedDict, Unpack
 
+from pydantic import BaseModel
+
 from composer.diagnostics.timing import RunSummary
 from composer.spec.gen_types import PROPERTIES_SUBDIR, under_project
 from composer.spec.types import CheckName, PropertyFormulation, PropertyTitle, VerificationArtifact
@@ -140,6 +142,17 @@ class ArtifactStore[I: ArtifactIdentifier, FormT: FormalResult](ABC):
         out = report_dir / "report.json"
         out.write_text(report.model_dump_json(indent=2) + "\n")
 
+    def write_ranking(self, ranking: BaseModel) -> Path:
+        """A prioritized run's full property ranking → ``{report}/property_ranking.json``.
+
+        Written whether or not the report phase later succeeds: it is the record of a decision
+        the run has already acted on, and the only place the scores and rationales behind the
+        deprioritized properties survive."""
+        out = self._report_dir() / "property_ranking.json"
+        out.write_text(ranking.model_dump_json(indent=2) + "\n")
+        _log.info("prioritization: wrote %s", out)
+        return out
+
 
     # -- shared run-level ---------------------------------------------------
 
@@ -155,21 +168,27 @@ class ArtifactStore[I: ArtifactIdentifier, FormT: FormalResult](ABC):
             json.dumps(payload, indent=2)
         )
 
-    def _job_info_payload(self, summary: RunSummary, *, user_id: str) -> dict[str, object]:
+    def _job_info_payload(
+        self, summary: RunSummary, *, user_id: str, run_mode: str
+    ) -> dict[str, object]:
         """The manifest body shared by every workflow: the tenant ``user_id``, the run's
-        ``run_id``, and the accumulated LLM ``token_usage``. Subclasses extend it with
-        any backend-specific usage they track."""
+        ``run_id``, its ``run_mode``, and the accumulated LLM ``token_usage``. Subclasses
+        extend it with any backend-specific usage they track."""
         return {
             "user_id": user_id,
             "run_id": summary.run_id,
+            "run_mode": run_mode,
             "token_usage": summary.token_usage_summary(),
         }
 
-    def write_job_info(self, summary: RunSummary, *, user_id: str) -> None:
+    def write_job_info(self, summary: RunSummary, *, user_id: str, run_mode: str) -> None:
         """The run's identity + usage manifest → ``{report}/job_info.json``, next to
-        ``report.json``. ``user_id`` is passed in so this stays a pure serializer of run
-        state; the body is :meth:`_job_info_payload`, which subclasses extend."""
-        payload = self._job_info_payload(summary, user_id=user_id)
+        ``report.json``. ``user_id`` and ``run_mode`` are passed in so this stays a pure
+        serializer of run state; the body is :meth:`_job_info_payload`, which subclasses
+        extend. ``run_mode`` is here rather than only in the report because this file is
+        written on every path, crash included, and is what the cloud reads back to tell which
+        mode a finished job ran under."""
+        payload = self._job_info_payload(summary, user_id=user_id, run_mode=run_mode)
         out = self._report_dir() / "job_info.json"
         out.write_text(json.dumps(payload, indent=2) + "\n")
         _log.info("job info: wrote %s", out)

--- a/composer/spec/cvl_generation.py
+++ b/composer/spec/cvl_generation.py
@@ -26,7 +26,7 @@ from composer.authoring.judge import PropertyFeedbackProtocol, RebuttalBase
 from composer.authoring.state import (
     AuthoringExtra, MappingVocab, SkippedProperty, spec_digest, validate_check_mapping,
 )
-from composer.authoring.tools import Titles, skip_tools as _skip_pair
+from composer.authoring.tools import skip_tools as _skip_pair
 from composer.spec.context import (
     WorkflowContext, CacheKey, CVLGeneration, CVLJudge,
 )
@@ -295,7 +295,7 @@ _SKIP_REASON = "Justification for why this property cannot be formalized"
 def skip_tools(
     titles: list[PropertyTitle],
     *,
-    protected: Titles | Sequence[PropertyTitle] = (),
+    protected: Sequence[PropertyTitle] = (),
 ) -> list[BaseTool]:
     """The skip-management pair, bound to the batch's property titles. ``protected`` names the
     titles ``record_skip`` must refuse."""
@@ -310,7 +310,7 @@ def skip_tools(
 def property_tools(
     services: FeedbackServices,
     *,
-    protected: Titles | Sequence[PropertyTitle] = (),
+    protected: Sequence[PropertyTitle] = (),
 ) -> list[BaseTool]:
     """The full property-management suite with the vanilla feedback tool.
     Callers with a custom feedback tool (e.g. the editor-aware source author)

--- a/composer/spec/cvl_generation.py
+++ b/composer/spec/cvl_generation.py
@@ -26,7 +26,7 @@ from composer.authoring.judge import PropertyFeedbackProtocol, RebuttalBase
 from composer.authoring.state import (
     AuthoringExtra, MappingVocab, SkippedProperty, spec_digest, validate_check_mapping,
 )
-from composer.authoring.tools import skip_tools as _skip_pair
+from composer.authoring.tools import Titles, skip_tools as _skip_pair
 from composer.spec.context import (
     WorkflowContext, CacheKey, CVLGeneration, CVLJudge,
 )
@@ -292,23 +292,37 @@ _SKIP_DESCRIPTION = """
 _SKIP_REASON = "Justification for why this property cannot be formalized"
 
 
-def skip_tools(titles: list[PropertyTitle]) -> list[BaseTool]:
-    """The skip-management pair, bound to the batch's property titles."""
+def skip_tools(
+    titles: list[PropertyTitle],
+    *,
+    protected: Titles | Sequence[PropertyTitle] = (),
+) -> list[BaseTool]:
+    """The skip-management pair, bound to the batch's property titles. ``protected`` names the
+    titles ``record_skip`` must refuse."""
     return _skip_pair(
         titles,
         skip_description=_SKIP_DESCRIPTION,
         skip_reason=_SKIP_REASON,
+        protected=protected,
     )
 
 
-def property_tools(services: FeedbackServices) -> list[BaseTool]:
+def property_tools(
+    services: FeedbackServices,
+    *,
+    protected: Titles | Sequence[PropertyTitle] = (),
+) -> list[BaseTool]:
     """The full property-management suite with the vanilla feedback tool.
     Callers with a custom feedback tool (e.g. the editor-aware source author)
     bind their own :class:`FeedbackToolBase` subclass and use
-    :func:`skip_tools` directly."""
+    :func:`skip_tools` directly.
+
+    ``protected`` is forwarded to the skip pair — a caller reaching its skip tools through
+    here must be able to protect a focus just as one calling :func:`skip_tools` directly can,
+    or the ban silently depends on which branch built the suite."""
     return [
         VanillaFeedbackTool.bind(services).as_tool("feedback_tool"),
-        *skip_tools(services.titles),
+        *skip_tools(services.titles, protected=protected),
     ]
 
 

--- a/composer/spec/prioritize.py
+++ b/composer/spec/prioritize.py
@@ -11,6 +11,11 @@ not an agent: an agent here would re-import the per-component cost the mode exis
 remove. Its output is validated in Python before anything acts on it — an unvalidated
 ranking would silently redirect the run's entire formalization budget.
 
+The model scores; it does not choose. Which property the run pursues falls out of those
+scores here (:func:`priority`, :func:`select`), so the ranking the artifact records and the
+property the run actually spends itself on are the same thing by construction rather than
+by agreement.
+
 The models live here rather than beside the cache key so ``pipeline/keys.py`` can
 import them without a cycle (see ``spec/key_family.py``: registries import producers,
 never the reverse), and the selection helper takes plain data so this module never
@@ -33,14 +38,19 @@ from composer.templates.loader import load_jinja_template
 
 _log = logging.getLogger(__name__)
 
-#: Ceiling on the supporting cluster. The primary property plus its lemmas is meant to
-#: stay a focused unit of work; past a handful of neighbours the batch is a component
-#: again and the mode has bought nothing.
-MAX_SUPPORTING = 4
+#: Ceiling on the supporting cluster. The primary property plus its lemmas is meant to stay a
+#: focused unit of work; past a couple of neighbours the batch is a component again and the mode
+#: has bought nothing.
+MAX_SUPPORTING = 2
+
+#: What a property the user actually raised is worth against one we inferred unaided. A bounded
+#: boost rather than a tiebreak or a dominator: a flagged concern should win at a comparable
+#: score, but should not drag a trivial property past a critical one.
+CRITICAL_MATCH_BONUS = 15
 
 
 class RankedProperty(BaseModel):
-    """One candidate's place in the ranking."""
+    """One candidate's place in the ranking, and what it rests on."""
     key: PropertyKey = Field(
         description="The [component, title] pair identifying the property, copied exactly "
         "from the candidate listing."
@@ -49,11 +59,18 @@ class RankedProperty(BaseModel):
         ge=0, le=100,
         description="How much proving this property would contribute to confidence in the "
         "overall correctness of the system, 0-100. Reserve the top of the range for "
-        "properties whose violation would be a critical bug.",
+        "properties whose violation would be a critical bug. Score the property's importance, "
+        "not how hard it looks to verify.",
     )
     critical_match: bool = Field(
         description="True if this property corresponds to a concern the user explicitly "
         "raised in the design document, threat model, or supplied context."
+    )
+    depends_on: list[PropertyTitle] = Field(
+        default_factory=list,
+        description="Titles of properties IN THIS PROPERTY'S OWN COMPONENT that would be needed "
+        "to state or discharge it: the lemmas it assumes, the invariants its argument leans on. "
+        "Not properties that are merely related to it. Leave empty if it stands alone.",
     )
     rationale: str = Field(
         description="One or two sentences justifying the score. Say what breaks if the "
@@ -62,24 +79,22 @@ class RankedProperty(BaseModel):
 
 
 class PropertyRanking(BaseModel):
-    """The full ranking plus the focus drawn from it."""
+    """Every candidate, scored. Which one the run pursues is derived from this, not stated
+    alongside it: see :func:`priority` and :func:`select`."""
     ranked: list[RankedProperty] = Field(
-        description="Every candidate property, highest score first. Each candidate must "
-        "appear exactly once."
-    )
-    primary: PropertyKey = Field(
-        description="The single property the run will pursue: the best combination of "
-        "contribution to overall correctness and match to the user's stated concerns."
-    )
-    supporting: list[PropertyKey] = Field(
-        description="Properties from the SAME component as the primary that are needed to "
-        "state or discharge it — lemmas it rests on, invariants it assumes. Not merely "
-        f"related properties. Leave empty if the primary stands alone. At most {MAX_SUPPORTING}."
+        description="Every candidate property, each appearing exactly once."
     )
     justification: str = Field(
-        description="Two to four sentences on why this property is the one worth the run's "
-        "whole verification budget, and what the supporting properties contribute to it."
+        description="Two to four sentences on which properties came out on top and why they are "
+        "the ones worth a verification budget."
     )
+
+
+def priority(rp: RankedProperty) -> int:
+    """What the run actually sorts on. The scoring model reports two things it can judge — how much
+    the property matters, and whether the user asked for it — and this is the one place their
+    trade-off is decided, so it is reviewable and the artifact can never disagree with the pick."""
+    return rp.score + (CRITICAL_MATCH_BONUS if rp.critical_match else 0)
 
 
 @dataclass(frozen=True)
@@ -107,20 +122,31 @@ class Selection:
 def build_candidates(
     units: Sequence[tuple[int, ComponentName, list[PropertyFormulation]]]
 ) -> list[Candidate]:
-    """Label every unit uniquely for the prompt. A name shared by two components gets a
-    disambiguating suffix rather than being silently merged."""
-    seen: Counter[str] = Counter()
+    """Label every unit for the prompt, uniquely.
+
+    Counting repeats is not enough: a component may itself be named ``Vault (2)``, and then a
+    second ``Vault`` numbered by count collides with it. Since the label is what the ranking names
+    a property by, a collision resolves a ranked entry onto the wrong component's batch. Suffix
+    until the label is actually unused instead, and assert it."""
+    taken: set[str] = set()
     out: list[Candidate] = []
     for unit_index, name, props in units:
-        seen[name] += 1
-        label = name if seen[name] == 1 else f"{name} ({seen[name]})"
+        label, n = name, 1
+        while label in taken:
+            n += 1
+            label = f"{name} ({n})"
+        taken.add(label)
         out.append(Candidate(unit_index, ComponentName(label), props))
+    assert len({c.label for c in out}) == len(out), "component labels must be unique"
     return out
 
 
 def validate_ranking(candidates: Sequence[Candidate], r: PropertyRanking) -> str | None:
     """``None`` if the ranking is usable, else the reason it is not — phrased for the model,
-    since it is fed straight back as the retry prompt."""
+    since it is fed straight back as the retry prompt.
+
+    There is no "did it pick the right one" check here, because nothing picks: the focus is
+    derived from these scores by :func:`select`."""
     by_key: dict[PropertyKey, Candidate] = {
         (c.label, p.title): c for c in candidates for p in c.props
     }
@@ -140,38 +166,40 @@ def validate_ranking(candidates: Sequence[Candidate], r: PropertyRanking) -> str
             "Every candidate must be ranked, including the ones you consider unimportant."
         )
 
-    primary = r.primary
-    if primary not in by_key:
-        return f"`primary` {primary} is not one of the candidate properties."
-
-    home = by_key[primary]
-    for key in r.supporting:
-        if key not in by_key:
-            return f"`supporting` entry {key} is not one of the candidate properties."
-        if by_key[key].unit_index != home.unit_index:
-            return (
-                f"`supporting` entry {key} belongs to a different component than the primary "
-                f"({home.label}). A run pursues one component's properties, so every supporting "
-                "property must come from the primary's own component."
-            )
+    for rp in r.ranked:
+        home = by_key[rp.key]
+        siblings = {p.title for p in home.props}
+        for dep in rp.depends_on:
+            if dep == rp.key[1]:
+                return (
+                    f"{rp.key} lists itself in `depends_on`. A property does not depend on itself."
+                )
+            if dep not in siblings:
+                return (
+                    f"{rp.key} lists {dep!r} in `depends_on`, which is not a property of its own "
+                    f"component ({home.label}). A run pursues one component's properties, so a "
+                    "dependency must come from the same component as the property that needs it."
+                )
     return None
 
 
 def select(candidates: Sequence[Candidate], r: PropertyRanking) -> Selection:
-    """Turn a *validated* ranking into the focus. Deduplicates the supporting cluster,
-    drops the primary from it, and truncates to :data:`MAX_SUPPORTING`."""
-    primary = r.primary
-    home = next(
-        c for c in candidates if any((c.label, p.title) == primary for p in c.props)
-    )
+    """Derive the focus from a *validated* ranking: the highest-priority property, plus what it
+    said it rests on, deduplicated and truncated to :data:`MAX_SUPPORTING`.
 
-    titles: list[PropertyTitle] = [primary[1]]
-    for key in r.supporting:
+    ``max`` keeps the first of equal-priority entries, so the model's own ordering still breaks
+    ties, but the choice itself is ours — which is what makes ``property_ranking.json`` and the
+    run's actual subject the same thing by construction."""
+    primary = max(r.ranked, key=priority)
+    home = next(c for c in candidates if c.label == primary.key[0])
+
+    titles: list[PropertyTitle] = [primary.key[1]]
+    for dep in primary.depends_on:
         if len(titles) - 1 == MAX_SUPPORTING:
             break
-        if key[1] in titles:
+        if dep in titles:
             continue
-        titles.append(key[1])
+        titles.append(dep)
 
     # Emit them in the component's own order so the author reads them as it would any
     # batch, with the primary first.

--- a/composer/spec/prioritize.py
+++ b/composer/spec/prioritize.py
@@ -1,0 +1,227 @@
+"""Ranking the whole candidate property set, and cutting it down to one focus.
+
+Property inference runs per component and never sees more than the component it was
+given, so nothing in the pipeline has ever compared two components' properties against
+each other. A ``prioritized`` run needs exactly that comparison: one judgement, over
+every candidate at once, of which property contributes most to the correctness of the
+system and which of its neighbours are needed to state or discharge it.
+
+That judgement is a single structured call (the shape ``report/grouping.py`` uses),
+not an agent: an agent here would re-import the per-component cost the mode exists to
+remove. Its output is validated in Python before anything acts on it — an unvalidated
+ranking would silently redirect the run's entire formalization budget.
+
+The models live here rather than beside the cache key so ``pipeline/keys.py`` can
+import them without a cycle (see ``spec/key_family.py``: registries import producers,
+never the reverse), and the selection helper takes plain data so this module never
+reaches back into the driver.
+"""
+
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from typing import Sequence
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from composer.input.files import Document
+from composer.llm.types import CacheLevel
+from composer.spec.types import ComponentName, PropertyFormulation, PropertyKey, PropertyTitle
+from composer.templates.loader import load_jinja_template
+
+_log = logging.getLogger(__name__)
+
+#: Ceiling on the supporting cluster. The primary property plus its lemmas is meant to
+#: stay a focused unit of work; past a handful of neighbours the batch is a component
+#: again and the mode has bought nothing.
+MAX_SUPPORTING = 4
+
+
+class RankedProperty(BaseModel):
+    """One candidate's place in the ranking."""
+    key: PropertyKey = Field(
+        description="The [component, title] pair identifying the property, copied exactly "
+        "from the candidate listing."
+    )
+    score: int = Field(
+        ge=0, le=100,
+        description="How much proving this property would contribute to confidence in the "
+        "overall correctness of the system, 0-100. Reserve the top of the range for "
+        "properties whose violation would be a critical bug.",
+    )
+    critical_match: bool = Field(
+        description="True if this property corresponds to a concern the user explicitly "
+        "raised in the design document, threat model, or supplied context."
+    )
+    rationale: str = Field(
+        description="One or two sentences justifying the score. Say what breaks if the "
+        "property does not hold."
+    )
+
+
+class PropertyRanking(BaseModel):
+    """The full ranking plus the focus drawn from it."""
+    ranked: list[RankedProperty] = Field(
+        description="Every candidate property, highest score first. Each candidate must "
+        "appear exactly once."
+    )
+    primary: PropertyKey = Field(
+        description="The single property the run will pursue: the best combination of "
+        "contribution to overall correctness and match to the user's stated concerns."
+    )
+    supporting: list[PropertyKey] = Field(
+        description="Properties from the SAME component as the primary that are needed to "
+        "state or discharge it — lemmas it rests on, invariants it assumes. Not merely "
+        f"related properties. Leave empty if the primary stands alone. At most {MAX_SUPPORTING}."
+    )
+    justification: str = Field(
+        description="Two to four sentences on why this property is the one worth the run's "
+        "whole verification budget, and what the supporting properties contribute to it."
+    )
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One component's extracted properties, as offered to the ranker.
+
+    ``label`` is what the model sees and names in a :class:`PropertyKey`. It is derived
+    from the component's display name but forced unique across the run: display names are
+    free text the analysis agent produced under no uniqueness constraint, so resolving a
+    ranking back onto components by name alone can land on the wrong one. ``unit_index``
+    is the identity the driver resolves against."""
+    unit_index: int
+    label: ComponentName
+    props: list[PropertyFormulation]
+
+
+@dataclass(frozen=True)
+class Selection:
+    """The focus: which unit survives, and which of its properties, in order."""
+    unit_index: int
+    titles: list[PropertyTitle]
+    ranking: PropertyRanking
+
+
+def build_candidates(
+    units: Sequence[tuple[int, ComponentName, list[PropertyFormulation]]]
+) -> list[Candidate]:
+    """Label every unit uniquely for the prompt. A name shared by two components gets a
+    disambiguating suffix rather than being silently merged."""
+    seen: Counter[str] = Counter()
+    out: list[Candidate] = []
+    for unit_index, name, props in units:
+        seen[name] += 1
+        label = name if seen[name] == 1 else f"{name} ({seen[name]})"
+        out.append(Candidate(unit_index, ComponentName(label), props))
+    return out
+
+
+def validate_ranking(candidates: Sequence[Candidate], r: PropertyRanking) -> str | None:
+    """``None`` if the ranking is usable, else the reason it is not — phrased for the model,
+    since it is fed straight back as the retry prompt."""
+    by_key: dict[PropertyKey, Candidate] = {
+        (c.label, p.title): c for c in candidates for p in c.props
+    }
+
+    seen: Counter[PropertyKey] = Counter(rp.key for rp in r.ranked)
+    unknown = [k for k in seen if k not in by_key]
+    if unknown:
+        return (
+            "These ranked entries name properties that are not in the candidate listing: "
+            f"{unknown}. Use the [component, title] pairs exactly as given."
+        )
+    if (dupes := [k for k, n in seen.items() if n > 1]):
+        return f"These properties appear more than once in `ranked`: {dupes}. Rank each exactly once."
+    if (missing := [k for k in by_key if k not in seen]):
+        return (
+            f"These candidate properties are missing from `ranked`: {missing}. "
+            "Every candidate must be ranked, including the ones you consider unimportant."
+        )
+
+    primary = r.primary
+    if primary not in by_key:
+        return f"`primary` {primary} is not one of the candidate properties."
+
+    home = by_key[primary]
+    for key in r.supporting:
+        if key not in by_key:
+            return f"`supporting` entry {key} is not one of the candidate properties."
+        if by_key[key].unit_index != home.unit_index:
+            return (
+                f"`supporting` entry {key} belongs to a different component than the primary "
+                f"({home.label}). A run pursues one component's properties, so every supporting "
+                "property must come from the primary's own component."
+            )
+    return None
+
+
+def select(candidates: Sequence[Candidate], r: PropertyRanking) -> Selection:
+    """Turn a *validated* ranking into the focus. Deduplicates the supporting cluster,
+    drops the primary from it, and truncates to :data:`MAX_SUPPORTING`."""
+    primary = r.primary
+    home = next(
+        c for c in candidates if any((c.label, p.title) == primary for p in c.props)
+    )
+
+    titles: list[PropertyTitle] = [primary[1]]
+    for key in r.supporting:
+        if len(titles) - 1 == MAX_SUPPORTING:
+            break
+        if key[1] in titles:
+            continue
+        titles.append(key[1])
+
+    # Emit them in the component's own order so the author reads them as it would any
+    # batch, with the primary first.
+    order = {p.title: i for i, p in enumerate(home.props)}
+    head, tail = titles[0], sorted(titles[1:], key=lambda t: order[t])
+    return Selection(home.unit_index, [head, *tail], r)
+
+
+async def rank_properties(
+    *,
+    llm: BaseChatModel,
+    contract_name: str,
+    candidates: Sequence[Candidate],
+    design_doc: Document | None,
+    threat_model: Document | None,
+    extra_context: Sequence[Document],
+    max_attempts: int = 2,
+) -> PropertyRanking:
+    """One structured call, validated, with a single corrective retry.
+
+    A ranking that will not validate raises rather than falling back to the whole
+    candidate set: a silent widening would spend exactly the budget the caller asked to
+    save, and failing here is cheap — nothing has been formalized yet."""
+    system = load_jinja_template("property_prioritization_system.j2")
+    user = load_jinja_template(
+        "property_prioritization_prompt.j2",
+        contract_name=contract_name,
+        candidates=candidates,
+        max_supporting=MAX_SUPPORTING,
+    )
+    docs = [d for d in (design_doc, threat_model, *extra_context) if d is not None]
+    content: list[dict | str] = [
+        {"type": "text", "text": user},
+        *(d.to_dict(CacheLevel.SHORT) for d in docs),
+    ]
+    bound = llm.with_structured_output(PropertyRanking)
+
+    messages: list = [SystemMessage(system), HumanMessage(content=content)]
+    problem: str | None = None
+    for attempt in range(max_attempts):
+        result = await bound.ainvoke(messages)
+        assert isinstance(result, PropertyRanking)
+        problem = validate_ranking(candidates, result)
+        if problem is None:
+            return result
+        _log.warning("property ranking rejected (attempt %d): %s", attempt + 1, problem)
+        messages = [
+            *messages,
+            HumanMessage(
+                f"Your ranking was rejected: {problem}\n\nProduce a corrected ranking."
+            ),
+        ]
+    raise ValueError(f"Property ranking did not validate after {max_attempts} attempts: {problem}")

--- a/composer/spec/prioritize.py
+++ b/composer/spec/prioritize.py
@@ -38,11 +38,6 @@ from composer.templates.loader import load_jinja_template
 
 _log = logging.getLogger(__name__)
 
-#: Ceiling on the pursued group. A claim stated by more properties than this is either not one
-#: claim or not a focused unit of work; past it the batch is a component again and the mode has
-#: bought nothing. A backstop, not the target — the prompt asks for small groups.
-MAX_FOCUS_PROPERTIES = 3
-
 #: What a property the user actually raised is worth against one we inferred unaided. A bounded
 #: boost rather than a tiebreak or a dominator: a flagged concern should win at a comparable
 #: score, but should not drag a trivial property past a critical one.
@@ -208,23 +203,18 @@ def select(candidates: Sequence[Candidate], r: PropertyRanking) -> Selection:
     decides, and whatever else states the same claim comes with it. ``max`` keeps the first of
     equal-priority entries, so the model's own ordering breaks ties — but the choice is ours,
     which is what makes ``property_ranking.json`` and the run's actual subject the same thing by
-    construction."""
+    construction.
+
+    The whole group is pursued. A claim is established by all the properties that state it or by
+    none of them, so there is no size at which dropping one is the right trade: a partial batch
+    spends most of the budget and leaves the claim open. The saving comes from the group being
+    one claim out of the whole candidate set, not from trimming the claim itself."""
     best = max(r.ranked, key=priority)
     group = next(g for g in r.groups if best.key in g.members)
     home = next(c for c in candidates if c.label == best.key[0])
 
     by_priority = {rp.key: priority(rp) for rp in r.ranked}
     members = sorted(group.members, key=lambda k: -by_priority[k])
-    if len(members) > MAX_FOCUS_PROPERTIES:
-        # The claim this group named is no longer fully established once we cut it, so say so
-        # rather than quietly pursuing a subset under the group's name.
-        _log.warning(
-            "focus group %r has %d members; pursuing the top %d only, so the claim is not "
-            "established in full",
-            group.claim, len(members), MAX_FOCUS_PROPERTIES,
-        )
-        members = members[:MAX_FOCUS_PROPERTIES]
-
     return Selection(home.unit_index, [k[1] for k in members], group.claim, r)
 
 
@@ -248,7 +238,6 @@ async def rank_properties(
         "property_prioritization_prompt.j2",
         contract_name=contract_name,
         candidates=candidates,
-        max_supporting=MAX_FOCUS_PROPERTIES,
     )
     docs = [d for d in (design_doc, threat_model, *extra_context) if d is not None]
     content: list[dict | str] = [

--- a/composer/spec/prioritize.py
+++ b/composer/spec/prioritize.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from typing import Sequence
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
 
 from composer.input.files import Document
@@ -38,10 +38,10 @@ from composer.templates.loader import load_jinja_template
 
 _log = logging.getLogger(__name__)
 
-#: Ceiling on the supporting cluster. The primary property plus its lemmas is meant to stay a
-#: focused unit of work; past a couple of neighbours the batch is a component again and the mode
-#: has bought nothing.
-MAX_SUPPORTING = 2
+#: Ceiling on the pursued group. A claim stated by more properties than this is either not one
+#: claim or not a focused unit of work; past it the batch is a component again and the mode has
+#: bought nothing. A backstop, not the target — the prompt asks for small groups.
+MAX_FOCUS_PROPERTIES = 3
 
 #: What a property the user actually raised is worth against one we inferred unaided. A bounded
 #: boost rather than a tiebreak or a dominator: a flagged concern should win at a comparable
@@ -50,27 +50,19 @@ CRITICAL_MATCH_BONUS = 15
 
 
 class RankedProperty(BaseModel):
-    """One candidate's place in the ranking, and what it rests on."""
+    """One candidate property, scored."""
     key: PropertyKey = Field(
         description="The [component, title] pair identifying the property, copied exactly "
         "from the candidate listing."
     )
     score: int = Field(
         ge=0, le=100,
-        description="How much proving this property would contribute to confidence in the "
-        "overall correctness of the system, 0-100. Reserve the top of the range for "
-        "properties whose violation would be a critical bug. Score the property's importance, "
-        "not how hard it looks to verify.",
+        description="How badly the protocol is hurt if this property does not hold. Score the "
+        "consequence of a violation, not how hard the property looks to verify.",
     )
     critical_match: bool = Field(
-        description="True if this property corresponds to a concern the user explicitly "
-        "raised in the design document, threat model, or supplied context."
-    )
-    depends_on: list[PropertyTitle] = Field(
-        default_factory=list,
-        description="Titles of properties IN THIS PROPERTY'S OWN COMPONENT that would be needed "
-        "to state or discharge it: the lemmas it assumes, the invariants its argument leans on. "
-        "Not properties that are merely related to it. Leave empty if it stands alone.",
+        description="True if this property corresponds to a concern the reader of the design "
+        "document, threat model, or supplied notes explicitly raised."
     )
     rationale: str = Field(
         description="One or two sentences justifying the score. Say what breaks if the "
@@ -78,21 +70,38 @@ class RankedProperty(BaseModel):
     )
 
 
+class PropertyGroup(BaseModel):
+    """Properties that together state one claim about the protocol."""
+    claim: str = Field(
+        description="The single thing these properties, taken together, establish about the "
+        "protocol. One or two sentences, in terms an auditor would use — not a restatement of "
+        "the property titles."
+    )
+    members: list[PropertyKey] = Field(
+        min_length=1,
+        description="The [component, title] pairs this claim is made of. All of them must "
+        "belong to the same component. Every candidate property appears in exactly one group.",
+    )
+
+
 class PropertyRanking(BaseModel):
-    """Every candidate, scored. Which one the run pursues is derived from this, not stated
-    alongside it: see :func:`priority` and :func:`select`."""
+    """Every candidate scored, and the claims they group into."""
     ranked: list[RankedProperty] = Field(
         description="Every candidate property, each appearing exactly once."
     )
+    groups: list[PropertyGroup] = Field(
+        description="The claims the candidates group into. Every candidate appears in exactly "
+        "one group."
+    )
     justification: str = Field(
-        description="Two to four sentences on which properties came out on top and why they are "
-        "the ones worth a verification budget."
+        description="Two to four sentences on which claim came out on top and why it is the one "
+        "worth proving."
     )
 
 
 def priority(rp: RankedProperty) -> int:
-    """What the run actually sorts on. The scoring model reports two things it can judge — how much
-    the property matters, and whether the user asked for it — and this is the one place their
+    """What the run sorts on. The scoring model reports two things it can judge — how much the
+    property matters, and whether the reader asked for it — and this is the one place their
     trade-off is decided, so it is reviewable and the artifact can never disagree with the pick."""
     return rp.score + (CRITICAL_MATCH_BONUS if rp.critical_match else 0)
 
@@ -101,11 +110,10 @@ def priority(rp: RankedProperty) -> int:
 class Candidate:
     """One component's extracted properties, as offered to the ranker.
 
-    ``label`` is what the model sees and names in a :class:`PropertyKey`. It is derived
-    from the component's display name but forced unique across the run: display names are
-    free text the analysis agent produced under no uniqueness constraint, so resolving a
-    ranking back onto components by name alone can land on the wrong one. ``unit_index``
-    is the identity the driver resolves against."""
+    ``label`` is what the model sees and names in a :class:`PropertyKey`: the component's own
+    display name, prefixed with ``unit_index`` so two components sharing a name are still
+    distinguishable in the prompt and in the persisted ranking. ``unit_index`` is the stable
+    per-run component id, and what the driver resolves against."""
     unit_index: int
     label: ComponentName
     props: list[PropertyFormulation]
@@ -113,99 +121,111 @@ class Candidate:
 
 @dataclass(frozen=True)
 class Selection:
-    """The focus: which unit survives, and which of its properties, in order."""
+    """The focus: which unit survives, which of its properties, and the claim they state."""
     unit_index: int
     titles: list[PropertyTitle]
+    claim: str
     ranking: PropertyRanking
 
 
 def build_candidates(
     units: Sequence[tuple[int, ComponentName, list[PropertyFormulation]]]
 ) -> list[Candidate]:
-    """Label every unit for the prompt, uniquely.
+    """Label every unit for the prompt.
 
-    Counting repeats is not enough: a component may itself be named ``Vault (2)``, and then a
-    second ``Vault`` numbered by count collides with it. Since the label is what the ranking names
-    a property by, a collision resolves a ranked entry onto the wrong component's batch. Suffix
-    until the label is actually unused instead, and assert it."""
-    taken: set[str] = set()
-    out: list[Candidate] = []
-    for unit_index, name, props in units:
-        label, n = name, 1
-        while label in taken:
-            n += 1
-            label = f"{name} ({n})"
-        taken.add(label)
-        out.append(Candidate(unit_index, ComponentName(label), props))
-    assert len({c.label for c in out}) == len(out), "component labels must be unique"
-    return out
+    The label carries ``unit_index``, the stable per-run component id, so a ranking always names
+    exactly one component even where two share a display name — and it needs no invented
+    uniquifying suffix to do it."""
+    return [
+        Candidate(unit_index, ComponentName(f"{unit_index}: {name}"), props)
+        for unit_index, name, props in units
+    ]
 
 
 def validate_ranking(candidates: Sequence[Candidate], r: PropertyRanking) -> str | None:
-    """``None`` if the ranking is usable, else the reason it is not — phrased for the model,
-    since it is fed straight back as the retry prompt.
+    """``None`` if the ranking is usable, else every reason it is not — phrased for the model,
+    since it is fed straight back as the correction.
 
-    There is no "did it pick the right one" check here, because nothing picks: the focus is
-    derived from these scores by :func:`select`."""
+    All problems are reported at once. Returning only the first means a badly malformed ranking
+    costs one attempt per mistake, and the attempts run out before the mistakes do.
+
+    There is no "did it pick the right one" check, because nothing picks: the focus is derived
+    from these scores by :func:`select`."""
     by_key: dict[PropertyKey, Candidate] = {
         (c.label, p.title): c for c in candidates for p in c.props
     }
+    problems: list[str] = []
 
     seen: Counter[PropertyKey] = Counter(rp.key for rp in r.ranked)
-    unknown = [k for k in seen if k not in by_key]
-    if unknown:
-        return (
-            "These ranked entries name properties that are not in the candidate listing: "
+    if (unknown := [k for k in seen if k not in by_key]):
+        problems.append(
+            f"These ranked entries name properties that are not in the candidate listing: "
             f"{unknown}. Use the [component, title] pairs exactly as given."
         )
     if (dupes := [k for k, n in seen.items() if n > 1]):
-        return f"These properties appear more than once in `ranked`: {dupes}. Rank each exactly once."
+        problems.append(
+            f"These properties appear more than once in `ranked`: {dupes}. Rank each exactly once."
+        )
     if (missing := [k for k in by_key if k not in seen]):
-        return (
+        problems.append(
             f"These candidate properties are missing from `ranked`: {missing}. "
             "Every candidate must be ranked, including the ones you consider unimportant."
         )
 
-    for rp in r.ranked:
-        home = by_key[rp.key]
-        siblings = {p.title for p in home.props}
-        for dep in rp.depends_on:
-            if dep == rp.key[1]:
-                return (
-                    f"{rp.key} lists itself in `depends_on`. A property does not depend on itself."
-                )
-            if dep not in siblings:
-                return (
-                    f"{rp.key} lists {dep!r} in `depends_on`, which is not a property of its own "
-                    f"component ({home.label}). A run pursues one component's properties, so a "
-                    "dependency must come from the same component as the property that needs it."
-                )
-    return None
+    grouped: Counter[PropertyKey] = Counter(k for g in r.groups for k in g.members)
+    if (unknown_g := [k for k in grouped if k not in by_key]):
+        problems.append(
+            f"These group members are not in the candidate listing: {unknown_g}."
+        )
+    if (dupes_g := [k for k, n in grouped.items() if n > 1]):
+        problems.append(
+            f"These properties are in more than one group: {dupes_g}. Each property belongs to "
+            "exactly one claim."
+        )
+    if (ungrouped := [k for k in by_key if k not in grouped]):
+        problems.append(
+            f"These candidate properties are in no group: {ungrouped}. Every property belongs to "
+            "exactly one claim, even if that claim has only one member."
+        )
+
+    for g in r.groups:
+        homes = {by_key[k].label for k in g.members if k in by_key}
+        if len(homes) > 1:
+            problems.append(
+                f"The group {g.claim!r} spans components {sorted(homes)}. A run pursues one "
+                "component's properties, so every member of a group must come from the same "
+                "component."
+            )
+
+    return "\n".join(problems) if problems else None
 
 
 def select(candidates: Sequence[Candidate], r: PropertyRanking) -> Selection:
-    """Derive the focus from a *validated* ranking: the highest-priority property, plus what it
-    said it rests on, deduplicated and truncated to :data:`MAX_SUPPORTING`.
+    """Derive the focus from a *validated* ranking: the group containing the highest-priority
+    property, which is the claim worth the run.
 
-    ``max`` keeps the first of equal-priority entries, so the model's own ordering still breaks
-    ties, but the choice itself is ours — which is what makes ``property_ranking.json`` and the
-    run's actual subject the same thing by construction."""
-    primary = max(r.ranked, key=priority)
-    home = next(c for c in candidates if c.label == primary.key[0])
+    A group is worth what its best member is worth, so the single most important property still
+    decides, and whatever else states the same claim comes with it. ``max`` keeps the first of
+    equal-priority entries, so the model's own ordering breaks ties — but the choice is ours,
+    which is what makes ``property_ranking.json`` and the run's actual subject the same thing by
+    construction."""
+    best = max(r.ranked, key=priority)
+    group = next(g for g in r.groups if best.key in g.members)
+    home = next(c for c in candidates if c.label == best.key[0])
 
-    titles: list[PropertyTitle] = [primary.key[1]]
-    for dep in primary.depends_on:
-        if len(titles) - 1 == MAX_SUPPORTING:
-            break
-        if dep in titles:
-            continue
-        titles.append(dep)
+    by_priority = {rp.key: priority(rp) for rp in r.ranked}
+    members = sorted(group.members, key=lambda k: -by_priority[k])
+    if len(members) > MAX_FOCUS_PROPERTIES:
+        # The claim this group named is no longer fully established once we cut it, so say so
+        # rather than quietly pursuing a subset under the group's name.
+        _log.warning(
+            "focus group %r has %d members; pursuing the top %d only, so the claim is not "
+            "established in full",
+            group.claim, len(members), MAX_FOCUS_PROPERTIES,
+        )
+        members = members[:MAX_FOCUS_PROPERTIES]
 
-    # Emit them in the component's own order so the author reads them as it would any
-    # batch, with the primary first.
-    order = {p.title: i for i, p in enumerate(home.props)}
-    head, tail = titles[0], sorted(titles[1:], key=lambda t: order[t])
-    return Selection(home.unit_index, [head, *tail], r)
+    return Selection(home.unit_index, [k[1] for k in members], group.claim, r)
 
 
 async def rank_properties(
@@ -228,7 +248,7 @@ async def rank_properties(
         "property_prioritization_prompt.j2",
         contract_name=contract_name,
         candidates=candidates,
-        max_supporting=MAX_SUPPORTING,
+        max_supporting=MAX_FOCUS_PROPERTIES,
     )
     docs = [d for d in (design_doc, threat_model, *extra_context) if d is not None]
     content: list[dict | str] = [
@@ -237,7 +257,7 @@ async def rank_properties(
     ]
     bound = llm.with_structured_output(PropertyRanking)
 
-    messages: list = [SystemMessage(system), HumanMessage(content=content)]
+    messages: list[BaseMessage] = [SystemMessage(system), HumanMessage(content=content)]
     problem: str | None = None
     for attempt in range(max_attempts):
         result = await bound.ainvoke(messages)
@@ -246,10 +266,13 @@ async def rank_properties(
         if problem is None:
             return result
         _log.warning("property ranking rejected (attempt %d): %s", attempt + 1, problem)
+        # Structured output hands back a parsed object and leaves no assistant turn behind, so
+        # without replaying it the model is asked to fix a ranking it has no memory of making.
         messages = [
             *messages,
+            AIMessage(content=result.model_dump_json()),
             HumanMessage(
-                f"Your ranking was rejected: {problem}\n\nProduce a corrected ranking."
+                f"That ranking was rejected:\n\n{problem}\n\nProduce a corrected ranking."
             ),
         ]
     raise ValueError(f"Property ranking did not validate after {max_attempts} attempts: {problem}")

--- a/composer/spec/source/artifacts.py
+++ b/composer/spec/source/artifacts.py
@@ -122,11 +122,13 @@ class ProverArtifactStore(ArtifactStore[SpecIdentity, GeneratedCVL]):
         (out_dir / "components_to_prover_runs.json").write_text(json.dumps(runs, indent=2))
 
     @override
-    def _job_info_payload(self, summary: RunSummary, *, user_id: str) -> dict[str, object]:
+    def _job_info_payload(
+        self, summary: RunSummary, *, user_id: str, run_mode: str
+    ) -> dict[str, object]:
         """Extends the shared manifest body with the prover-reported runtime: the
         autoprove ``job_info.json`` also records ``prover_usage`` (summed prover
         start-to-end time), alongside the base identity + ``token_usage``."""
         return {
-            **super()._job_info_payload(summary, user_id=user_id),
+            **super()._job_info_payload(summary, user_id=user_id, run_mode=run_mode),
             "prover_usage": summary.prover_usage_summary(),
         }

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -19,7 +19,7 @@ from graphcore.tools.vfs import VFSAccessor, VFSState
 
 from composer.authoring.judge import PropertyFeedbackProtocol
 from composer.authoring.state import SkippedProperty, check_completion
-from composer.authoring.tools import give_up_tool
+from composer.authoring.tools import gated_give_up_tool, give_up_tool
 from composer.spec.cvl_generation import (
     static_tools, property_tools, skip_tools, CVLGenerationExtra, FEEDBACK_VALIDATION_KEY,
     validate_property_rules, CVL_JUDGE_KEY, run_cvl_generator,
@@ -177,6 +177,38 @@ _GIVE_UP_DESCRIPTION = """
     mechanisms to complete your task.
     """
 
+#: How many prover runs a prioritized author owes before an ``exhausted`` surrender is even
+#: considered. Three is enough to have compiled a spec, seen a real counterexample, and tried
+#: something about it — the shortest honest account of "I tried".
+FOCUS_MIN_GIVE_UP_ATTEMPTS = 3
+
+_FOCUS_GIVE_UP_DESCRIPTION = """
+    Call this tool to stop work on this task.
+
+    This run exists to establish the property you were given, so stopping is gated: an
+    `exhausted` stop is rejected until you have actually run the prover several times, and you
+    must enumerate what you tried. If the toolchain itself is unusable, stop immediately with
+    sort='environment' — that is not gated.
+    """
+
+
+@dataclass
+class FocusPolicy:
+    """The tightened exits a prioritized author runs under: the properties it may not retire,
+    and the prover-run floor under an ``exhausted`` give-up.
+
+    ``lifted`` is flipped by the budget monitor's wrap-up, whose order — delete what does not
+    work, skip the rest, publish — requires exactly the skips this forbids. Holding the
+    protection past that point would deadlock the session the budget was trying to end. It is
+    process-local rather than graph state deliberately: budget accounting is per-process too, so
+    a resumed session starts with a fresh budget and a fresh protection together."""
+    protected: tuple[PropertyTitle, ...]
+    min_give_up_attempts: int = FOCUS_MIN_GIVE_UP_ATTEMPTS
+    lifted: bool = False
+
+    def protected_titles(self) -> tuple[PropertyTitle, ...]:
+        return () if self.lifted else self.protected
+
 
 class ResourceView(TypedDict):
     """A CVLResource prepared for the prompt: ``import_path`` is the CVL import
@@ -192,6 +224,10 @@ class PropertyGenParams(TypedDict):
     resources: list[ResourceView]
     properties: list[PropertyFormulation]
     contract_name: str
+    #: Whether this batch is a prioritized run's focus rather than a component's full property
+    #: list. It changes what the agent is told to do when stuck: a focused batch has no other
+    #: work to fall back on, so the prompt directs it to decompose rather than to skip.
+    focused: bool
 
 class PropertyGenerationConfig(SummaryConfig[SourceCVLGenerationState]):
     def __init__(self, source_editing: bool = False):
@@ -697,14 +733,22 @@ a partial spec is better than going over budget. Concretely:
 """
 
 
-def _author_monitor() -> Callable[[SourceCVLGenerationState], MonitorReturn]:
+def _author_monitor(focus: FocusPolicy | None = None) -> Callable[[SourceCVLGenerationState], MonitorReturn]:
     """The author's monitor: budget wrap-up takes precedence; otherwise the
     usual reminders-channel drain. On the (single) turn the budget warning
     fires any pending reminders are dropped — moot, since the warning tells
-    the agent to ignore prover/feedback outcomes anyway."""
+    the agent to ignore prover/feedback outcomes anyway.
+
+    The wrap-up also lifts a prioritized run's focus protection: the order it gives is to skip
+    what does not work, which the protection would otherwise refuse."""
+    def _wrap_up(_s: SourceCVLGenerationState, _c: object) -> dict:
+        if focus is not None:
+            focus.lifted = True
+        return {"required_validations": [], "budget_curtailed": True}
+
     b_monitor = budget_monitor(
         warning_message=lambda _s, c: _BUDGET_WRAPUP_MESSAGE.format(resource=constraint_sort_to_noun(c)),
-        state_transformer=lambda _s, _c: {"required_validations": [], "budget_curtailed": True},
+        state_transformer=_wrap_up,
         on_overbudget=raise_budget_exceeded,
     )
 
@@ -729,6 +773,7 @@ async def batch_cvl_generation(
     spec_dir: Path,
     spec_stem: str,
     editing_tools: EditingTools | None,
+    focus: FocusPolicy | None = None,
 ) -> BatchGeneratedCVLResult:
     # *spec_dir* (project-root-relative) is where the caller will persist the spec
     # authored here. The prover resolves the spec's CVL imports relative to its own
@@ -749,7 +794,8 @@ async def batch_cvl_generation(
         "context": component,
         "properties": props,
         "contract_name": source.contract_name,
-        "sort": "existing"
+        "sort": "existing",
+        "focused": focus is not None,
     })
 
     sys_prompt : list[RawPromptInput | type[CacheMarker]] = [
@@ -826,9 +872,11 @@ async def batch_cvl_generation(
         "context": component,
         "source_editing": editing is not None,
     })
+    protected = focus.protected_titles if focus is not None else ()
     if editing is None:
         feedback_suite = property_tools(
-            property_feedback_judge(judge_ctx, env, judge_prompt, props)
+            property_feedback_judge(judge_ctx, env, judge_prompt, props),
+            protected=protected,
         )
     else:
         judge_impl = source_feedback_judge(
@@ -836,7 +884,7 @@ async def batch_cvl_generation(
         )
         feedback_suite = [
             EditorAwareFeedbackTool.bind(judge_impl).as_tool("feedback_tool"),
-            *skip_tools(titles),
+            *skip_tools(titles, protected=protected),
         ]
 
     # use "cache=long" to account for very long prover runs.
@@ -864,13 +912,18 @@ async def batch_cvl_generation(
         [prover_tool.lg_tool,
          ExpectRulePassage.as_tool("expect_rule_passage"),
          ExpectRuleFailure.as_tool("expect_rule_failure"),
-         give_up_tool(name="give_up", description=_GIVE_UP_DESCRIPTION, label="CVL generation"),
+         give_up_tool(name="give_up", description=_GIVE_UP_DESCRIPTION, label="CVL generation")
+         if focus is None else
+         gated_give_up_tool(
+             name="give_up", description=_FOCUS_GIVE_UP_DESCRIPTION, label="CVL generation",
+             min_attempts=focus.min_give_up_attempts,
+         ),
          PublishResultTool.bind(titles).as_tool("result"),
          ctx.get_memory_tool()]
     ).with_state(
         SourceCVLGenerationState
     ).with_monitor(
-        _author_monitor()
+        _author_monitor(focus)
     ).with_output_key(
         "result"
     ).with_input(

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -192,22 +192,16 @@ _FOCUS_GIVE_UP_DESCRIPTION = """
     """
 
 
-@dataclass
+@dataclass(frozen=True)
 class FocusPolicy:
     """The tightened exits a prioritized author runs under: the properties it may not retire,
     and the prover-run floor under an ``exhausted`` give-up.
 
-    ``lifted`` is flipped by the budget monitor's wrap-up, whose order — delete what does not
-    work, skip the rest, publish — requires exactly the skips this forbids. Holding the
-    protection past that point would deadlock the session the budget was trying to end. It is
-    process-local rather than graph state deliberately: budget accounting is per-process too, so
-    a resumed session starts with a fresh budget and a fresh protection together."""
+    Both are static. Whether the skip protection currently applies is read from
+    ``budget_curtailed`` in the graph state, which the budget monitor already sets and which a
+    checkpoint carries — a flag here would shadow it and could disagree with it on resume."""
     protected: tuple[PropertyTitle, ...]
     min_give_up_attempts: int = FOCUS_MIN_GIVE_UP_ATTEMPTS
-    lifted: bool = False
-
-    def protected_titles(self) -> tuple[PropertyTitle, ...]:
-        return () if self.lifted else self.protected
 
 
 class ResourceView(TypedDict):
@@ -733,22 +727,17 @@ a partial spec is better than going over budget. Concretely:
 """
 
 
-def _author_monitor(focus: FocusPolicy | None = None) -> Callable[[SourceCVLGenerationState], MonitorReturn]:
+def _author_monitor() -> Callable[[SourceCVLGenerationState], MonitorReturn]:
     """The author's monitor: budget wrap-up takes precedence; otherwise the
     usual reminders-channel drain. On the (single) turn the budget warning
     fires any pending reminders are dropped — moot, since the warning tells
     the agent to ignore prover/feedback outcomes anyway.
 
-    The wrap-up also lifts a prioritized run's focus protection: the order it gives is to skip
-    what does not work, which the protection would otherwise refuse."""
-    def _wrap_up(_s: SourceCVLGenerationState, _c: object) -> dict:
-        if focus is not None:
-            focus.lifted = True
-        return {"required_validations": [], "budget_curtailed": True}
-
+    ``budget_curtailed`` is what lifts a prioritized run's focus protection, which the skip tool
+    reads directly, so the wrap-up needs no separate signal for it."""
     b_monitor = budget_monitor(
         warning_message=lambda _s, c: _BUDGET_WRAPUP_MESSAGE.format(resource=constraint_sort_to_noun(c)),
-        state_transformer=_wrap_up,
+        state_transformer=lambda _s, _c: {"required_validations": [], "budget_curtailed": True},
         on_overbudget=raise_budget_exceeded,
     )
 
@@ -872,7 +861,7 @@ async def batch_cvl_generation(
         "context": component,
         "source_editing": editing is not None,
     })
-    protected = focus.protected_titles if focus is not None else ()
+    protected = focus.protected if focus is not None else ()
     if editing is None:
         feedback_suite = property_tools(
             property_feedback_judge(judge_ctx, env, judge_prompt, props),
@@ -923,7 +912,7 @@ async def batch_cvl_generation(
     ).with_state(
         SourceCVLGenerationState
     ).with_monitor(
-        _author_monitor(focus)
+        _author_monitor()
     ).with_output_key(
         "result"
     ).with_input(

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -905,7 +905,7 @@ async def batch_cvl_generation(
          if focus is None else
          gated_give_up_tool(
              name="give_up", description=_FOCUS_GIVE_UP_DESCRIPTION, label="CVL generation",
-             min_attempts=focus.min_give_up_attempts,
+             min_attempts=focus.min_give_up_attempts, state_ty=SourceCVLGenerationState,
          ),
          PublishResultTool.bind(titles).as_tool("result"),
          ctx.get_memory_tool()]

--- a/composer/spec/source/autoprove_common.py
+++ b/composer/spec/source/autoprove_common.py
@@ -18,6 +18,7 @@ from composer.spec.context import (
     SourceFields
 )
 from composer.pipeline.cli import cli_pipeline, user_ns
+from composer.pipeline.run_mode import RunMode, resolve_run_mode
 from composer.pipeline.ptypes import DEFAULT_MAX_CPU_TASKS
 from composer.pipeline.ecosystem import EVM
 from composer.spec.source.pipeline import ProverBackend, GeneratedCVL
@@ -60,6 +61,7 @@ class AutoProveArgs(ExtendedModelOptions, RAGDBOptions, Protocol):
     max_bug_rounds: int
     budget: str | None
     time_budget: float | None
+    run_mode: str | None
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +92,13 @@ async def _entry_point(summary: RunSummary) -> AsyncIterator[Executor]:
     parser.add_argument("--max-bug-rounds", type=int, default=3, help="Maximum number of bug-extraction rounds run per component during property analysis (default: 3)")
     parser.add_argument("--budget", default=None, help="Path to a run-budget file (JSON or YAML): {total: USD, caps: {phase: USD, ...}}. Omit to run unbudgeted.")
     parser.add_argument("--time-budget", default=None, type=float, help="Total wall time to run the entire execution. Omit to run without in process limit")
+    parser.add_argument(
+        "--run-mode", choices=[m.value for m in RunMode], default=None,
+        help="How much of the inferred property set to pursue. 'comprehensive' (the default) "
+             "formalizes every property of every component. 'prioritized' ranks them all, then "
+             "spends the run on the highest-contribution property and the properties it rests "
+             "on. Also settable as AUTOPROVER_RUN_MODE; this flag wins.",
+    )
 
     args = cast(AutoProveArgs, parser.parse_args())
     async with autoprove_executor(args, summary) as runner:
@@ -105,6 +114,7 @@ async def autoprove_executor(args: AutoProveArgs, summary: RunSummary) -> AsyncI
     """
 
     thread_id = f"autoprove_{uuid.uuid4().hex[:12]}"
+    run_mode = resolve_run_mode(args.run_mode)
 
     async def exit_logger(
         run: SourceFields,
@@ -121,7 +131,7 @@ async def autoprove_executor(args: AutoProveArgs, summary: RunSummary) -> AsyncI
         # discovery crashed).
         try:
             ProverArtifactStore(run.project_root, run.contract_name).write_job_info(
-                summary, user_id=get_uid()
+                summary, user_id=get_uid(), run_mode=run_mode.value
             )
         except Exception:
             _logger.exception("failed to dump job info")
@@ -137,6 +147,7 @@ async def autoprove_executor(args: AutoProveArgs, summary: RunSummary) -> AsyncI
                 thread_id=thread_id,
                 task_handler=handler,
                 at_exit=exit_logger,
+                run_mode=run_mode,
                 workflow="autoprove"
             ) as (staged, cont),
             PostgreSQLRAGDatabase.rag_context(staged.embed_model, args.rag_db) as rag_db

--- a/composer/spec/source/harness.py
+++ b/composer/spec/source/harness.py
@@ -163,7 +163,7 @@ def lift_harnessed(
 
     Declared beside the models because every consumer of the harnessed view
     must build it identically — the prover pipeline, and any offline walker
-    re-deriving component cache keys (``composer.meta.run``): the harnessed
+    re-deriving component cache keys (``composer.cli.cache_autoprove``): the harnessed
     app is part of the unit's ``cache_material``."""
     contract_to_harness: dict[SolidityIdentifier, list[HarnessDefinition]] = {}
     for c in sys_desc.transitive_closure:

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -46,7 +46,9 @@ from composer.spec.source.struct_invariant import get_invariant_formulation
 from composer.spec.source.autosetup import SetupSuccess
 from composer.spec.source.prover import get_prover_tool, materializing_project
 from composer.spec.source.plugin import CertoraProverTools
-from composer.spec.source.author import batch_cvl_generation, EditingTools, SourceEditing, ProverTool
+from composer.spec.source.author import (
+    batch_cvl_generation, EditingTools, FocusPolicy, SourceEditing, ProverTool,
+)
 from composer.spec.source.artifacts import ProverArtifactStore, ComponentSpec, InvariantSpec
 from composer.spec.source.report_prover import make_prover_fetcher
 from composer.spec.source.report.collect import (
@@ -70,6 +72,7 @@ from composer.pipeline.core import (
     Curtailed
 )
 from composer.pipeline.ecosystem import main_instance
+from composer.pipeline.run_mode import RunMode
 from composer.pipeline.keys import COMMON_SYSTEM_CACHE_KEY
 from composer.spec.source.keys import AP_PROPERTIES_KEY_NAME, INV_CVL_KEY
 
@@ -126,6 +129,13 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
             spec_stem=ComponentSpec(feat.slugified_name).stem,
             editing_tools=EditingTools(
                 editing=self._deps.editing, tool_provider=extra_tools
+            ),
+            # A prioritized run staked itself on these properties, so the author's exits
+            # tighten around them: they cannot be skipped, and an exhausted give-up is
+            # refused until the prover has actually been run.
+            focus=(
+                FocusPolicy(protected=tuple(p.title for p in props))
+                if run.run_mode is RunMode.PRIORITIZED else None
             ),
         )
 

--- a/composer/spec/source/report/build.py
+++ b/composer/spec/source/report/build.py
@@ -22,7 +22,8 @@ from composer.spec.source.report.grouping import (
     build_fallback_grouping, build_groups, call_grouping_llm, PropertyGroup
 )
 from composer.spec.source.report.schema import (
-    AutoProverReport, Finding, Outcome, PropertyKey, ReportBackend, RuleRef, SourceEditRecord,
+    AutoProverReport, DeprioritizedProperty, Finding, Outcome, PropertyKey, ReportBackend,
+    RuleRef, SourceEditRecord,
     VerificationArtifactRecord,
 )
 
@@ -49,6 +50,8 @@ async def build_report[R: ReportableResult](
     verification_artifacts: list[VerificationArtifactRecord] | None = None,
     findings_llm: BaseChatModel | None = None,
     fetch_evidence: EvidenceFetcher | None = None,
+    run_mode: str | None = None,
+    deprioritized: list[DeprioritizedProperty] | None = None,
 ) -> AutoProverReport:
     """Build and return the in-memory `AutoProverReport`. Persistence is the caller's job.
 
@@ -74,6 +77,7 @@ async def build_report[R: ReportableResult](
         coverage = validate(
             properties=properties, rules=rules, groups=groups, skipped=skipped,
             gave_up=gave_up, curtailed=curtailed, dropped_orphan_rules=dropped,
+            deprioritized_count=len(deprioritized or []),
         )
     else:
         try:
@@ -84,6 +88,7 @@ async def build_report[R: ReportableResult](
             coverage = validate(
                 properties=properties, rules=rules, groups=groups, skipped=skipped,
                 gave_up=gave_up, curtailed=curtailed, dropped_orphan_rules=dropped,
+                deprioritized_count=len(deprioritized or []),
             )
             grouped: set[PropertyKey] = {k for g in groups for k in g.members}
             if not grouped:
@@ -102,6 +107,7 @@ async def build_report[R: ReportableResult](
             coverage = validate(
                 properties=properties, rules=rules, groups=groups, skipped=skipped,
                 gave_up=gave_up, curtailed=curtailed, dropped_orphan_rules=dropped,
+                deprioritized_count=len(deprioritized or []),
             )
             coverage.warnings = ["FALLBACK GROUPING APPLIED"] + coverage.warnings
 
@@ -130,6 +136,8 @@ async def build_report[R: ReportableResult](
 
     report = AutoProverReport(
         backend=backend,
+        run_mode=run_mode,
+        deprioritized=deprioritized or [],
         contract_name=contract_name,
         run_timestamp_utc=datetime.now(timezone.utc).isoformat(),
         prover_links=prover_links,

--- a/composer/spec/source/report/coverage.py
+++ b/composer/spec/source/report/coverage.py
@@ -27,6 +27,7 @@ def validate(
     gave_up: list[GaveUpComponent],
     curtailed: list[CurtailedComponent],
     dropped_orphan_rules: int,
+    deprioritized_count: int = 0,
 ) -> CoverageReport:
     """Cross-check the grouping against the property set; produce a `CoverageReport`.
 
@@ -70,8 +71,15 @@ def validate(
         )
 
     sizes = [len(g.members) for g in groups]
+    if deprioritized_count:
+        warnings.append(
+            f"{deprioritized_count} inferred propert(ies) were deprioritized before "
+            "formalization; this run pursued a focus, not the whole property set."
+        )
+
     return CoverageReport(
         total_properties=len(properties),
+        deprioritized_count=deprioritized_count,
         total_rules=len(rules),
         total_groups=len(groups),
         properties_per_group_min=min(sizes) if sizes else 0,

--- a/composer/spec/source/report/schema.py
+++ b/composer/spec/source/report/schema.py
@@ -15,16 +15,14 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from composer.spec.types import ComponentName, PropertyFormulation, PropertyTitle, RuleName
+from composer.spec.types import (
+    ComponentName, PropertyFormulation, PropertyKey, PropertyTitle, PropertyType, RuleName,
+)
 
 type RuleRef = tuple[str, RuleName]
 """A rule's identity: ``(spec_file, name)``. A name is only unique within a spec, so the defining
 spec file disambiguates a rule re-stated under the same name in another spec (and collapses a single
 definition — e.g. an imported structural invariant — seen through several component runs)."""
-
-type PropertyKey = tuple[ComponentName, PropertyTitle]
-"""A property's identity: ``(component, title)`` — the cross-reference key groups use for members."""
-
 
 class Outcome(str, Enum):
     """Backend-agnostic per-unit (rule / test) result. Each backend's native analysis status maps
@@ -182,11 +180,18 @@ class PropertyGroup(BaseModel):
 class CoverageReport(BaseModel):
     """Validation outcomes after grouping (see :func:`coverage.validate`)."""
     total_properties: int
+    #: Properties this run inferred and then chose not to pursue — non-zero only in a
+    #: prioritized run, where formalization is deliberately narrowed to one focus. Read it
+    #: alongside ``total_properties``, which counts only what reached the groupings.
+    deprioritized_count: int = 0
     total_rules: int
     total_groups: int
     properties_per_group_min: int
     properties_per_group_max: int
     property_coverage_complete: bool
+    """Every property that reached formalization landed in a group. It says nothing about
+    whether every property the run *inferred* was pursued — a prioritized run drops most of
+    them before this point, and reports that in ``deprioritized_count``."""
     properties_in_no_group: list[PropertyKey] = Field(default_factory=list)
     #: rules whose properties span >1 group — expected (rules repeat), reported as a stat not an error
     rules_spanning_multiple_groups: list[RuleName] = Field(default_factory=list)
@@ -304,10 +309,30 @@ class Finding(BaseModel):
     provenance: FindingProvenance | None = None
 
 
+class DeprioritizedProperty(BaseModel):
+    """A property this run inferred and deliberately did not pursue, with the ranker's reason.
+
+    Present only for a prioritized run. The point of recording them is that a prioritized
+    report otherwise looks exactly like a contract with very few properties: this is the list
+    that says what was set aside, and why."""
+    component: ComponentName
+    title: PropertyTitle
+    sort: PropertyType
+    description: str
+    score: int
+    rationale: str
+
+
 class AutoProverReport(BaseModel):
     """Top-level report document — written to ``certora/ap_report/report.json``."""
     schema_version: Literal["3.0", "3.1"] = "3.1"
     backend: ReportBackend = "prover"
+    #: How much of the inferred property set the run pursued ("comprehensive" or
+    #: "prioritized"). Absent on reports written before the mode existed, which are all
+    #: comprehensive.
+    run_mode: str | None = None
+    #: What a prioritized run set aside. Empty for a comprehensive run.
+    deprioritized: list[DeprioritizedProperty] = Field(default_factory=list)
     contract_name: str
     run_timestamp_utc: str | None = None
     #: component name (or "Structural Invariants") -> prover run link/path

--- a/composer/spec/source/report/schema.py
+++ b/composer/spec/source/report/schema.py
@@ -309,16 +309,13 @@ class Finding(BaseModel):
     provenance: FindingProvenance | None = None
 
 
-class DeprioritizedProperty(BaseModel):
+class DeprioritizedProperty(PropertyFormulation):
     """A property this run inferred and deliberately did not pursue, with the ranker's reason.
 
     Present only for a prioritized run. The point of recording them is that a prioritized
     report otherwise looks exactly like a contract with very few properties: this is the list
     that says what was set aside, and why."""
     component: ComponentName
-    title: PropertyTitle
-    sort: PropertyType
-    description: str
     score: int
     rationale: str
 

--- a/composer/spec/types.py
+++ b/composer/spec/types.py
@@ -103,6 +103,12 @@ class UntitledPropertyFormulation(BaseModel):
             case "safety_property":
                 return "Safety Property"
 
+type PropertyKey = tuple[ComponentName, PropertyTitle]
+"""A property's identity across a run: ``(component, title)``. Titles are unique within a
+component, so the pair is unique run-wide — it is what the report's groups cross-reference and
+what the prioritizer names when it points at one of many components' candidates."""
+
+
 class PropertyFormulation(UntitledPropertyFormulation):
     """
     A property or invariant that must hold for the component

--- a/composer/templates/property_generation_prompt.j2
+++ b/composer/templates/property_generation_prompt.j2
@@ -131,6 +131,27 @@ VERIFIED *or* that rule must be explicitly marked as "expected to fail" using th
 IMPORTANT: Do not try to reason yourself about whether any property is true or possible — focus solely on authoring CVL which will *demonstrate* the desired properties.
 
 <skipping>
+{% if focused %}
+This run is being spent on the properties above and nothing else. They were chosen out of everything
+inferred for this contract because they are the ones worth verifying, so there is no other work to fall
+back on: whatever you establish here is the entire result.
+
+You therefore may not retire them. `record_skip` will refuse them, and the `give_up` tool rejects a
+`sort='exhausted'` stop until you have actually put a spec in front of the prover several times and can
+enumerate what you tried. When you are stuck, the move is to make the problem smaller, not to put it down:
+
+  - Decompose it. Prove the lemmas the property rests on as their own rules and build up to it.
+  - Strengthen the setup. A harness, a summary, or a `require` that rules out states the contract itself
+    cannot reach will often turn an unprovable rule into a provable one.
+  - Weaken it honestly. If the full property will not go through, formalize the strongest core of it that
+    will, and say plainly in your commentary what you proved and what you did not.
+
+If you encounter an environment issue that prevents this task from making any progress — for example, the
+`certoraRun` executable is not installed/available, the required `solc` version is missing, or some other
+required toolchain component is absent — call `give_up` with `sort='environment'` and a clear, specific
+explanation of the missing component so the user can fix the environment and re-run. That stop is not
+gated: do it as soon as the environment issue is identified, and do not keep retrying.
+{% else %}
 If you genuinely cannot formalize a property after thorough effort, use the `record_skip` tool to declare
 which property (by its title) you are skipping and why. The feedback judge will evaluate whether
 your justification is valid — do not skip properties lightly.
@@ -146,6 +167,7 @@ is identified; do not keep retrying.
 Outside of environment issues, only use `give_up` as a LAST RESORT after repeated attempts — for example,
 when the feedback judge keeps rejecting every attempted formulation, or the source code is fundamentally
 unspecifiable as written.
+{% endif %}
 </skipping>
 
 {% if resources %}

--- a/composer/templates/property_generation_prompt.j2
+++ b/composer/templates/property_generation_prompt.j2
@@ -140,11 +140,15 @@ You therefore may not retire them. `record_skip` will refuse them, and the `give
 `sort='exhausted'` stop until you have actually put a spec in front of the prover several times and can
 enumerate what you tried. When you are stuck, the move is to make the problem smaller, not to put it down:
 
-  - Decompose it. Prove the lemmas the property rests on as their own rules and build up to it.
-  - Strengthen the setup. A harness, a summary, or a `require` that rules out states the contract itself
-    cannot reach will often turn an unprovable rule into a provable one.
-  - Weaken it honestly. If the full property will not go through, formalize the strongest core of it that
-    will, and say plainly in your commentary what you proved and what you did not.
+  - Decompose it. Prove a smaller statement that the property is built out of as its own rule, and work
+    up from there.
+  - Weaken it honestly. If the full property will not go through, formalize the strongest version of it
+    that does, and say plainly in your commentary what you proved and what you did not.
+
+Weakening is not licence to reach a passing rule by any means. A rule that passes because it assumes
+away the states where the property is interesting proves nothing, and neither does one weakened until
+it no longer says anything. Either is a worse outcome than an honest account of what would not go
+through — the point of this run is a real result about the property, not a green check.
 
 If you encounter an environment issue that prevents this task from making any progress — for example, the
 `certoraRun` executable is not installed/available, the required `solc` version is missing, or some other

--- a/composer/templates/property_prioritization_prompt.j2
+++ b/composer/templates/property_prioritization_prompt.j2
@@ -1,0 +1,13 @@
+Contract: {{ contract_name }}
+
+Candidate properties, by component
+({{ candidates | map(attribute='props') | map('length') | sum }} across {{ candidates | length }} components):
+{% for c in candidates %}
+Component: {{ c.label }}
+{%- for p in c.props %}
+  - [{{ c.label }}] {{ p.title }}  (sort: {{ p.sort }})
+      {{ p.description }}
+{%- endfor %}
+{% endfor %}
+Rank all of them, then choose the one property this run should pursue and the properties from its
+own component that it depends on.

--- a/composer/templates/property_prioritization_prompt.j2
+++ b/composer/templates/property_prioritization_prompt.j2
@@ -9,5 +9,5 @@ Component: {{ c.label }}
       {{ p.description }}
 {%- endfor %}
 {% endfor %}
-Rank all of them, then choose the one property this run should pursue and the properties from its
-own component that it depends on.
+Score all of them, and for each record which properties of its own component it would need in
+order to be stated or discharged.

--- a/composer/templates/property_prioritization_prompt.j2
+++ b/composer/templates/property_prioritization_prompt.j2
@@ -9,5 +9,4 @@ Component: {{ c.label }}
       {{ p.description }}
 {%- endfor %}
 {% endfor %}
-Score all of them, and for each record which properties of its own component it would need in
-order to be stated or discharged.
+Score all of them, then group them into claims.

--- a/composer/templates/property_prioritization_system.j2
+++ b/composer/templates/property_prioritization_system.j2
@@ -1,44 +1,87 @@
-You are deciding where a single formal-verification budget should be spent on a smart contract
-system.
+You are an expert security and software analyst with deep experience auditing Web3 (DeFi)
+protocols. You know the failure modes that recur in this space — reentrancy, oracle manipulation,
+rounding leakage across paths, access-control bypasses, MEV / front-running, lifecycle and
+pause/unpause bugs, governance abuse, etc. — and you know which of them cost users money and which
+are cosmetic.
 
-You are given every candidate property that property inference produced, grouped by the component
-it was inferred for. Each carries a unique title, a `sort` ("invariant", "safety_property",
-"attack_vector") and an English description. You may also be given the system's design document, a
-threat model, and further context the user supplied.
+# Background
 
-Score every candidate, and record what each one rests on. You are not choosing a winner: the run
-picks the highest-priority property from your scores, so the scores are the decision.
+An earlier stage read this protocol's source and design document and proposed a list of *security
+properties* for it: statements that should hold if the protocol is correct. They fall into three
+categories, and each candidate below is tagged with one:
 
-For each candidate give:
-  - `score`: 0-100, how much *proving it* would raise confidence in the overall correctness of the
-    system. Score importance, not difficulty.
-  - `critical_match`: whether it answers a concern the user actually raised, in the design
-    document, the threat model, or the supplied context. This is worth a fixed bonus on top of the
-    score, so mark it honestly rather than generously.
-  - `depends_on`: the properties from the SAME component that would be needed to state or discharge
-    this one — the lemmas it assumes, the invariants its argument leans on. Only the run's chosen
-    property has its dependencies pursued, and only the first {{ max_supporting }} of them, so put
-    the ones the proof genuinely cannot do without first. A property that is merely *related* is
-    not a dependency; leave it out.
-  - `rationale`: one or two sentences. Say what breaks if the property does not hold.
+1. **Invariants** — representational invariants that hold from construction onwards, e.g. "the sum
+   of all user balances equals the total supply".
+2. **Safety properties** — statements about what a correct protocol makes impossible, e.g. "a user
+   without the admin role cannot approve other admins".
+3. **Attack vectors** — edge cases that could plausibly be exploited to the protocol's detriment.
 
-WHAT MAKES A PROPERTY WORTH THE RUN:
-  W1. Its violation is a real loss — funds, access, or an accounting identity — not a cosmetic
-      deviation.
-  W2. It constrains behaviour across many entry points rather than one narrow path.
-  W3. The user pointed at it. That is what `critical_match` is for.
-  W4. It is falsifiable against the code as written. A property that restates a compiler guarantee
-      or that no implementation could violate buys nothing.
+Those properties have not been proved. Proving one means writing a formal specification for it and
+running the Certora Prover against the contract, which takes an expert-level agent a long time and
+a great deal of money. This *run* — one pass of that pipeline over this contract — can afford to
+pursue a single claim, and no more.
 
-WHAT DOES NOT MAKE A PROPERTY WORTH THE RUN:
-  N1. Being easy to verify.
-  N2. Being the first or most prominent in the listing.
-  N3. Belonging to the largest component.
+# Task
 
-HARD CONSTRAINTS — violating these means your output is rejected:
+Two things, over the candidate listing you are given.
+
+**Score every candidate.** How badly is the protocol hurt if this property does not hold? Score the
+consequence of a violation. Do not score how hard the property looks to prove; a hard property that
+matters beats an easy one that does not.
+
+**Group the candidates into claims.** Several properties often say one thing between them. Put each
+candidate in exactly one group and name what that group, taken together, establishes. Keep groups
+small — two to four properties is typical, and a group of one is fine when a property stands alone.
+
+The run pursues the group containing the highest-scoring property, so the scores decide what is
+proved. Every member of a group must belong to the same component: a run works on one component's
+properties, and a group spanning two of them could not be pursued.
+
+# Scoring
+
+    Score 100
+      Good example: "Total assets backing the pool are always at least the sum of user claims"
+        (violation means the protocol is insolvent and users cannot be made whole)
+      Good example: "Only an account holding the admin role can change the fee recipient"
+        (violation hands protocol revenue to an attacker)
+
+    Score 70
+      Good example: "Shares minted on deposit equal assets deposited times the current exchange rate"
+        (violation leaks value on every deposit, silently and cumulatively)
+      Good example: "A withdrawal request cannot be fulfilled twice"
+
+    Score 40
+      Good example: "The pause flag blocks deposits while set"
+        (a stated rule of the protocol, but breaking it does not directly move funds)
+      Good example: "Oracle price updates are rejected when older than the staleness window"
+
+    Score 10
+      Bad example: "The version string is set at construction"
+        (nothing of value depends on it)
+      Bad example: "totalSupply is a uint256"
+        (no implementation could violate this — it is a compiler guarantee, not a property)
+
+Add nothing for a property being easy to state, being first in the listing, or belonging to the
+component with the most properties.
+
+# What raises a score
+
+  - **Real loss.** Funds, access, or an accounting identity — not a cosmetic deviation.
+  - **Falsifiable against this code.** A property that restates a compiler guarantee, or that no
+    implementation of this contract could violate, buys nothing however grand it sounds.
+
+# The `critical_match` flag
+
+Set it when a property answers a concern raised explicitly in the design document, threat model, or
+supplied notes — something the reader of those documents asked to be checked, rather than something
+inferred unaided. It carries a fixed bonus on top of the score, so mark it honestly: flagging
+everything makes it meaningless.
+
+# Hard constraints — violating these means your output is rejected
+
   H1. `ranked` contains every candidate exactly once.
-  H2. Every [component, title] pair you emit is copied exactly from the listing.
-  H3. Every `depends_on` entry is a property title from the same component as the property that
-      lists it, and no property lists itself.
+  H2. Every candidate appears in exactly one group.
+  H3. Every [component, title] pair is copied exactly from the listing.
+  H4. All members of a group belong to the same component.
 
 Return the structured output exactly matching the requested schema.

--- a/composer/templates/property_prioritization_system.j2
+++ b/composer/templates/property_prioritization_system.j2
@@ -1,0 +1,43 @@
+You are deciding where a single formal-verification budget should be spent on a smart contract
+system.
+
+You are given every candidate property that property inference produced, grouped by the component
+it was inferred for. Each carries a unique title, a `sort` ("invariant", "safety_property",
+"attack_vector") and an English description. You may also be given the system's design document, a
+threat model, and further context the user supplied.
+
+Your job has two halves.
+
+**Rank every candidate.** Score each 0-100 on how much *proving it* would raise confidence in the
+overall correctness of the system, and mark whether it answers a concern the user actually raised.
+The score is about the property's importance, not how hard it looks to verify.
+
+**Pick one property to pursue, plus what it rests on.** The run will formalize the primary property
+and nothing else, so it is worth the whole budget only if its failure would matter. Alongside it,
+name the properties from the SAME component that are needed to state or discharge it — the lemmas it
+assumes, the invariants its argument leans on. At most {{ max_supporting }}, and fewer is better.
+A property that is merely *related* to the primary is not supporting it; leave it out.
+
+WHAT MAKES A PROPERTY WORTH THE RUN:
+  W1. Its violation is a real loss — funds, access, or an accounting identity — not a cosmetic
+      deviation.
+  W2. It constrains behaviour across many entry points rather than one narrow path.
+  W3. The user pointed at it. A concern stated in the design document, the threat model, or the
+      supplied context outranks one you inferred unaided, even at a similar score.
+  W4. It is falsifiable against the code as written. A property that restates a compiler guarantee
+      or that no implementation could violate buys nothing.
+
+WHAT DOES NOT MAKE A PROPERTY WORTH THE RUN:
+  N1. Being easy to verify.
+  N2. Being the first or most prominent in the listing.
+  N3. Belonging to the largest component.
+
+HARD CONSTRAINTS — violating these means your output is rejected:
+  H1. `ranked` contains every candidate exactly once, highest score first.
+  H2. Every [component, title] pair you emit is copied exactly from the listing.
+  H3. `primary` is one of the candidates.
+  H4. Every entry in `supporting` belongs to the same component as `primary`, and `primary` itself
+      is not among them.
+  H5. `supporting` holds at most {{ max_supporting }} entries.
+
+Return the structured output exactly matching the requested schema.

--- a/composer/templates/property_prioritization_system.j2
+++ b/composer/templates/property_prioritization_system.j2
@@ -30,12 +30,29 @@ consequence of a violation. Do not score how hard the property looks to prove; a
 matters beats an easy one that does not.
 
 **Group the candidates into claims.** Several properties often say one thing between them. Put each
-candidate in exactly one group and name what that group, taken together, establishes. Keep groups
-small — two to four properties is typical, and a group of one is fine when a property stands alone.
+candidate in exactly one group and name what that group, taken together, establishes. A group of
+one is fine when a property stands alone.
 
-The run pursues the group containing the highest-scoring property, so the scores decide what is
-proved. Every member of a group must belong to the same component: a run works on one component's
-properties, and a group spanning two of them could not be pursued.
+The run pursues the group containing the highest-scoring property, and it pursues all of it, so a
+group must hold everything its claim rests on. A property that has to hold for the claim to mean
+anything belongs in the group even when its own score is low; leaving it out does not make the run
+cheaper, it makes the claim unproven. Equally, a property the claim does not need belongs in its
+own group — padding a group spends the run's budget on properties nobody chose.
+
+    Good example: claim "the vault is solvent — every share is backed by a unit of collateral it
+      can be redeemed for", grouping the supply/collateral identity, the ledger-sums-correctly
+      property, the no-burn-past-your-balance property, and the redemption property that says what
+      solvency is *for*. The last one scores lower on its own and is the point of the other three.
+    Bad example: the same claim, with the redemption property split into a group of its own
+      because the first three were "enough". The run proves an accounting identity and never
+      establishes that anyone can get their money out.
+    Bad example: that solvency group with the ERC-20 `name()`/`symbol()` properties added because
+      they are in the same component. They are not what solvency rests on.
+
+Every member of a group must belong to the same component: a run works on one component's
+properties, and a group spanning two of them could not be pursued. Where the same claim genuinely
+arises in two components, group it in the component that states it best and score the other
+component's copies on their own merits.
 
 # Scoring
 
@@ -83,5 +100,6 @@ everything makes it meaningless.
   H2. Every candidate appears in exactly one group.
   H3. Every [component, title] pair is copied exactly from the listing.
   H4. All members of a group belong to the same component.
+  H5. A group contains every property its claim rests on — the run pursues the whole group.
 
 Return the structured output exactly matching the requested schema.

--- a/composer/templates/property_prioritization_system.j2
+++ b/composer/templates/property_prioritization_system.j2
@@ -6,24 +6,27 @@ it was inferred for. Each carries a unique title, a `sort` ("invariant", "safety
 "attack_vector") and an English description. You may also be given the system's design document, a
 threat model, and further context the user supplied.
 
-Your job has two halves.
+Score every candidate, and record what each one rests on. You are not choosing a winner: the run
+picks the highest-priority property from your scores, so the scores are the decision.
 
-**Rank every candidate.** Score each 0-100 on how much *proving it* would raise confidence in the
-overall correctness of the system, and mark whether it answers a concern the user actually raised.
-The score is about the property's importance, not how hard it looks to verify.
-
-**Pick one property to pursue, plus what it rests on.** The run will formalize the primary property
-and nothing else, so it is worth the whole budget only if its failure would matter. Alongside it,
-name the properties from the SAME component that are needed to state or discharge it — the lemmas it
-assumes, the invariants its argument leans on. At most {{ max_supporting }}, and fewer is better.
-A property that is merely *related* to the primary is not supporting it; leave it out.
+For each candidate give:
+  - `score`: 0-100, how much *proving it* would raise confidence in the overall correctness of the
+    system. Score importance, not difficulty.
+  - `critical_match`: whether it answers a concern the user actually raised, in the design
+    document, the threat model, or the supplied context. This is worth a fixed bonus on top of the
+    score, so mark it honestly rather than generously.
+  - `depends_on`: the properties from the SAME component that would be needed to state or discharge
+    this one — the lemmas it assumes, the invariants its argument leans on. Only the run's chosen
+    property has its dependencies pursued, and only the first {{ max_supporting }} of them, so put
+    the ones the proof genuinely cannot do without first. A property that is merely *related* is
+    not a dependency; leave it out.
+  - `rationale`: one or two sentences. Say what breaks if the property does not hold.
 
 WHAT MAKES A PROPERTY WORTH THE RUN:
   W1. Its violation is a real loss — funds, access, or an accounting identity — not a cosmetic
       deviation.
   W2. It constrains behaviour across many entry points rather than one narrow path.
-  W3. The user pointed at it. A concern stated in the design document, the threat model, or the
-      supplied context outranks one you inferred unaided, even at a similar score.
+  W3. The user pointed at it. That is what `critical_match` is for.
   W4. It is falsifiable against the code as written. A property that restates a compiler guarantee
       or that no implementation could violate buys nothing.
 
@@ -33,11 +36,9 @@ WHAT DOES NOT MAKE A PROPERTY WORTH THE RUN:
   N3. Belonging to the largest component.
 
 HARD CONSTRAINTS — violating these means your output is rejected:
-  H1. `ranked` contains every candidate exactly once, highest score first.
+  H1. `ranked` contains every candidate exactly once.
   H2. Every [component, title] pair you emit is copied exactly from the listing.
-  H3. `primary` is one of the candidates.
-  H4. Every entry in `supporting` belongs to the same component as `primary`, and `primary` itself
-      is not among them.
-  H5. `supporting` holds at most {{ max_supporting }} entries.
+  H3. Every `depends_on` entry is a property title from the same component as the property that
+      lists it, and no property lists itself.
 
 Return the structured output exactly matching the requested schema.

--- a/tests/test_autoprove_integration.py
+++ b/tests/test_autoprove_integration.py
@@ -106,7 +106,8 @@ def _make_args(rag_conn: str, scenario_dir: Path, system_doc: str | None) -> Aut
         thinking_tokens=2048,
         memory_tool=False,
         interleaved_thinking=False,
-        time_budget=None
+        time_budget=None,
+        run_mode=None,
     ))
 
 

--- a/tests/test_focus_exits.py
+++ b/tests/test_focus_exits.py
@@ -35,7 +35,7 @@ def _prover_calls(n: int) -> list[AIMessage]:
 async def _give_up(sort: str, runs: int, floor: int = FLOOR) -> str:
     inst = _Gated(
         sort=sort, reason="r", attempts=["tried the obvious rule"],
-        state={"messages": _prover_calls(runs)}, tool_call_id="t",
+        state={"messages": _prover_calls(runs), "failed": None}, tool_call_id="t",
     )
     tok = _Gated._dep_ctx.set(floor)
     try:
@@ -107,7 +107,7 @@ async def test_the_reason_must_enumerate_attempts():
     with pytest.raises(pydantic.ValidationError):
         _Gated(
             sort="exhausted", reason="r", attempts=[],
-            state={"messages": []}, tool_call_id="t",
+            state={"messages": [], "failed": None}, tool_call_id="t",
         )
 
 

--- a/tests/test_focus_exits.py
+++ b/tests/test_focus_exits.py
@@ -1,0 +1,156 @@
+"""The tightened exits a prioritized author runs under.
+
+Two escape hatches let a CVL author walk away from a property: the `give_up` tool, and
+`record_skip`. With a whole run staked on one property, either is a total loss, so both are
+constrained — but neither may be constrained into a deadlock, which is what these tests are
+really about. The gate must stay satisfiable when the toolchain is broken, and the skip
+protection must stand down when the budget monitor orders a wrap-up.
+"""
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from composer.authoring.tools import GatedGiveUp, RecordSkip, _verify_attempts, skip_tools
+from composer.spec.source.author import FocusPolicy
+from composer.spec.types import PropertyTitle
+
+pytestmark = pytest.mark.asyncio
+
+FLOOR = 3
+_Gated = GatedGiveUp.with_template(
+    description="Stop work.", reason="why", label="CVL generation"
+)
+_Skip = RecordSkip.with_template(description="Skip it.", reason="why")
+
+
+def _prover_calls(n: int) -> list[AIMessage]:
+    return [
+        AIMessage(content="", tool_calls=[{"name": "verify_spec", "args": {}, "id": f"c{i}"}])
+        for i in range(n)
+    ]
+
+
+async def _give_up(sort: str, runs: int, floor: int = FLOOR) -> str:
+    inst = _Gated(
+        sort=sort, reason="r", attempts=["tried the obvious rule"],
+        state={"messages": _prover_calls(runs)}, tool_call_id="t",
+    )
+    tok = _Gated._dep_ctx.set(floor)
+    try:
+        cmd = await inst.run()
+    finally:
+        _Gated._dep_ctx.reset(tok)
+    return str(cmd.update["messages"][0].content)
+
+
+async def _skip_via(tools, title: str) -> str:
+    """Invoke the ``record_skip`` from a built tool list, as the graph would."""
+    tool = next(t for t in tools if t.name == "record_skip")
+    out = await tool.ainvoke(
+        {"name": "record_skip", "args": {"property_title": title, "reason": "cannot do it"},
+         "id": "t", "type": "tool_call"}
+    )
+    return str(out.update["messages"][0].content)
+
+
+TITLES = [PropertyTitle("solvency"), PropertyTitle("shares_sane")]
+
+
+def _direct(protected):
+    """The editing branch: ``skip_tools`` called directly (spec/source/author.py)."""
+    return skip_tools(TITLES, skip_description="d", skip_reason="r", protected=protected)
+
+
+def _via_property_tools(protected):
+    """The non-editing branch: the same pair reached through ``property_tools``
+    (spec/cvl_generation.py). Both must honour the protection, or the ban depends on which
+    branch happened to build the suite."""
+    from composer.spec.cvl_generation import property_tools
+
+    class _Services:
+        titles = TITLES
+
+    return property_tools(_Services(), protected=protected)  # type: ignore[arg-type]
+
+
+# --- the give-up gate ------------------------------------------------------
+
+
+@pytest.mark.parametrize("runs", [0, 1, FLOOR - 1])
+async def test_exhausted_is_refused_before_the_prover_floor(runs):
+    out = await _give_up("exhausted", runs)
+    assert "Rejected" in out and str(FLOOR) in out
+
+
+@pytest.mark.parametrize("runs", [FLOOR, FLOOR + 5])
+async def test_exhausted_is_accepted_once_the_floor_is_met(runs):
+    assert await _give_up("exhausted", runs) == "Accepted"
+
+
+async def test_an_environment_stop_is_never_gated():
+    # A missing certoraRun or solc produces no prover run at all, so gating this stop would make
+    # the floor unsatisfiable and hold the agent against its recursion limit instead.
+    assert await _give_up("environment", 0) == "Accepted"
+
+
+async def test_the_reason_must_enumerate_attempts():
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        _Gated(
+            sort="exhausted", reason="r", attempts=[],
+            state={"messages": []}, tool_call_id="t",
+        )
+
+
+async def test_attempts_are_counted_from_tool_calls_not_prover_reports():
+    # prover_history only grows when the prover returns a report, and the failures worth
+    # escalating through (a spec that will not type-check) return before that. Counting calls
+    # is what makes the floor reachable.
+    state = {"messages": [*_prover_calls(2), AIMessage(content="thinking out loud")]}
+    assert _verify_attempts(state) == 2
+    assert _verify_attempts({"messages": []}) == 0
+    assert _verify_attempts({}) == 0
+
+
+# --- the focus policy ------------------------------------------------------
+
+
+async def test_the_budget_wrap_up_lifts_the_focus_protection():
+    # The wrap-up alert orders the agent to skip everything that does not work. A protection
+    # that outlived that order would deadlock the session the budget was trying to end.
+    focus = FocusPolicy(protected=(PropertyTitle("solvency"),))
+    assert focus.protected_titles() == ("solvency",)
+    focus.lifted = True
+    assert focus.protected_titles() == ()
+
+
+# --- the skip protection, on both binding paths ----------------------------
+
+
+@pytest.mark.parametrize("build", [_direct, _via_property_tools], ids=["skip_tools", "property_tools"])
+async def test_a_protected_property_cannot_be_skipped(build):
+    out = await _skip_via(build(lambda: (PropertyTitle("solvency"),)), "solvency")
+    assert "cannot be skipped" in out
+
+
+@pytest.mark.parametrize("build", [_direct, _via_property_tools], ids=["skip_tools", "property_tools"])
+async def test_an_unprotected_property_can_still_be_skipped(build):
+    # The supporting cluster is protected too in a real run, but the mechanism must not be
+    # "refuse everything" — an unprotected title still goes through.
+    out = await _skip_via(build(lambda: (PropertyTitle("solvency"),)), "shares_sane")
+    assert "Recorded skip" in out
+
+
+@pytest.mark.parametrize("build", [_direct, _via_property_tools], ids=["skip_tools", "property_tools"])
+async def test_nothing_is_protected_by_default(build):
+    out = await _skip_via(build(()), "solvency")
+    assert "Recorded skip" in out
+
+
+async def test_the_lifted_policy_lets_the_budget_wrap_up_skip_the_focus():
+    focus = FocusPolicy(protected=(PropertyTitle("solvency"),))
+    tools = _direct(focus.protected_titles)
+    assert "cannot be skipped" in await _skip_via(tools, "solvency")
+    focus.lifted = True
+    assert "Recorded skip" in await _skip_via(tools, "solvency")

--- a/tests/test_focus_exits.py
+++ b/tests/test_focus_exits.py
@@ -10,7 +10,9 @@ protection must stand down when the budget monitor orders a wrap-up.
 import pytest
 from langchain_core.messages import AIMessage
 
-from composer.authoring.tools import GatedGiveUp, RecordSkip, _verify_attempts, skip_tools
+from composer.authoring.tools import (
+    GatedGiveUp, RecordSkip, SkipScope, _verify_attempts, skip_tools,
+)
 from composer.spec.source.author import FocusPolicy
 from composer.spec.types import PropertyTitle
 
@@ -37,32 +39,38 @@ async def _give_up(sort: str, runs: int, floor: int = FLOOR) -> str:
     )
     tok = _Gated._dep_ctx.set(floor)
     try:
-        cmd = await inst.run()
+        out = await inst.run()
     finally:
         _Gated._dep_ctx.reset(tok)
-    return str(cmd.update["messages"][0].content)
+    # A refusal is a plain string; only an accepted surrender writes state.
+    return out if isinstance(out, str) else str(out.update["messages"][0].content)
 
 
-async def _skip_via(tools, title: str) -> str:
-    """Invoke the ``record_skip`` from a built tool list, as the graph would."""
-    tool = next(t for t in tools if t.name == "record_skip")
-    out = await tool.ainvoke(
-        {"name": "record_skip", "args": {"property_title": title, "reason": "cannot do it"},
-         "id": "t", "type": "tool_call"}
+async def _skip(scope: SkipScope, title: str, *, curtailed: bool = False) -> str:
+    """Run ``record_skip`` against the scope a builder produced, with the state it reads."""
+    inst = _Skip(
+        property_title=PropertyTitle(title), reason="cannot do it",
+        state={"messages": [], "budget_curtailed": curtailed}, tool_call_id="t",
     )
-    return str(out.update["messages"][0].content)
+    tok = _Skip._dep_ctx.set(scope)
+    try:
+        out = await inst.run()
+    finally:
+        _Skip._dep_ctx.reset(tok)
+    return out if isinstance(out, str) else str(out.update["messages"][0].content)
 
 
 TITLES = [PropertyTitle("solvency"), PropertyTitle("shares_sane")]
+PROTECT_SOLVENCY = [PropertyTitle("solvency")]
 
 
 def _direct(protected):
-    """The editing branch: ``skip_tools`` called directly (spec/source/author.py)."""
+    """The editing branch builds the pair with ``skip_tools`` (spec/source/author.py)."""
     return skip_tools(TITLES, skip_description="d", skip_reason="r", protected=protected)
 
 
 def _via_property_tools(protected):
-    """The non-editing branch: the same pair reached through ``property_tools``
+    """The non-editing branch reaches the same pair through ``property_tools``
     (spec/cvl_generation.py). Both must honour the protection, or the ban depends on which
     branch happened to build the suite."""
     from composer.spec.cvl_generation import property_tools
@@ -113,44 +121,39 @@ async def test_attempts_are_counted_from_tool_calls_not_prover_reports():
     assert _verify_attempts({}) == 0
 
 
-# --- the focus policy ------------------------------------------------------
+# --- the skip protection --------------------------------------------------
+
+
+@pytest.mark.parametrize("build", [_direct, _via_property_tools], ids=["skip_tools", "property_tools"])
+async def test_both_binding_paths_offer_record_skip(build):
+    # The author reaches its skip pair by either route; a protection wired into only one is
+    # silently bypassable from the other.
+    assert {"record_skip", "unskip_property"} <= {tool.name for tool in build(PROTECT_SOLVENCY)}
+
+
+async def test_a_protected_property_cannot_be_skipped():
+    scope = SkipScope(titles=lambda: TITLES, protected=frozenset(PROTECT_SOLVENCY))
+    assert "cannot be skipped" in await _skip(scope, "solvency")
+
+
+async def test_an_unprotected_property_can_still_be_skipped():
+    scope = SkipScope(titles=lambda: TITLES, protected=frozenset(PROTECT_SOLVENCY))
+    assert "Recorded skip" in await _skip(scope, "shares_sane")
+
+
+async def test_nothing_is_protected_by_default():
+    assert "Recorded skip" in await _skip(SkipScope(titles=lambda: TITLES), "solvency")
 
 
 async def test_the_budget_wrap_up_lifts_the_focus_protection():
-    # The wrap-up alert orders the agent to skip everything that does not work. A protection
-    # that outlived that order would deadlock the session the budget was trying to end.
-    focus = FocusPolicy(protected=(PropertyTitle("solvency"),))
-    assert focus.protected_titles() == ("solvency",)
-    focus.lifted = True
-    assert focus.protected_titles() == ()
+    # The wrap-up order is "skip everything that does not work", which the protection would
+    # otherwise refuse, deadlocking the session the budget was ending. The signal is
+    # ``budget_curtailed`` in the graph state, so it survives a checkpoint; a flag on the policy
+    # object would not, and could disagree with the state it shadows.
+    scope = SkipScope(titles=lambda: TITLES, protected=frozenset(PROTECT_SOLVENCY))
+    assert "cannot be skipped" in await _skip(scope, "solvency")
+    assert "Recorded skip" in await _skip(scope, "solvency", curtailed=True)
 
 
-# --- the skip protection, on both binding paths ----------------------------
-
-
-@pytest.mark.parametrize("build", [_direct, _via_property_tools], ids=["skip_tools", "property_tools"])
-async def test_a_protected_property_cannot_be_skipped(build):
-    out = await _skip_via(build(lambda: (PropertyTitle("solvency"),)), "solvency")
-    assert "cannot be skipped" in out
-
-
-@pytest.mark.parametrize("build", [_direct, _via_property_tools], ids=["skip_tools", "property_tools"])
-async def test_an_unprotected_property_can_still_be_skipped(build):
-    # The supporting cluster is protected too in a real run, but the mechanism must not be
-    # "refuse everything" — an unprotected title still goes through.
-    out = await _skip_via(build(lambda: (PropertyTitle("solvency"),)), "shares_sane")
-    assert "Recorded skip" in out
-
-
-@pytest.mark.parametrize("build", [_direct, _via_property_tools], ids=["skip_tools", "property_tools"])
-async def test_nothing_is_protected_by_default(build):
-    out = await _skip_via(build(()), "solvency")
-    assert "Recorded skip" in out
-
-
-async def test_the_lifted_policy_lets_the_budget_wrap_up_skip_the_focus():
-    focus = FocusPolicy(protected=(PropertyTitle("solvency"),))
-    tools = _direct(focus.protected_titles)
-    assert "cannot be skipped" in await _skip_via(tools, "solvency")
-    focus.lifted = True
-    assert "Recorded skip" in await _skip_via(tools, "solvency")
+async def test_the_focus_policy_holds_no_mutable_state():
+    assert not hasattr(FocusPolicy(protected=(PropertyTitle("solvency"),)), "lifted")

--- a/tests/test_pipeline_overlap.py
+++ b/tests/test_pipeline_overlap.py
@@ -17,6 +17,7 @@ import asyncio
 
 import pytest
 
+from composer.pipeline.run_mode import RunMode
 import composer.pipeline.core as core
 from composer.pipeline.core import run_pipeline
 from composer.pipeline.ecosystem import EVM
@@ -113,6 +114,7 @@ class _Run:
     """Just enough ``PipelineRun`` for the driver: runners that await the job inline."""
 
     source = _Source()
+    run_mode = RunMode.COMPREHENSIVE
     env = None
     ctx = _Ctx()
 

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -16,6 +16,8 @@ import asyncio
 
 import pytest
 
+from composer.pipeline.run_mode import RunMode
+from composer.spec.prioritize import PropertyRanking, RankedProperty
 import composer.pipeline.core as core
 from composer.pipeline.core import run_pipeline
 from composer.pipeline.ecosystem import EVM
@@ -28,6 +30,7 @@ class _Store:
     def write_properties(self, *_a, **_kw): ...
     def write_artifact(self, *_a, **_kw): return "artifact"
     def write_report(self, *_a, **_kw): ...
+    def write_ranking(self, *_a, **_kw): return "property_ranking.json"
 
 
 class _Unit:
@@ -125,6 +128,10 @@ class _Ctx:
 
     def child(self, *_a, **_kw): return self
 
+    async def cache_get(self, _ty): return None
+
+    async def cache_put(self, _v): ...
+
 
 class _FeatCtx:
     def child(self, key, tags = None):
@@ -138,11 +145,19 @@ class _FeatCtx:
 class _Source:
     contract_name = "Vault"
     relative_path = "programs/vault/src/lib.rs"
+    content = None
+
+
+class _Env:
+    """Only the model accessor the ranker's call site reaches for."""
+
+    def llm_heavy(self): return None
 
 
 class _Run:
     source = _Source()
-    env = None
+    run_mode = RunMode.COMPREHENSIVE
+    env = _Env()
     ctx = _Ctx()
 
     async def runner(self, task_info, job):
@@ -154,7 +169,9 @@ def _prop(title: str) -> PropertyFormulation:
 
 
 async def _drive[F: (_Staged, _Formalizer)](
-    monkeypatch, units: dict[str, list[str]], formalizer: F
+    monkeypatch, units: dict[str, list[str]], formalizer: F, *,
+    run_mode: RunMode = RunMode.COMPREHENSIVE,
+    ranking=None,
 ) -> F:
     async def fake_analysis(*_a, **_kw): return "analyzed"
 
@@ -169,7 +186,13 @@ async def _drive[F: (_Staged, _Formalizer)](
     monkeypatch.setattr(core, "run_component_analysis", fake_analysis)
     monkeypatch.setattr(core, "_extract_all", fake_extract_all)
     monkeypatch.setattr(core, "build_report", fake_report)
-    await run_pipeline(_Backend(_Prepared(formalizer)), _Run(), max_bug_rounds=1, ecosystem=EVM)  # type: ignore[arg-type]
+    if ranking is not None:
+        async def fake_rank(**_kw): return ranking
+        monkeypatch.setattr(core, "rank_properties", fake_rank)
+
+    run = _Run()
+    run.run_mode = run_mode  # type: ignore[misc]
+    await run_pipeline(_Backend(_Prepared(formalizer)), run, max_bug_rounds=1, ecosystem=EVM)  # type: ignore[arg-type]
     return formalizer
 
 
@@ -200,3 +223,58 @@ async def test_an_unstaged_formalizer_is_formalized_directly(monkeypatch):
     # and the driver must fan out over exactly that object rather than looking for a staging step.
     f = await _drive(monkeypatch, {"deposits": ["a"], "admin": ["b"]}, _Formalizer())
     assert sorted(c[0] for c in f.calls) == ["formalize:admin", "formalize:deposits"]
+
+
+
+# ---------------------------------------------------------------------------
+# Prioritized mode: the cut, and what it must leave alone
+# ---------------------------------------------------------------------------
+
+
+def _ranking(primary, supporting, order):
+    return PropertyRanking(
+        ranked=[
+            RankedProperty(key=k, score=100 - i, critical_match=False, rationale="r")
+            for i, k in enumerate(order)
+        ],
+        primary=primary,
+        supporting=supporting,
+        justification="j",
+    )
+
+
+async def test_prioritized_formalizes_one_batch_and_begin_still_sees_only_it(monkeypatch):
+    # The whole saving: three components' properties are extracted, one batch is formalized.
+    # ``begin`` is handed the pruned list too, so a backend that authors a shared artifact from
+    # the batches authors it from the focus rather than from everything.
+    units = {"deposits": ["a", "b"], "admin": ["c"], "farms": ["d"]}
+    order = [("deposits", "a"), ("deposits", "b"), ("admin", "c"), ("farms", "d")]
+    s = await _drive(
+        monkeypatch, units, _Staged(), run_mode=RunMode.PRIORITIZED,
+        ranking=_ranking(("deposits", "a"), [("deposits", "b")], order),
+    )
+    assert s.calls[0] == ("begin", ["a", "b"])
+    assert [c[0] for c in s.calls[1:]] == ["formalize:deposits"]
+
+
+async def test_prioritized_leaves_the_pre_formalization_overlap_alone(monkeypatch):
+    # D2: the fixed prefix is not what this mode makes cheaper, and it must keep running —
+    # ``begin`` is still called exactly once, before any formalization.
+    units = {"deposits": ["a"], "admin": ["b"]}
+    order = [("deposits", "a"), ("admin", "b")]
+    s = await _drive(
+        monkeypatch, units, _Staged(), run_mode=RunMode.PRIORITIZED,
+        ranking=_ranking(("admin", "b"), [], order),
+    )
+    names = [c[0] for c in s.calls]
+    assert names.count("begin") == 1 and names[0] == "begin"
+    assert names[1:] == ["formalize:admin"]
+
+
+async def test_comprehensive_never_calls_the_ranker(monkeypatch):
+    def boom(**_kw):
+        raise AssertionError("the ranker must not run in comprehensive mode")
+
+    monkeypatch.setattr(core, "rank_properties", boom)
+    s = await _drive(monkeypatch, {"deposits": ["a"], "admin": ["b"]}, _Staged())
+    assert sorted(c[0] for c in s.calls) == ["begin", "formalize:admin", "formalize:deposits"]

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -17,6 +17,7 @@ import asyncio
 import pytest
 
 from composer.pipeline.run_mode import RunMode
+from composer.authoring.state import SkippedProperty
 from composer.spec.prioritize import PropertyRanking, RankedProperty
 import composer.pipeline.core as core
 from composer.pipeline.core import run_pipeline
@@ -231,14 +232,19 @@ async def test_an_unstaged_formalizer_is_formalized_directly(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _ranking(primary, supporting, order):
+def _ranking(winner, deps, order):
+    """Score ``winner`` above everything else, so the derived focus is deterministic."""
     return PropertyRanking(
         ranked=[
-            RankedProperty(key=k, score=100 - i, critical_match=False, rationale="r")
-            for i, k in enumerate(order)
+            RankedProperty(
+                key=k,
+                score=90 if k == winner else 10,
+                critical_match=False,
+                depends_on=deps if k == winner else [],
+                rationale="r",
+            )
+            for k in order
         ],
-        primary=primary,
-        supporting=supporting,
         justification="j",
     )
 
@@ -251,7 +257,7 @@ async def test_prioritized_formalizes_one_batch_and_begin_still_sees_only_it(mon
     order = [("deposits", "a"), ("deposits", "b"), ("admin", "c"), ("farms", "d")]
     s = await _drive(
         monkeypatch, units, _Staged(), run_mode=RunMode.PRIORITIZED,
-        ranking=_ranking(("deposits", "a"), [("deposits", "b")], order),
+        ranking=_ranking(("deposits", "a"), ["b"], order),
     )
     assert s.calls[0] == ("begin", ["a", "b"])
     assert [c[0] for c in s.calls[1:]] == ["formalize:deposits"]
@@ -278,3 +284,40 @@ async def test_comprehensive_never_calls_the_ranker(monkeypatch):
     monkeypatch.setattr(core, "rank_properties", boom)
     s = await _drive(monkeypatch, {"deposits": ["a"], "admin": ["b"]}, _Staged())
     assert sorted(c[0] for c in s.calls) == ["begin", "formalize:admin", "formalize:deposits"]
+
+
+# ---------------------------------------------------------------------------
+# A cache hit must not smuggle a retired focus past the protections
+# ---------------------------------------------------------------------------
+
+
+class _Result:
+    """The two members ``_focus_satisfied`` reads off a backend result."""
+
+    def __init__(self, mapped: list[str], skipped: list[str] = []):
+        self._mapped = mapped
+        self.skipped = [SkippedProperty(property_title=t, reason="r") for t in skipped]
+
+    def property_checks(self):
+        return [(t, ["rule_" + t]) for t in self._mapped]
+
+
+def _props(*titles):
+    return [PropertyFormulation(title=t, sort="invariant", description="d") for t in titles]
+
+
+def test_a_result_that_maps_every_focus_property_satisfies_the_focus():
+    assert core._focus_satisfied(_Result(["a", "b"]), _props("a", "b"))  # type: ignore[arg-type]
+
+
+def test_a_skipped_focus_property_does_not_satisfy_the_focus():
+    # The exact hazard: a cached comprehensive result that retired the property a prioritized run
+    # exists to establish. A replay never runs the author's tools, so nothing else would catch it.
+    assert not core._focus_satisfied(  # type: ignore[arg-type]
+        _Result(["b"], skipped=["a"]), _props("a", "b")
+    )
+
+
+def test_an_unmapped_focus_property_does_not_satisfy_the_focus():
+    assert not core._focus_satisfied(_Result(["a"]), _props("a", "b"))  # type: ignore[arg-type]
+    assert not core._focus_satisfied(_Result([]), _props("a"))  # type: ignore[arg-type]

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -18,7 +18,7 @@ import pytest
 
 from composer.pipeline.run_mode import RunMode
 from composer.authoring.state import SkippedProperty
-from composer.spec.prioritize import PropertyRanking, RankedProperty
+from composer.spec.prioritize import PropertyGroup, PropertyRanking, RankedProperty
 import composer.pipeline.core as core
 from composer.pipeline.core import run_pipeline
 from composer.pipeline.ecosystem import EVM
@@ -232,18 +232,20 @@ async def test_an_unstaged_formalizer_is_formalized_directly(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _ranking(winner, deps, order):
-    """Score ``winner`` above everything else, so the derived focus is deterministic."""
+def _ranking(winner, also, order):
+    """Score ``winner`` above everything else, so the derived focus is deterministic. ``also``
+    names the other titles sharing the winner's claim."""
+    with_winner = [winner, *((winner[0], t) for t in also)]
     return PropertyRanking(
         ranked=[
-            RankedProperty(
-                key=k,
-                score=90 if k == winner else 10,
-                critical_match=False,
-                depends_on=deps if k == winner else [],
-                rationale="r",
-            )
+            RankedProperty(key=k, score=90 if k == winner else 10, critical_match=False,
+                           rationale="r")
             for k in order
+        ],
+        groups=[
+            PropertyGroup(claim="the claim under test", members=with_winner),
+            *(PropertyGroup(claim=f"claim:{k[1]}", members=[k])
+              for k in order if k not in with_winner),
         ],
         justification="j",
     )
@@ -254,10 +256,10 @@ async def test_prioritized_formalizes_one_batch_and_begin_still_sees_only_it(mon
     # ``begin`` is handed the pruned list too, so a backend that authors a shared artifact from
     # the batches authors it from the focus rather than from everything.
     units = {"deposits": ["a", "b"], "admin": ["c"], "farms": ["d"]}
-    order = [("deposits", "a"), ("deposits", "b"), ("admin", "c"), ("farms", "d")]
+    order = [("0: deposits", "a"), ("0: deposits", "b"), ("1: admin", "c"), ("2: farms", "d")]
     s = await _drive(
         monkeypatch, units, _Staged(), run_mode=RunMode.PRIORITIZED,
-        ranking=_ranking(("deposits", "a"), ["b"], order),
+        ranking=_ranking(("0: deposits", "a"), ["b"], order),
     )
     assert s.calls[0] == ("begin", ["a", "b"])
     assert [c[0] for c in s.calls[1:]] == ["formalize:deposits"]
@@ -267,10 +269,10 @@ async def test_prioritized_leaves_the_pre_formalization_overlap_alone(monkeypatc
     # D2: the fixed prefix is not what this mode makes cheaper, and it must keep running —
     # ``begin`` is still called exactly once, before any formalization.
     units = {"deposits": ["a"], "admin": ["b"]}
-    order = [("deposits", "a"), ("admin", "b")]
+    order = [("0: deposits", "a"), ("1: admin", "b")]
     s = await _drive(
         monkeypatch, units, _Staged(), run_mode=RunMode.PRIORITIZED,
-        ranking=_ranking(("admin", "b"), [], order),
+        ranking=_ranking(("1: admin", "b"), [], order),
     )
     names = [c[0] for c in s.calls]
     assert names.count("begin") == 1 and names[0] == "begin"
@@ -348,7 +350,7 @@ async def test_ranking_does_not_wait_for_pre_formalization(monkeypatch):
     async def fake_rank(**_kw):
         order.append("rank")
         release.set()  # only now let the setup finish; if the driver awaited it first, we deadlock
-        return _ranking(("deposits", "a"), [], [("deposits", "a")])
+        return _ranking(("0: deposits", "a"), [], [("0: deposits", "a")])
 
     async def fake_report(*_a, **_kw): return object()
 

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -321,3 +321,49 @@ def test_a_skipped_focus_property_does_not_satisfy_the_focus():
 def test_an_unmapped_focus_property_does_not_satisfy_the_focus():
     assert not core._focus_satisfied(_Result(["a"]), _props("a", "b"))  # type: ignore[arg-type]
     assert not core._focus_satisfied(_Result([]), _props("a"))  # type: ignore[arg-type]
+
+
+async def test_ranking_does_not_wait_for_pre_formalization(monkeypatch):
+    """The ranking reads nothing ``prepare_formalization`` produces, so it must not queue
+    behind it. On a real contract that setup is hours of autosetup and invariant proving, and
+    the focus is knowable the moment extraction lands."""
+    order: list[str] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _SlowPrepared(_Prepared):
+        async def prepare_formalization(self, run):
+            order.append("prep:start")
+            started.set()
+            await release.wait()
+            order.append("prep:done")
+            return await super().prepare_formalization(run)
+
+    async def fake_analysis(*_a, **_kw): return "analyzed"
+
+    async def fake_extract_all(*_a, **_kw):
+        await started.wait()  # the setup is in flight, exactly as in a real run
+        return [core._Batch(_Unit("deposits", 0), [_prop("a")], _FeatCtx())]  # type: ignore[arg-type]
+
+    async def fake_rank(**_kw):
+        order.append("rank")
+        release.set()  # only now let the setup finish; if the driver awaited it first, we deadlock
+        return _ranking(("deposits", "a"), [], [("deposits", "a")])
+
+    async def fake_report(*_a, **_kw): return object()
+
+    monkeypatch.setattr(core, "run_component_analysis", fake_analysis)
+    monkeypatch.setattr(core, "_extract_all", fake_extract_all)
+    monkeypatch.setattr(core, "rank_properties", fake_rank)
+    monkeypatch.setattr(core, "build_report", fake_report)
+
+    run = _Run()
+    run.run_mode = RunMode.PRIORITIZED  # type: ignore[misc]
+    formalizer = _Staged()
+    backend = _Backend(_SlowPrepared(formalizer))
+    async with asyncio.timeout(5):
+        await run_pipeline(backend, run, max_bug_rounds=1, ecosystem=EVM)  # type: ignore[arg-type]
+
+    assert order == ["prep:start", "rank", "prep:done"], (
+        f"ranking must run while pre-formalization is still in flight; got {order}"
+    )

--- a/tests/test_prioritize.py
+++ b/tests/test_prioritize.py
@@ -1,17 +1,20 @@
 """The prioritized run's decision: how the focus is derived, and the guards around it.
 
 Everything here is LLM-free. The ranker's *judgement* cannot be tested, but the arithmetic that
-turns its scores into a focus can be, and so can the validation that stands between a bad
-structured-output response and a run that formalizes the wrong thing (or nothing).
+turns its scores into a focus can be, and so can the validation standing between a bad
+structured-output response and a run that proves the wrong thing (or nothing).
 """
 
 import pytest
 
 from composer.spec.prioritize import (
-    CRITICAL_MATCH_BONUS, MAX_SUPPORTING, Candidate, PropertyRanking, RankedProperty,
-    build_candidates, priority, select, validate_ranking,
+    CRITICAL_MATCH_BONUS, MAX_FOCUS_PROPERTIES, Candidate, PropertyGroup, PropertyRanking,
+    RankedProperty, build_candidates, priority, select, validate_ranking,
 )
 from composer.spec.types import ComponentName, PropertyFormulation, PropertyTitle
+
+VAULT = "0: Vault"
+FEES = "1: Fees"
 
 
 def _prop(title: str) -> PropertyFormulation:
@@ -25,162 +28,204 @@ def _cands() -> list[Candidate]:
     ])
 
 
-def _entry(comp, title, score, *, critical=False, deps=()):
+def _e(comp, title, score, *, critical=False):
     return RankedProperty(
         key=(ComponentName(comp), PropertyTitle(title)),
-        score=score, critical_match=critical,
-        depends_on=[PropertyTitle(d) for d in deps], rationale="r",
+        score=score, critical_match=critical, rationale="r",
     )
 
 
-def _ranking(*entries) -> PropertyRanking:
-    return PropertyRanking(ranked=list(entries), justification="j")
+def _g(claim, *keys):
+    return PropertyGroup(claim=claim, members=[(ComponentName(c), PropertyTitle(t)) for c, t in keys])
 
 
-def _all(**overrides) -> PropertyRanking:
-    """Every candidate scored, low by default, with named overrides."""
-    base = {
-        ("Vault", "solvency"): 40, ("Vault", "no_free_mint"): 30,
-        ("Vault", "shares_sane"): 20, ("Fees", "fee_bounded"): 10,
-    }
-    return _ranking(*[
-        overrides.get(f"{c}.{t}") or _entry(c, t, s) for (c, t), s in base.items()
-    ])
+def _ranking(entries, groups):
+    return PropertyRanking(ranked=entries, groups=groups, justification="j")
+
+
+def _default(**score_overrides):
+    """Every candidate scored low, each in its own group, with named score overrides."""
+    base = [(VAULT, "solvency"), (VAULT, "no_free_mint"), (VAULT, "shares_sane"), (FEES, "fee_bounded")]
+    entries = [_e(c, t, score_overrides.get(t, 10)) for c, t in base]
+    return _ranking(entries, [_g(f"claim:{t}", (c, t)) for c, t in base])
 
 
 # --- labels ---------------------------------------------------------------
 
 
-def test_labels_are_unique_even_against_a_component_named_like_a_suffix():
-    # Numbering repeats is not enough: a real component may already be called "Vault (2)", and a
-    # second "Vault" numbered by count would collide with it and resolve onto the wrong batch.
+def test_labels_carry_the_component_index():
+    # Two components can share a display name; the index is the stable id, so it goes in the
+    # label rather than an invented suffix.
     cands = build_candidates([
         (0, ComponentName("Vault"), [_prop("a")]),
         (3, ComponentName("Vault"), [_prop("b")]),
-        (7, ComponentName("Vault (2)"), [_prop("c")]),
-        (9, ComponentName("Vault"), [_prop("d")]),
     ])
-    labels = [c.label for c in cands]
-    assert len(set(labels)) == len(labels)
-    assert [c.unit_index for c in cands] == [0, 3, 7, 9]
+    assert [c.label for c in cands] == ["0: Vault", "3: Vault"]
+    assert [c.unit_index for c in cands] == [0, 3]
 
 
 # --- deriving the focus ---------------------------------------------------
 
 
-def test_the_focus_is_the_highest_priority_entry_wherever_it_sits_in_the_list():
-    # The ranking carries no "primary" field, so the artifact and the run cannot disagree: the
-    # focus is computed from the same scores the artifact records, in any order.
+def test_the_focus_is_the_group_holding_the_highest_scoring_property():
     cands = _cands()
-    r = _all(**{"Fees.fee_bounded": _entry("Fees", "fee_bounded", 90)})
+    r = _ranking(
+        [_e(VAULT, "solvency", 90), _e(VAULT, "no_free_mint", 80),
+         _e(VAULT, "shares_sane", 20), _e(FEES, "fee_bounded", 10)],
+        [_g("the vault stays solvent", (VAULT, "solvency"), (VAULT, "no_free_mint")),
+         _g("shares are sane", (VAULT, "shares_sane")),
+         _g("fees are bounded", (FEES, "fee_bounded"))],
+    )
     assert validate_ranking(cands, r) is None
     sel = select(cands, r)
-    assert sel.unit_index == 1 and sel.titles == ["fee_bounded"]
+    assert sel.unit_index == 0
+    assert sel.claim == "the vault stays solvent"
+    assert sel.titles == ["solvency", "no_free_mint"]
+
+
+def test_a_lower_scoring_property_rides_along_in_the_winning_group():
+    # The point of grouping: a property that would never win alone is pursued because it is part
+    # of the claim that did win.
+    cands = _cands()
+    r = _ranking(
+        [_e(VAULT, "solvency", 90), _e(VAULT, "shares_sane", 1),
+         _e(VAULT, "no_free_mint", 80), _e(FEES, "fee_bounded", 10)],
+        [_g("the vault stays solvent", (VAULT, "solvency"), (VAULT, "shares_sane")),
+         _g("no free mint", (VAULT, "no_free_mint")),
+         _g("fees", (FEES, "fee_bounded"))],
+    )
+    assert validate_ranking(cands, r) is None
+    assert select(cands, r).titles == ["solvency", "shares_sane"]
 
 
 def test_a_flagged_concern_wins_at_a_comparable_score():
     cands = _cands()
-    r = _all(**{
-        "Vault.solvency": _entry("Vault", "solvency", 40),
-        "Vault.no_free_mint": _entry("Vault", "no_free_mint", 30, critical=True),
-    })
+    r = _default(solvency=40)
+    r.ranked[1] = _e(VAULT, "no_free_mint", 30, critical=True)
     # 30 + 15 beats 40.
     assert select(cands, r).titles == ["no_free_mint"]
 
 
 def test_a_flagged_concern_does_not_drag_a_trivial_property_past_a_critical_one():
     cands = _cands()
-    r = _all(**{
-        "Vault.solvency": _entry("Vault", "solvency", 90),
-        "Vault.no_free_mint": _entry("Vault", "no_free_mint", 30, critical=True),
-    })
-    # The bonus is bounded, so a 60-point gap survives it.
+    r = _default(solvency=90)
+    r.ranked[1] = _e(VAULT, "no_free_mint", 30, critical=True)
     assert select(cands, r).titles == ["solvency"]
-    assert priority(_entry("x", "y", 30, critical=True)) == 30 + CRITICAL_MATCH_BONUS
+    assert priority(_e(VAULT, "x", 30, critical=True)) == 30 + CRITICAL_MATCH_BONUS
 
 
-def test_the_focus_pulls_in_what_the_winner_says_it_rests_on():
-    cands = _cands()
-    r = _all(**{
-        "Vault.solvency": _entry("Vault", "solvency", 90, deps=["shares_sane"]),
-    })
-    assert validate_ranking(cands, r) is None
-    # The primary leads; dependencies follow in the component's own order.
-    assert select(cands, r).titles == ["solvency", "shares_sane"]
-
-
-def test_only_the_winner_s_dependencies_are_pursued():
-    cands = _cands()
-    r = _all(**{
-        "Vault.solvency": _entry("Vault", "solvency", 90),
-        "Vault.no_free_mint": _entry("Vault", "no_free_mint", 30, deps=["shares_sane"]),
-    })
-    assert select(cands, r).titles == ["solvency"]
-
-
-def test_dependencies_are_deduplicated_and_never_repeat_the_primary():
-    cands = _cands()
-    r = _all(**{
-        "Vault.solvency": _entry(
-            "Vault", "solvency", 90, deps=["shares_sane", "shares_sane"],
-        ),
-    })
-    assert select(cands, r).titles == ["solvency", "shares_sane"]
-
-
-def test_the_batch_is_the_primary_plus_at_most_the_cap():
-    props = [_prop(f"p{i}") for i in range(MAX_SUPPORTING + 5)]
+def test_an_over_large_group_is_truncated_to_its_best_members(caplog):
+    props = [_prop(f"p{i}") for i in range(MAX_FOCUS_PROPERTIES + 3)]
     cands = build_candidates([(0, ComponentName("Vault"), props)])
-    r = _ranking(
-        _entry("Vault", "p0", 90, deps=[p.title for p in props[1:]]),
-        *[_entry("Vault", p.title, 10) for p in props[1:]],
-    )
+    label = "0: Vault"
+    entries = [_e(label, p.title, 100 - i) for i, p in enumerate(props)]
+    r = _ranking(entries, [_g("everything at once", *[(label, p.title) for p in props])])
     assert validate_ranking(cands, r) is None
-    assert len(select(cands, r).titles) == MAX_SUPPORTING + 1
+
+    sel = select(cands, r)
+    assert sel.titles == [p.title for p in props[:MAX_FOCUS_PROPERTIES]]
+    # Truncating means the claim is no longer established in full; that must not be silent.
+    assert any("not established in full" in rec.message for rec in caplog.records)
 
 
 def test_selection_never_yields_an_empty_batch():
-    # The driver raises "No properties extracted from any component" on an empty batch list, so the
-    # cut must always leave at least the primary standing.
-    cands = _cands()
-    sel = select(cands, _all())
-    assert sel.titles
+    # The driver raises "No properties extracted from any component" on an empty batch list.
+    assert select(_cands(), _default()).titles
 
 
 # --- validation -----------------------------------------------------------
 
 
-def test_a_dependency_from_another_component_is_rejected():
-    # D1: one component's batch survives, so a dependency elsewhere could never be formalized.
+def test_a_group_spanning_components_is_rejected():
+    # A run formalizes one component's batch, so a cross-component claim could not be pursued.
     cands = _cands()
-    r = _all(**{"Vault.solvency": _entry("Vault", "solvency", 90, deps=["fee_bounded"])})
+    r = _ranking(
+        [_e(VAULT, "solvency", 90), _e(VAULT, "no_free_mint", 10),
+         _e(VAULT, "shares_sane", 10), _e(FEES, "fee_bounded", 10)],
+        [_g("everything", (VAULT, "solvency"), (FEES, "fee_bounded")),
+         _g("rest", (VAULT, "no_free_mint"), (VAULT, "shares_sane"))],
+    )
     problem = validate_ranking(cands, r)
-    assert problem is not None and "same component" in problem
+    assert problem is not None and "spans components" in problem
 
 
-def test_a_self_dependency_is_rejected():
+def test_a_property_in_no_group_is_rejected():
     cands = _cands()
-    r = _all(**{"Vault.solvency": _entry("Vault", "solvency", 90, deps=["solvency"])})
+    r = _default()
+    r.groups = r.groups[:-1]
     problem = validate_ranking(cands, r)
-    assert problem is not None and "itself" in problem
+    assert problem is not None and "in no group" in problem
+
+
+def test_a_property_in_two_groups_is_rejected():
+    cands = _cands()
+    r = _default()
+    r.groups.append(_g("again", (VAULT, "solvency")))
+    problem = validate_ranking(cands, r)
+    assert problem is not None and "more than one group" in problem
 
 
 def test_a_missing_candidate_is_rejected():
     cands = _cands()
-    r = _ranking(_entry("Vault", "solvency", 40))
+    r = _default()
+    r.ranked = r.ranked[:-1]
     problem = validate_ranking(cands, r)
     assert problem is not None and "missing from `ranked`" in problem
 
 
-def test_a_duplicated_candidate_is_rejected():
-    cands = _cands()
-    r = _ranking(*_all().ranked, _entry("Vault", "solvency", 40))
-    problem = validate_ranking(cands, r)
-    assert problem is not None and "more than once" in problem
-
-
 def test_an_invented_property_is_rejected():
     cands = _cands()
-    r = _ranking(*_all().ranked, _entry("Vault", "not_a_real_property", 99))
+    r = _default()
+    r.ranked.append(_e(VAULT, "not_a_real_property", 99))
+    r.groups.append(_g("invented", (VAULT, "not_a_real_property")))
     problem = validate_ranking(cands, r)
     assert problem is not None and "not in the candidate listing" in problem
+
+
+def test_every_problem_is_reported_at_once():
+    # One error per attempt would run out of attempts before it ran out of mistakes.
+    cands = _cands()
+    r = _default()
+    r.ranked = r.ranked[:-1]          # a candidate missing from `ranked`
+    r.groups = r.groups[:-1]          # and the same one in no group
+    r.ranked.append(_e(VAULT, "invented", 50))
+    r.groups.append(_g("invented", (VAULT, "invented")))
+    problem = validate_ranking(cands, r)
+    assert problem is not None
+    assert "not in the candidate listing" in problem
+    assert "missing from `ranked`" in problem
+    assert "in no group" in problem
+
+
+# --- the retry -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_retry_shows_the_model_what_it_produced():
+    """Structured output hands back a parsed object and leaves no assistant turn behind, so
+    without replaying it the model is asked to fix a ranking it has no memory of making."""
+    import composer.spec.prioritize as prioritize
+
+    cands = _cands()
+    bad = _default()
+    bad.ranked = bad.ranked[:-1]          # a candidate missing from `ranked`
+    good = _default()
+    seen: list[list] = []
+
+    class _Bound:
+        async def ainvoke(self, messages):
+            seen.append(list(messages))
+            return bad if len(seen) == 1 else good
+
+    class _LLM:
+        def with_structured_output(self, _ty): return _Bound()
+
+    out = await prioritize.rank_properties(
+        llm=_LLM(), contract_name="Vault", candidates=cands,  # type: ignore[arg-type]
+        design_doc=None, threat_model=None, extra_context=[],
+    )
+    assert out is good
+    assert len(seen) == 2, "the invalid ranking should have been retried"
+
+    replayed = "".join(str(m.content) for m in seen[1])
+    assert "solvency" in replayed and "missing from `ranked`" in replayed

--- a/tests/test_prioritize.py
+++ b/tests/test_prioritize.py
@@ -8,7 +8,7 @@ structured-output response and a run that proves the wrong thing (or nothing).
 import pytest
 
 from composer.spec.prioritize import (
-    CRITICAL_MATCH_BONUS, MAX_FOCUS_PROPERTIES, Candidate, PropertyGroup, PropertyRanking,
+    CRITICAL_MATCH_BONUS, Candidate, PropertyGroup, PropertyRanking,
     RankedProperty, build_candidates, priority, select, validate_ranking,
 )
 from composer.spec.types import ComponentName, PropertyFormulation, PropertyTitle
@@ -114,18 +114,36 @@ def test_a_flagged_concern_does_not_drag_a_trivial_property_past_a_critical_one(
     assert priority(_e(VAULT, "x", 30, critical=True)) == 30 + CRITICAL_MATCH_BONUS
 
 
-def test_an_over_large_group_is_truncated_to_its_best_members(caplog):
-    props = [_prop(f"p{i}") for i in range(MAX_FOCUS_PROPERTIES + 3)]
+def test_a_large_group_is_pursued_whole():
+    # The claim is the unit of work: every property stating it is formalized, however many that
+    # is. Dropping the tail would spend most of the budget and leave the claim open.
+    props = [_prop(f"p{i}") for i in range(6)]
     cands = build_candidates([(0, ComponentName("Vault"), props)])
     label = "0: Vault"
     entries = [_e(label, p.title, 100 - i) for i, p in enumerate(props)]
     r = _ranking(entries, [_g("everything at once", *[(label, p.title) for p in props])])
     assert validate_ranking(cands, r) is None
 
-    sel = select(cands, r)
-    assert sel.titles == [p.title for p in props[:MAX_FOCUS_PROPERTIES]]
-    # Truncating means the claim is no longer established in full; that must not be silent.
-    assert any("not established in full" in rec.message for rec in caplog.records)
+    assert select(cands, r).titles == [p.title for p in props]
+
+
+def test_a_low_scoring_member_of_the_winning_group_is_still_pursued():
+    # The shape that motivated dropping the cap: the claim's own conclusion, outscored by the
+    # properties it depends on because they carry critical_match. It is in the group, so it is
+    # pursued.
+    props = [_prop("identity"), _prop("ledger_sums"), _prop("no_over_burn"), _prop("redemption")]
+    cands = build_candidates([(0, ComponentName("Vault"), props)])
+    label = "0: Vault"
+    entries = [
+        _e(label, "identity", 100, critical=True),
+        _e(label, "ledger_sums", 92, critical=True),
+        _e(label, "no_over_burn", 90, critical=True),
+        _e(label, "redemption", 95),
+    ]
+    r = _ranking(entries, [_g("solvency", *[(label, p.title) for p in props])])
+    assert validate_ranking(cands, r) is None
+
+    assert set(select(cands, r).titles) == {p.title for p in props}
 
 
 def test_selection_never_yields_an_empty_batch():

--- a/tests/test_prioritize.py
+++ b/tests/test_prioritize.py
@@ -1,0 +1,137 @@
+"""The prioritized run's decision: ranking validation and the cut it makes.
+
+Everything here is LLM-free — the ranker's *judgement* cannot be tested, but the guards
+around it can, and those are what stand between a bad structured-output response and a run
+that formalizes the wrong thing (or nothing).
+"""
+
+import pytest
+
+from composer.spec.prioritize import (
+    MAX_SUPPORTING, Candidate, PropertyRanking, RankedProperty, build_candidates, select,
+    validate_ranking,
+)
+from composer.spec.types import ComponentName, PropertyFormulation, PropertyTitle
+
+
+def _prop(title: str) -> PropertyFormulation:
+    return PropertyFormulation(title=PropertyTitle(title), sort="invariant", description=f"d:{title}")
+
+
+def _cands() -> list[Candidate]:
+    return build_candidates([
+        (0, ComponentName("Vault"), [_prop("solvency"), _prop("no_free_mint"), _prop("shares_sane")]),
+        (1, ComponentName("Fees"), [_prop("fee_bounded")]),
+    ])
+
+
+def _ranking(
+    order: list[tuple[str, str]],
+    primary: tuple[str, str],
+    supporting: list[tuple[str, str]],
+) -> PropertyRanking:
+    return PropertyRanking(
+        ranked=[
+            RankedProperty(
+                key=(ComponentName(c), PropertyTitle(t)),
+                score=100 - i, critical_match=False, rationale="r",
+            )
+            for i, (c, t) in enumerate(order)
+        ],
+        primary=(ComponentName(primary[0]), PropertyTitle(primary[1])),
+        supporting=[(ComponentName(c), PropertyTitle(t)) for c, t in supporting],
+        justification="j",
+    )
+
+
+ALL = [("Vault", "solvency"), ("Vault", "no_free_mint"), ("Vault", "shares_sane"), ("Fees", "fee_bounded")]
+
+
+def test_components_sharing_a_name_get_distinct_labels():
+    # Component display names come from the analysis LLM under no uniqueness constraint, so
+    # resolving a ranking by name alone could land on the wrong component's batch.
+    cands = build_candidates([
+        (0, ComponentName("Vault"), [_prop("a")]),
+        (3, ComponentName("Vault"), [_prop("b")]),
+        (7, ComponentName("Fees"), [_prop("c")]),
+    ])
+    assert [c.label for c in cands] == ["Vault", "Vault (2)", "Fees"]
+    assert [c.unit_index for c in cands] == [0, 3, 7]
+
+
+def test_a_well_formed_ranking_validates_and_selects_the_focus():
+    cands = _cands()
+    r = _ranking(ALL, ("Vault", "solvency"), [("Vault", "shares_sane")])
+    assert validate_ranking(cands, r) is None
+
+    sel = select(cands, r)
+    assert sel.unit_index == 0
+    # The primary leads; the rest follow in the component's own order.
+    assert sel.titles == ["solvency", "shares_sane"]
+
+
+def test_supporting_is_deduplicated_and_never_repeats_the_primary():
+    cands = _cands()
+    r = _ranking(
+        ALL, ("Vault", "solvency"),
+        [("Vault", "shares_sane"), ("Vault", "shares_sane"), ("Vault", "solvency")],
+    )
+    assert validate_ranking(cands, r) is None
+    assert select(cands, r).titles == ["solvency", "shares_sane"]
+
+
+def test_supporting_is_capped():
+    props = [_prop(f"p{i}") for i in range(MAX_SUPPORTING + 5)]
+    cands = build_candidates([(0, ComponentName("Vault"), props)])
+    order = [("Vault", p.title) for p in props]
+    r = _ranking(order, ("Vault", "p0"), [("Vault", p.title) for p in props[1:]])
+    assert validate_ranking(cands, r) is None
+    # The cap bounds the *supporting* cluster; the primary is always kept on top of it.
+    assert len(select(cands, r).titles) == MAX_SUPPORTING + 1
+
+
+def test_supporting_from_another_component_is_rejected():
+    # D1: one component's batch survives. A supporting property elsewhere cannot ride along,
+    # because nothing would formalize it.
+    cands = _cands()
+    r = _ranking(ALL, ("Vault", "solvency"), [("Fees", "fee_bounded")])
+    problem = validate_ranking(cands, r)
+    assert problem is not None and "different component" in problem
+
+
+def test_a_missing_candidate_is_rejected():
+    cands = _cands()
+    r = _ranking(ALL[:-1], ("Vault", "solvency"), [])
+    problem = validate_ranking(cands, r)
+    assert problem is not None and "missing from `ranked`" in problem
+
+
+def test_a_duplicated_candidate_is_rejected():
+    cands = _cands()
+    r = _ranking(ALL + [("Vault", "solvency")], ("Vault", "solvency"), [])
+    problem = validate_ranking(cands, r)
+    assert problem is not None and "more than once" in problem
+
+
+def test_an_invented_property_is_rejected():
+    cands = _cands()
+    r = _ranking(ALL + [("Vault", "not_a_real_property")], ("Vault", "solvency"), [])
+    problem = validate_ranking(cands, r)
+    assert problem is not None and "not in the candidate listing" in problem
+
+
+def test_an_unresolvable_primary_is_rejected():
+    cands = _cands()
+    r = _ranking(ALL, ("Fees", "solvency"), [])
+    problem = validate_ranking(cands, r)
+    assert problem is not None and "primary" in problem
+
+
+def test_selection_never_yields_an_empty_batch():
+    # The driver raises "No properties extracted from any component" on an empty batch list, so
+    # the cut must always leave at least the primary standing.
+    cands = _cands()
+    r = _ranking(ALL, ("Fees", "fee_bounded"), [])
+    assert validate_ranking(cands, r) is None
+    sel = select(cands, r)
+    assert sel.unit_index == 1 and sel.titles == ["fee_bounded"]

--- a/tests/test_prioritize.py
+++ b/tests/test_prioritize.py
@@ -1,15 +1,15 @@
-"""The prioritized run's decision: ranking validation and the cut it makes.
+"""The prioritized run's decision: how the focus is derived, and the guards around it.
 
-Everything here is LLM-free — the ranker's *judgement* cannot be tested, but the guards
-around it can, and those are what stand between a bad structured-output response and a run
-that formalizes the wrong thing (or nothing).
+Everything here is LLM-free. The ranker's *judgement* cannot be tested, but the arithmetic that
+turns its scores into a focus can be, and so can the validation that stands between a bad
+structured-output response and a run that formalizes the wrong thing (or nothing).
 """
 
 import pytest
 
 from composer.spec.prioritize import (
-    MAX_SUPPORTING, Candidate, PropertyRanking, RankedProperty, build_candidates, select,
-    validate_ranking,
+    CRITICAL_MATCH_BONUS, MAX_SUPPORTING, Candidate, PropertyRanking, RankedProperty,
+    build_candidates, priority, select, validate_ranking,
 )
 from composer.spec.types import ComponentName, PropertyFormulation, PropertyTitle
 
@@ -25,113 +25,162 @@ def _cands() -> list[Candidate]:
     ])
 
 
-def _ranking(
-    order: list[tuple[str, str]],
-    primary: tuple[str, str],
-    supporting: list[tuple[str, str]],
-) -> PropertyRanking:
-    return PropertyRanking(
-        ranked=[
-            RankedProperty(
-                key=(ComponentName(c), PropertyTitle(t)),
-                score=100 - i, critical_match=False, rationale="r",
-            )
-            for i, (c, t) in enumerate(order)
-        ],
-        primary=(ComponentName(primary[0]), PropertyTitle(primary[1])),
-        supporting=[(ComponentName(c), PropertyTitle(t)) for c, t in supporting],
-        justification="j",
+def _entry(comp, title, score, *, critical=False, deps=()):
+    return RankedProperty(
+        key=(ComponentName(comp), PropertyTitle(title)),
+        score=score, critical_match=critical,
+        depends_on=[PropertyTitle(d) for d in deps], rationale="r",
     )
 
 
-ALL = [("Vault", "solvency"), ("Vault", "no_free_mint"), ("Vault", "shares_sane"), ("Fees", "fee_bounded")]
+def _ranking(*entries) -> PropertyRanking:
+    return PropertyRanking(ranked=list(entries), justification="j")
 
 
-def test_components_sharing_a_name_get_distinct_labels():
-    # Component display names come from the analysis LLM under no uniqueness constraint, so
-    # resolving a ranking by name alone could land on the wrong component's batch.
+def _all(**overrides) -> PropertyRanking:
+    """Every candidate scored, low by default, with named overrides."""
+    base = {
+        ("Vault", "solvency"): 40, ("Vault", "no_free_mint"): 30,
+        ("Vault", "shares_sane"): 20, ("Fees", "fee_bounded"): 10,
+    }
+    return _ranking(*[
+        overrides.get(f"{c}.{t}") or _entry(c, t, s) for (c, t), s in base.items()
+    ])
+
+
+# --- labels ---------------------------------------------------------------
+
+
+def test_labels_are_unique_even_against_a_component_named_like_a_suffix():
+    # Numbering repeats is not enough: a real component may already be called "Vault (2)", and a
+    # second "Vault" numbered by count would collide with it and resolve onto the wrong batch.
     cands = build_candidates([
         (0, ComponentName("Vault"), [_prop("a")]),
         (3, ComponentName("Vault"), [_prop("b")]),
-        (7, ComponentName("Fees"), [_prop("c")]),
+        (7, ComponentName("Vault (2)"), [_prop("c")]),
+        (9, ComponentName("Vault"), [_prop("d")]),
     ])
-    assert [c.label for c in cands] == ["Vault", "Vault (2)", "Fees"]
-    assert [c.unit_index for c in cands] == [0, 3, 7]
+    labels = [c.label for c in cands]
+    assert len(set(labels)) == len(labels)
+    assert [c.unit_index for c in cands] == [0, 3, 7, 9]
 
 
-def test_a_well_formed_ranking_validates_and_selects_the_focus():
+# --- deriving the focus ---------------------------------------------------
+
+
+def test_the_focus_is_the_highest_priority_entry_wherever_it_sits_in_the_list():
+    # The ranking carries no "primary" field, so the artifact and the run cannot disagree: the
+    # focus is computed from the same scores the artifact records, in any order.
     cands = _cands()
-    r = _ranking(ALL, ("Vault", "solvency"), [("Vault", "shares_sane")])
+    r = _all(**{"Fees.fee_bounded": _entry("Fees", "fee_bounded", 90)})
     assert validate_ranking(cands, r) is None
-
     sel = select(cands, r)
-    assert sel.unit_index == 0
-    # The primary leads; the rest follow in the component's own order.
-    assert sel.titles == ["solvency", "shares_sane"]
+    assert sel.unit_index == 1 and sel.titles == ["fee_bounded"]
 
 
-def test_supporting_is_deduplicated_and_never_repeats_the_primary():
+def test_a_flagged_concern_wins_at_a_comparable_score():
     cands = _cands()
-    r = _ranking(
-        ALL, ("Vault", "solvency"),
-        [("Vault", "shares_sane"), ("Vault", "shares_sane"), ("Vault", "solvency")],
-    )
+    r = _all(**{
+        "Vault.solvency": _entry("Vault", "solvency", 40),
+        "Vault.no_free_mint": _entry("Vault", "no_free_mint", 30, critical=True),
+    })
+    # 30 + 15 beats 40.
+    assert select(cands, r).titles == ["no_free_mint"]
+
+
+def test_a_flagged_concern_does_not_drag_a_trivial_property_past_a_critical_one():
+    cands = _cands()
+    r = _all(**{
+        "Vault.solvency": _entry("Vault", "solvency", 90),
+        "Vault.no_free_mint": _entry("Vault", "no_free_mint", 30, critical=True),
+    })
+    # The bonus is bounded, so a 60-point gap survives it.
+    assert select(cands, r).titles == ["solvency"]
+    assert priority(_entry("x", "y", 30, critical=True)) == 30 + CRITICAL_MATCH_BONUS
+
+
+def test_the_focus_pulls_in_what_the_winner_says_it_rests_on():
+    cands = _cands()
+    r = _all(**{
+        "Vault.solvency": _entry("Vault", "solvency", 90, deps=["shares_sane"]),
+    })
     assert validate_ranking(cands, r) is None
+    # The primary leads; dependencies follow in the component's own order.
     assert select(cands, r).titles == ["solvency", "shares_sane"]
 
 
-def test_supporting_is_capped():
+def test_only_the_winner_s_dependencies_are_pursued():
+    cands = _cands()
+    r = _all(**{
+        "Vault.solvency": _entry("Vault", "solvency", 90),
+        "Vault.no_free_mint": _entry("Vault", "no_free_mint", 30, deps=["shares_sane"]),
+    })
+    assert select(cands, r).titles == ["solvency"]
+
+
+def test_dependencies_are_deduplicated_and_never_repeat_the_primary():
+    cands = _cands()
+    r = _all(**{
+        "Vault.solvency": _entry(
+            "Vault", "solvency", 90, deps=["shares_sane", "shares_sane"],
+        ),
+    })
+    assert select(cands, r).titles == ["solvency", "shares_sane"]
+
+
+def test_the_batch_is_the_primary_plus_at_most_the_cap():
     props = [_prop(f"p{i}") for i in range(MAX_SUPPORTING + 5)]
     cands = build_candidates([(0, ComponentName("Vault"), props)])
-    order = [("Vault", p.title) for p in props]
-    r = _ranking(order, ("Vault", "p0"), [("Vault", p.title) for p in props[1:]])
+    r = _ranking(
+        _entry("Vault", "p0", 90, deps=[p.title for p in props[1:]]),
+        *[_entry("Vault", p.title, 10) for p in props[1:]],
+    )
     assert validate_ranking(cands, r) is None
-    # The cap bounds the *supporting* cluster; the primary is always kept on top of it.
     assert len(select(cands, r).titles) == MAX_SUPPORTING + 1
 
 
-def test_supporting_from_another_component_is_rejected():
-    # D1: one component's batch survives. A supporting property elsewhere cannot ride along,
-    # because nothing would formalize it.
+def test_selection_never_yields_an_empty_batch():
+    # The driver raises "No properties extracted from any component" on an empty batch list, so the
+    # cut must always leave at least the primary standing.
     cands = _cands()
-    r = _ranking(ALL, ("Vault", "solvency"), [("Fees", "fee_bounded")])
+    sel = select(cands, _all())
+    assert sel.titles
+
+
+# --- validation -----------------------------------------------------------
+
+
+def test_a_dependency_from_another_component_is_rejected():
+    # D1: one component's batch survives, so a dependency elsewhere could never be formalized.
+    cands = _cands()
+    r = _all(**{"Vault.solvency": _entry("Vault", "solvency", 90, deps=["fee_bounded"])})
     problem = validate_ranking(cands, r)
-    assert problem is not None and "different component" in problem
+    assert problem is not None and "same component" in problem
+
+
+def test_a_self_dependency_is_rejected():
+    cands = _cands()
+    r = _all(**{"Vault.solvency": _entry("Vault", "solvency", 90, deps=["solvency"])})
+    problem = validate_ranking(cands, r)
+    assert problem is not None and "itself" in problem
 
 
 def test_a_missing_candidate_is_rejected():
     cands = _cands()
-    r = _ranking(ALL[:-1], ("Vault", "solvency"), [])
+    r = _ranking(_entry("Vault", "solvency", 40))
     problem = validate_ranking(cands, r)
     assert problem is not None and "missing from `ranked`" in problem
 
 
 def test_a_duplicated_candidate_is_rejected():
     cands = _cands()
-    r = _ranking(ALL + [("Vault", "solvency")], ("Vault", "solvency"), [])
+    r = _ranking(*_all().ranked, _entry("Vault", "solvency", 40))
     problem = validate_ranking(cands, r)
     assert problem is not None and "more than once" in problem
 
 
 def test_an_invented_property_is_rejected():
     cands = _cands()
-    r = _ranking(ALL + [("Vault", "not_a_real_property")], ("Vault", "solvency"), [])
+    r = _ranking(*_all().ranked, _entry("Vault", "not_a_real_property", 99))
     problem = validate_ranking(cands, r)
     assert problem is not None and "not in the candidate listing" in problem
-
-
-def test_an_unresolvable_primary_is_rejected():
-    cands = _cands()
-    r = _ranking(ALL, ("Fees", "solvency"), [])
-    problem = validate_ranking(cands, r)
-    assert problem is not None and "primary" in problem
-
-
-def test_selection_never_yields_an_empty_batch():
-    # The driver raises "No properties extracted from any component" on an empty batch list, so
-    # the cut must always leave at least the primary standing.
-    cands = _cands()
-    r = _ranking(ALL, ("Fees", "fee_bounded"), [])
-    assert validate_ranking(cands, r) is None
-    sel = select(cands, r)
-    assert sel.unit_index == 1 and sel.titles == ["fee_bounded"]


### PR DESCRIPTION
## Why

Today there is nono guaranteed correlation between the effort put by the agent and the value of the output. Property inference fans out per
component, every property it invents gets the full CVL authoring + prover + counterexample
treatment, and `budget_integration.md` already names `formalization` the dominant cost. That phase
scales with (components x properties), so an inference agent that thinks of forty properties bills
for forty.

## What

Today's behaviour becomes run mode `comprehensive` and stays the default. `prioritized` ranks every
candidate property across every component once, then spends the run on the highest-contribution
property plus the properties needed to state or discharge it. One property, pursued properly,
instead of everything pursued shallowly.

Concretely, a prioritized batch is the primary property plus **at most two** dependencies drawn from
its own component. All three are first-class: the feedback judge demands rules for each, they count
in the report, and all of them are skip-protected. The model does not pick the primary. It scores
every candidate and records what each rests on; `priority = score + 15 if critical_match` is applied
in code, so `property_ranking.json` and the property the run actually spends itself on are the same
thing by construction.

The insertion point is one seam in `composer/pipeline/core.py`, between `_extract_all` and
`staged.begin`. That is the first and only point where every component's candidates exist together:
inference never sees more than the unit it was given, and the per-component plugin hook cannot
compare across units either.

## How it is turned on

`--run-mode prioritized`, or `AUTOPROVER_RUN_MODE=prioritized`.

The value rides on `PipelineRun`, which the driver and the CVL author both already hold, so
`run_pipeline` and the backend protocols needed no new parameter.

## The ranking is not trusted

A single structured call, cached under the properties namespace, validated in Python before anything
acts on it: every candidate ranked exactly once, no invented keys, and every `depends_on` naming a
property of its own component. An unusable ranking raises rather than falling back to the whole
candidate set, because a silent widening would spend exactly what this mode exists to save. The
failure is cheap anyway, since nothing has been formalized yet.

## The author may not walk away

Two escape hatches would each be a total loss when the run is one property, so both tighten:
`record_skip` refuses the focus properties, and `give_up` rejects an `exhausted` stop until the
prover has actually been run a few times, with the attempts enumerated.

Two escapes are deliberate, and both are the difference between a gate and a deadlock:

- `sort='environment'` is never gated. A missing `certoraRun` or `solc` produces no prover run at
  all, so a bare attempt floor would be unsatisfiable and would hold the agent against its recursion
  limit instead of letting it report a broken toolchain.
- The budget monitor's wrap-up lifts the skip protection. Its order is "delete what does not work,
  skip the rest, publish", which is exactly what the protection forbids.

The floor counts `verify_spec` tool calls rather than `prover_history`. `prover_history` only grows
when the prover returns a report, and `verify_spec` returns early with a bare string when the spec
will not type-check, which is the failure most worth escalating through.

## The output says what it did not look at

A prioritized `report.json` would otherwise be indistinguishable from a contract with three
properties. So `report.json` carries `run_mode` and the deprioritized properties with their scores
and rationales, `coverage` carries a `deprioritized_count` and a warning, the full ranking is written
to `property_ranking.json`, and `job_info.json` records the mode on every path including a crash.

## What does not get cheaper

`prepare_formalization` is untouched, so the harness lift,
AutoSetup, custom summaries, structural invariants **and the invariant CVL/prover loop** cost exactly
what they cost today, as does per-component property inference (it has to run before anything can be
ranked). The saving is the formalization fan-out, which is the dominant cost. Two more caveats: in
`--cloud` mode components already verify in parallel, so the wall-clock win is smaller than the money
win, and a `GaveUp` is never cached, so a prioritized run against a genuinely unprovable property is
the worst case for this design.

## Scope

Prover flow only. The foundry and rust-app entry points keep their own parsers and do not expose the
flag, because the focus protections live in the CVL author: a prioritized foundry run would get the
narrowing without the discipline, which is the worst of both.

## Also in here

`FINAL_PROPERTIES_KEY` now forks on the mode. Its leaf was fixed apart from the threat-model,
interactive and extra-context parameters, so a prioritized run would have overwritten a
comprehensive run's record for the same component with its one-property batch, and an offline walker
would have read the pruned list as if it were everything inference found.

## Testing

`tests/test_prioritize.py` covers the validation and the cut, including that a supporting property
from another component is rejected and that the selection can never return an empty batch list (the
driver raises on that). `tests/test_focus_exits.py` covers the gate and the skip protection on
**both** binding paths, since the author reaches its skip tools either through `skip_tools` directly
or through `property_tools`, and a protection on only one is silently bypassable. Driver-level tests
in `tests/test_pipeline_staged_formalizer.py` prove one batch reaches formalization, that `begin`
still runs once beforehand, and that the ranker never runs in comprehensive mode.

`pytest -m "not expensive"`: 1126 passed. `pyright`: 0 errors. The 21 errors in the suite are a local
`pgvector` testcontainer that will not stay up; they are in `test_rag_db` / `test_indexed_tool` and
predate this branch.

## Not validated here

The ranker's judgement. The mechanism is tested; whether it picks the right property is what the
first real runs are for, and `property_ranking.json` is the artifact to read when checking that.

