### PR TITLE
Check that declared source paths exist during component analysis

### DIFF
--- a/composer/cli/natspec_startup.py
+++ b/composer/cli/natspec_startup.py
@@ -25,6 +25,7 @@ _StubTemplate = PartialTemplate[PathChoosingConf, StubGenCallParams]("stub_gener
 def build_mental_model(
     *,
     source_root: pathlib.Path | None,
+    forbidden_read: GlobalExcludeArg,
     config_init: dict | None,
 ) -> MentalModel:
     # In from-source (update) mode the agent picks file locations to fit the
@@ -50,6 +51,7 @@ def build_mental_model(
                 prompt=stub_prompt,
             ),
             source_root=source_root,
+            forbidden_read=forbidden_read,
             config_init=config_init,
         )
     return MentalModel(

--- a/composer/cli/tui_pipeline.py
+++ b/composer/cli/tui_pipeline.py
@@ -195,6 +195,7 @@ async def _main() -> int:
 
             mental_model = build_mental_model(
                 source_root=source_root_path,
+                forbidden_read=forbidden_read,
                 config_init=config_init,
             )
 

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -32,6 +32,7 @@ import enum
 import functools
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import (
     Protocol, Any, ClassVar, Concatenate, cast, Awaitable, Sequence, Callable, ContextManager, overload
 )
@@ -495,6 +496,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                     input=source, env=run.env,
                     extra_input=[*ecosystem.analysis_extra_input(source), *spec.extra_input],
                     expected_main_id=source.contract_name,
+                    project_root=Path(source.project_root),
                     system_template=ecosystem.analysis_prompts.system,
                     initial_template=ecosystem.analysis_prompts.initial,
                     validate=ecosystem.validate_analysis,

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -497,6 +497,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                     extra_input=[*ecosystem.analysis_extra_input(source), *spec.extra_input],
                     expected_main_id=source.contract_name,
                     project_root=Path(source.project_root),
+                    forbidden_read=source.forbidden_read,
                     system_template=ecosystem.analysis_prompts.system,
                     initial_template=ecosystem.analysis_prompts.initial,
                     validate=ecosystem.validate_analysis,

--- a/composer/pipeline/ecosystem.py
+++ b/composer/pipeline/ecosystem.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any, Callable, Collection, Literal, Mapping, TypedDict
 
+from graphcore.tools.vfs import GlobalExcludeArg
+
 from composer.spec.context import SourceCode
 from composer.spec.code_explorer import CodeExplorerPromptParams
 from composer.spec.gen_types import TypedTemplate
@@ -132,10 +134,13 @@ class Ecosystem[App: BaseApplication, Main, Unit: FeatureUnit]:
     analysis_prompts: PromptPair[AnalysisPromptParams, AnalysisPromptParams]
     #: Prompts for the per-component property-inference agent.
     property_prompts: PropertyPrompts[Unit]
-    #: Connectivity/shape validation of the analyzed model (retry feedback on failure). The third
-    #: argument is the project root any source paths the model carries are relative to, and is
-    #: ``None`` when the run has no source tree; an ecosystem whose model carries no paths ignores it.
-    validate_analysis: Callable[[App, SourceIdentifier | None, Path | None], str | None]
+    #: Connectivity/shape validation of the analyzed model (retry feedback on failure). The last
+    #: two arguments are the source surface any paths the model carries are read in: the project
+    #: root, ``None`` when the run has no source tree, and the ``forbidden_read`` that root is
+    #: served through. An ecosystem whose model carries no paths ignores both.
+    validate_analysis: Callable[
+        [App, SourceIdentifier | None, Path | None, GlobalExcludeArg], str | None
+    ]
     #: Locate the target unit (the "main contract"/program) in the analyzed model.
     locate_main: Callable[[App, SourceCode], Main]
     #: Enumerate the units the extraction phase infers properties for — one batch per unit. Both
@@ -336,7 +341,10 @@ def _validate_program_components(prog: SolanaProgram) -> list[str]:
 
 
 def _solana_validate(
-    app: SolanaApplication, expected_main: SourceIdentifier | None, _project_root: Path | None
+    app: SolanaApplication,
+    expected_main: SourceIdentifier | None,
+    _project_root: Path | None,
+    _forbidden_read: GlobalExcludeArg,
 ) -> str | None:
     """Connectivity/shape validation for a ``SolanaApplication`` (retry feedback on failure).
 
@@ -344,9 +352,9 @@ def _solana_validate(
     ``Callable[[App, ...]]``, so the seam already guarantees the model came from *this* ecosystem's
     ``system_model``. An earlier version narrowed at runtime and returned ``None`` for a foreign
     application; that silently passed a model this function cannot check, and the parameter type is
-    what makes the case unreachable instead. The project root is part of the seam because a Solidity
-    model's components carry source file paths to check; nothing in the Solana model does, so it is
-    unused here.
+    what makes the case unreachable instead. The source surface is part of the seam because a
+    Solidity model's components carry source file paths to check; nothing in the Solana model does,
+    so it is unused here.
     Mirrors the EVM ``validate_solidity_connectivity`` structure: unique program identifiers and names,
     unique instruction slugs within a program, unique component names/slugs within a program, the
     component↔instruction mapping valid and total, component interactions resolving, and the
@@ -553,7 +561,10 @@ def _validate_contract_components(contract: SorobanContract) -> list[str]:
 
 
 def _soroban_validate(
-    app: SorobanApplication, expected_main: SourceIdentifier | None, _project_root: Path | None
+    app: SorobanApplication,
+    expected_main: SourceIdentifier | None,
+    _project_root: Path | None,
+    _forbidden_read: GlobalExcludeArg,
 ) -> str | None:
     errors: list[str] = []
     known_identifiers: set[str] = set()

--- a/composer/pipeline/ecosystem.py
+++ b/composer/pipeline/ecosystem.py
@@ -15,7 +15,7 @@ Solana model + prompts and reuses the shared ``RUST`` language facet. See ``docs
 """
 
 from dataclasses import dataclass
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from typing import Any, Callable, Collection, Literal, Mapping, TypedDict
 
 from composer.spec.context import SourceCode
@@ -132,8 +132,10 @@ class Ecosystem[App: BaseApplication, Main, Unit: FeatureUnit]:
     analysis_prompts: PromptPair[AnalysisPromptParams, AnalysisPromptParams]
     #: Prompts for the per-component property-inference agent.
     property_prompts: PropertyPrompts[Unit]
-    #: Connectivity/shape validation of the analyzed model (retry feedback on failure).
-    validate_analysis: Callable[[App, SourceIdentifier | None], str | None]
+    #: Connectivity/shape validation of the analyzed model (retry feedback on failure). The third
+    #: argument is the project root any source paths the model carries are relative to, and is
+    #: ``None`` when the run has no source tree; an ecosystem whose model carries no paths ignores it.
+    validate_analysis: Callable[[App, SourceIdentifier | None, Path | None], str | None]
     #: Locate the target unit (the "main contract"/program) in the analyzed model.
     locate_main: Callable[[App, SourceCode], Main]
     #: Enumerate the units the extraction phase infers properties for — one batch per unit. Both
@@ -333,14 +335,18 @@ def _validate_program_components(prog: SolanaProgram) -> list[str]:
     return errors
 
 
-def _solana_validate(app: SolanaApplication, expected_main: SourceIdentifier | None) -> str | None:
+def _solana_validate(
+    app: SolanaApplication, expected_main: SourceIdentifier | None, _project_root: Path | None
+) -> str | None:
     """Connectivity/shape validation for a ``SolanaApplication`` (retry feedback on failure).
 
     Typed over ``SolanaApplication``, not ``BaseApplication``: ``Ecosystem.validate_analysis`` is
     ``Callable[[App, ...]]``, so the seam already guarantees the model came from *this* ecosystem's
     ``system_model``. An earlier version narrowed at runtime and returned ``None`` for a foreign
     application; that silently passed a model this function cannot check, and the parameter type is
-    what makes the case unreachable instead.
+    what makes the case unreachable instead. The project root is part of the seam because a Solidity
+    model's components carry source file paths to check; nothing in the Solana model does, so it is
+    unused here.
     Mirrors the EVM ``validate_solidity_connectivity`` structure: unique program identifiers and names,
     unique instruction slugs within a program, unique component names/slugs within a program, the
     component↔instruction mapping valid and total, component interactions resolving, and the
@@ -547,7 +553,7 @@ def _validate_contract_components(contract: SorobanContract) -> list[str]:
 
 
 def _soroban_validate(
-    app: SorobanApplication, expected_main: SourceIdentifier | None
+    app: SorobanApplication, expected_main: SourceIdentifier | None, _project_root: Path | None
 ) -> str | None:
     errors: list[str] = []
     known_identifiers: set[str] = set()

--- a/composer/spec/natspec/system_analysis.py
+++ b/composer/spec/natspec/system_analysis.py
@@ -41,6 +41,7 @@ async def run_component_analysis[A: NatspecApplication](
         extra_input=[],
         input=input,
         project_root=mental_model.source_root,
+        forbidden_read=mental_model.forbidden_read,
         system_template=ecosystem.analysis_prompts.system,
         initial_template=ecosystem.analysis_prompts.initial,
         validate=validate_solidity_connectivity,

--- a/composer/spec/natspec/system_analysis.py
+++ b/composer/spec/natspec/system_analysis.py
@@ -40,6 +40,7 @@ async def run_component_analysis[A: NatspecApplication](
         env=tools,
         extra_input=[],
         input=input,
+        project_root=mental_model.source_root,
         system_template=ecosystem.analysis_prompts.system,
         initial_template=ecosystem.analysis_prompts.initial,
         validate=validate_solidity_connectivity,

--- a/composer/spec/natspec/task_description.py
+++ b/composer/spec/natspec/task_description.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, AsyncContextManager, Awaitable, ContextManager, Iterator, Mapping, Self, TypedDict
 
+from graphcore.tools.vfs import GlobalExcludeArg
+
 from composer.spec.gen_types import ITypedTemplate
 from composer.spec.natspec.models import (
     InterfaceDeclModel,
@@ -180,6 +182,10 @@ class MentalModel[A: NatspecApplication, I: InterfaceDeclModel, S: StubDeclarati
     interface_desc: AgentDescription[InterfaceResult[I], InterfaceGenCallParams]
     stub_desc: AgentDescription[S, StubGenCallParams]
     source_root: pathlib.Path | None = None
+    #: What ``source_root`` is served to the agent through, so anything checking a path the agent
+    #: wrote asks the same question its file tools answer. ``None`` in greenfield, which has no
+    #: tree to serve.
+    forbidden_read: GlobalExcludeArg = None
     config_init: dict | None = None
 
     @property

--- a/composer/spec/system_analysis.py
+++ b/composer/spec/system_analysis.py
@@ -2,10 +2,11 @@ import enum
 import logging
 import os
 from dataclasses import dataclass
-from pathlib import Path, PurePath, PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Mapping, NotRequired, Any, Callable, TypedDict
 
 from graphcore.graph import MessagesState, FlowInput
+from graphcore.tools.vfs import GlobalExcludeArg, make_exclude_pred
 
 
 from composer.spec.context import (
@@ -19,7 +20,7 @@ from composer.spec.system_model import (
 )
 from composer.spec.types import SourceIdentifier
 from composer.spec.service_host import ServiceHost, Sort
-from composer.spec.util import fs_forbidden_read, fs_withheld_subtree, slugify_filename
+from composer.spec.util import fs_withheld_subtree, slugify_filename
 from composer.tools.thinking import RoughDraftState, get_rough_draft_tools
 from composer.diagnostics.budget import budget_monitor
 
@@ -59,9 +60,10 @@ class _PathFault(enum.Enum):
     WITHHELD = "is not readable through your file tools; name a file they hand back instead."
 
 
-def _path_fault(root: Path, declared: str) -> _PathFault | None:
+def _path_fault(root: Path, declared: str, withheld: Callable[[str], bool]) -> _PathFault | None:
     """What is wrong with a declared source path, or ``None`` when it names a file under *root*
-    that the agent's own file tools hand back.
+    that the agent's own file tools hand back. *withheld* is the run's own ``forbidden_read``,
+    normalized, so the check asks the same question the tools serving those files answer.
 
     Containment is lexical — relative, and never stepping up out of the root. Resolving the path
     would follow symlinks, and a dependency tree symlinked in under ``lib/`` or ``node_modules/``
@@ -81,29 +83,34 @@ def _path_fault(root: Path, declared: str) -> _PathFault | None:
         return _PathFault.DIRECTORY
     if not candidate.is_file():
         return _PathFault.MISSING
-    if fs_forbidden_read(PurePath(declared)):
+    if withheld(declared):
         return _PathFault.WITHHELD
     return None
 
 
-def _readable_files_named(root: Path, names: set[str]) -> dict[str, list[str]]:
+def _readable_files_named(
+    root: Path, names: set[str], withheld: Callable[[str], bool]
+) -> dict[str, list[str]]:
     """Project-root-relative paths of every readable file whose base name is in *names*, from a
     single walk of the tree.
 
     One walk for all the wanted names rather than one per name: a project that sits a directory
     below the root drops the same leading component from every path it declares, so a whole
-    submission's worth of distinct base names goes wrong together. Wholly withheld directories are
-    pruned on the way down instead of filtered out of the results, which keeps a report directory
-    or a ``.certora_internal`` tree off the walk entirely. This runs while the agent waits on its
-    retry, so both matter.
+    submission's worth of distinct base names goes wrong together. This runs while the agent waits
+    on its retry, so the cost of the walk itself matters: ``fs_withheld_subtree`` prunes prover and
+    VCS scratch on the way down, keeping a report directory or a ``.certora_internal`` tree off the
+    walk entirely. That prune is a cost measure, not the readability rule — *withheld* is, and it
+    cannot serve as a prune, since a directory it excludes whole (``lib/``, say) still holds .sol
+    the agent may read.
     """
     found: dict[str, list[str]] = {name: [] for name in names}
     for dirpath, dirnames, filenames in os.walk(root):
         rel_dir = Path(dirpath).relative_to(root)
         dirnames[:] = [d for d in dirnames if not fs_withheld_subtree(rel_dir / d)]
         for filename in filenames:
-            if filename in found and not fs_forbidden_read(rel_dir / filename):
-                found[filename].append((rel_dir / filename).as_posix())
+            rel = (rel_dir / filename).as_posix()
+            if filename in found and not withheld(rel):
+                found[filename].append(rel)
     return {name: sorted(paths) for name, paths in found.items()}
 
 
@@ -152,19 +159,23 @@ class _PathComplaint:
         )
 
 
-def _path_complaints(app: BaseApplication, project_root: Path) -> list[str]:
+def _path_complaints(
+    app: BaseApplication, project_root: Path, forbidden_read: GlobalExcludeArg
+) -> list[str]:
     """Every declared source path in *app* that names no readable file under *project_root*,
-    worded for the agent's retry."""
+    worded for the agent's retry. *forbidden_read* is normalized once here rather than per path,
+    so its regex form is compiled once for the whole submission."""
+    withheld = make_exclude_pred(forbidden_read)
     complaints: list[_PathComplaint] = []
     for c in app.components:
         if isinstance(c, SourceExplicitContract | ExistingFromSource):
-            fault = _path_fault(project_root, c.path)
+            fault = _path_fault(project_root, c.path, withheld)
             if fault is not None:
                 complaints.append(
                     _PathComplaint(f"Contract {c.solidity_identifier}", c.path, fault)
                 )
         elif isinstance(c, SourceExternalActor) and c.path is not None:
-            fault = _path_fault(project_root, c.path)
+            fault = _path_fault(project_root, c.path, withheld)
             if fault is not None:
                 complaints.append(_PathComplaint(
                     f"External actor {c.name}", c.path, fault,
@@ -175,12 +186,15 @@ def _path_complaints(app: BaseApplication, project_root: Path) -> list[str]:
         PurePosixPath(complaint.declared).name
         for complaint in complaints if complaint.fault is _PathFault.MISSING
     }
-    same_named = _readable_files_named(project_root, wanted) if wanted else {}
+    same_named = _readable_files_named(project_root, wanted, withheld) if wanted else {}
     return [complaint.render(same_named) for complaint in complaints]
 
 
 def validate_solidity_connectivity(
-    app: BaseApplication, expected_main_id: SourceIdentifier | None, project_root: Path | None
+    app: BaseApplication,
+    expected_main_id: SourceIdentifier | None,
+    project_root: Path | None,
+    forbidden_read: GlobalExcludeArg,
 ) -> str | None:
     """Connectivity/shape validation for the Solidity model *family*: typed over
     ``BaseApplication`` because it checks only the contract/actor/interaction graph that
@@ -188,15 +202,19 @@ def validate_solidity_connectivity(
     ``FromSourceApplication`` all share. Both callers name it directly; neither can use the
     other's ``Ecosystem.validate_analysis``, which is narrowed to one ``system_model``.
 
-    The source-carrying subtypes additionally declare project-root-relative paths, and
-    ``project_root`` is the tree those are required to name a file in; ``None`` means the run has
-    no source tree, where no component declares a path in the first place. Path complaints join
-    the same accumulated message as the graph ones, so a submission wrong in both ways is
-    corrected in a single retry."""
+    The source-carrying subtypes additionally declare project-root-relative paths, and the tree
+    those are required to name a file in travels as a pair: ``project_root``, and the
+    ``forbidden_read`` the run serves that tree through, so a path is held to the rule the agent's
+    own file tools apply rather than to a default. ``project_root`` is ``None`` when the run has no
+    source tree, where no component declares a path in the first place. Path complaints join the
+    same accumulated message as the graph ones, so a submission wrong in both ways is corrected in
+    a single retry."""
     # The path complaints lead: they are gathered in one go so the tree behind the relocation
     # hints is walked once, and whether there are any decides if the reference block below
     # carries the path frame.
-    path_errors: list[str] = [] if project_root is None else _path_complaints(app, project_root)
+    path_errors: list[str] = (
+        [] if project_root is None else _path_complaints(app, project_root, forbidden_read)
+    )
     errors: list[str] = list(path_errors)
     known_components: dict[str, set[str]] = {}
     known_external: set[str] = set()
@@ -279,9 +297,10 @@ async def run_component_analysis[T: BaseApplication](
     expected_main_id: SourceIdentifier | None = None,
     *,
     project_root: Path | None,
+    forbidden_read: GlobalExcludeArg,
     system_template: TypedTemplate[AnalysisPromptParams],
     initial_template: TypedTemplate[AnalysisPromptParams],
-    validate: Callable[[T, SourceIdentifier | None, Path | None], str | None],
+    validate: Callable[[T, SourceIdentifier | None, Path | None, GlobalExcludeArg], str | None],
 ) -> T | None:
     """Analyze application components from a system doc and optionally source code.
 
@@ -292,8 +311,10 @@ async def run_component_analysis[T: BaseApplication](
     no-doc prompt branch and never dereferences a missing ``content``.
 
     ``project_root`` is the tree the validator resolves any source paths the model declares
-    against; it is required (not defaulted) so a new call site has to say what the model's paths
-    mean, and is ``None`` only when the run has no source tree.
+    against, and ``forbidden_read`` is what that tree is served through, so the validator holds a
+    path to the same readability rule the agent's file tools do. Both are required (not defaulted)
+    so a new call site has to say what the model's paths mean; ``project_root`` is ``None`` only
+    when the run has no source tree.
 
     The cache is the other way into an analyzed model, so a hit is held to the same validation a
     freshly generated model is. Its key covers the project and the contract, nothing about the
@@ -303,7 +324,7 @@ async def run_component_analysis[T: BaseApplication](
     """
 
     def _check(app: T) -> str | None:
-        return validate(app, expected_main_id, project_root)
+        return validate(app, expected_main_id, project_root, forbidden_read)
 
     if (cached := await child_ctxt.cache_get(ty)) is not None:
         stale = _check(cached)

--- a/composer/spec/system_analysis.py
+++ b/composer/spec/system_analysis.py
@@ -1,4 +1,9 @@
-from typing import NotRequired, Any, Callable, TypedDict
+import enum
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path, PurePath, PurePosixPath
+from typing import Mapping, NotRequired, Any, Callable, TypedDict
 
 from graphcore.graph import MessagesState, FlowInput
 
@@ -8,14 +13,19 @@ from composer.spec.context import (
 )
 from composer.spec.gen_types import TypedTemplate
 from composer.spec.graph_builder import bind_standard, run_to_completion
-from composer.spec.system_model import BaseApplication, ExplicitContract, ExternalActor, ExternalDependency
+from composer.spec.system_model import (
+    BaseApplication, ExistingFromSource, ExplicitContract, ExternalActor, ExternalDependency,
+    SourceExplicitContract, SourceExternalActor,
+)
 from composer.spec.types import SourceIdentifier
 from composer.spec.service_host import ServiceHost, Sort
-from composer.spec.util import slugify_filename
+from composer.spec.util import fs_forbidden_read, fs_withheld_subtree, slugify_filename
 from composer.tools.thinking import RoughDraftState, get_rough_draft_tools
 from composer.diagnostics.budget import budget_monitor
 
 DESCRIPTION = "Component analysis"
+
+_logger = logging.getLogger(__name__)
 
 
 class AnalysisPromptParams(TypedDict):
@@ -28,15 +38,166 @@ class AnalysisPromptParams(TypedDict):
 ANALYSIS_SYSTEM_TEMPLATE = TypedTemplate[AnalysisPromptParams]("application_analysis_system.j2")
 ANALYSIS_INITIAL_TEMPLATE = TypedTemplate[AnalysisPromptParams]("application_analysis_prompt.j2")
 
+#: How many same-named files a relocation hint names before it stops listing them.
+_MAX_RELOCATION_CANDIDATES = 10
+
+#: The paragraph that states the frame a declared path is read in. Appended to the reference
+#: block rather than to each error, so a submission with several bad paths is told once.
+_PATH_FRAME = (
+    "\n\nPaths are relative to the project root — exactly the paths list_files prints and "
+    "get_file accepts, carrying every leading directory those tools show."
+)
+
+
+class _PathFault(enum.Enum):
+    """Why a declared source path is unusable. Each value reads as the tail of
+    "... declares path X, which ..."."""
+
+    OUTSIDE = "does not name a file under the project root."
+    DIRECTORY = "is a directory, not a Solidity file."
+    MISSING = "does not exist."
+    WITHHELD = "is not readable through your file tools; name a file they hand back instead."
+
+
+def _path_fault(root: Path, declared: str) -> _PathFault | None:
+    """What is wrong with a declared source path, or ``None`` when it names a file under *root*
+    that the agent's own file tools hand back.
+
+    Containment is lexical — relative, and never stepping up out of the root. Resolving the path
+    would follow symlinks, and a dependency tree symlinked in under ``lib/`` or ``node_modules/``
+    holds real Solidity that ``fs_forbidden_read`` deliberately keeps readable, so the agent is
+    entitled to name a file there and has no way to restate it as a non-symlinked path.
+
+    Readability is the one gate: a path the agent's own tools would withhold is not accepted here
+    either. A relocation hint searches the same surface, with the narrower reach of a walk that
+    does not descend symlinked directories — matching those tools, which reach a symlinked file
+    when asked for it directly but do not enumerate one.
+    """
+    parsed = PurePosixPath(declared)
+    if parsed.is_absolute() or ".." in parsed.parts:
+        return _PathFault.OUTSIDE
+    candidate = root / declared
+    if candidate.is_dir():
+        return _PathFault.DIRECTORY
+    if not candidate.is_file():
+        return _PathFault.MISSING
+    if fs_forbidden_read(PurePath(declared)):
+        return _PathFault.WITHHELD
+    return None
+
+
+def _readable_files_named(root: Path, names: set[str]) -> dict[str, list[str]]:
+    """Project-root-relative paths of every readable file whose base name is in *names*, from a
+    single walk of the tree.
+
+    One walk for all the wanted names rather than one per name: a project that sits a directory
+    below the root drops the same leading component from every path it declares, so a whole
+    submission's worth of distinct base names goes wrong together. Wholly withheld directories are
+    pruned on the way down instead of filtered out of the results, which keeps a report directory
+    or a ``.certora_internal`` tree off the walk entirely. This runs while the agent waits on its
+    retry, so both matter.
+    """
+    found: dict[str, list[str]] = {name: [] for name in names}
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = Path(dirpath).relative_to(root)
+        dirnames[:] = [d for d in dirnames if not fs_withheld_subtree(rel_dir / d)]
+        for filename in filenames:
+            if filename in found and not fs_forbidden_read(rel_dir / filename):
+                found[filename].append((rel_dir / filename).as_posix())
+    return {name: sorted(paths) for name, paths in found.items()}
+
+
+def _relocate(declared: str, same_named: Mapping[str, list[str]]) -> str:
+    """The half of a missing-path complaint that says where to look instead: the readable files
+    carrying the declared file name, narrowed to those whose path *ends* in the declared path.
+    A path that lost a leading directory tail-matches exactly one real file, which turns the
+    complaint into an answer the agent can copy."""
+    name = PurePosixPath(declared).name
+    candidates = same_named[name]
+    tail_matches = [c for c in candidates if c.endswith("/" + declared)]
+    if tail_matches:
+        candidates = tail_matches
+    if not candidates:
+        return (
+            f" No file named {name!r} is readable anywhere in the project; locate the definition "
+            f"with grep_files, or drop this component if it has no file in the source tree."
+        )
+    if len(candidates) == 1:
+        return f" The one file with that name is {candidates[0]!r}."
+    shown = candidates[:_MAX_RELOCATION_CANDIDATES]
+    more = "" if len(shown) == len(candidates) else f" (and {len(candidates) - len(shown)} more)"
+    return (
+        f" Files with that name: {', '.join(repr(c) for c in shown)}{more}. Read them and "
+        f"resubmit the one that defines what you described."
+    )
+
+
+@dataclass(frozen=True)
+class _PathComplaint:
+    """One declared path the source tree does not back. Held unrendered until the pass over
+    components is done, because the relocation hints for every complaint come out of one walk."""
+
+    #: Names the component the path belongs to, e.g. "Contract Vault".
+    subject: str
+    declared: str
+    fault: _PathFault
+    #: What this kind of component may do instead of naming a file; empty where it has no way out.
+    remedy: str = ""
+
+    def render(self, same_named: Mapping[str, list[str]]) -> str:
+        hint = _relocate(self.declared, same_named) if self.fault is _PathFault.MISSING else ""
+        return (
+            f"{self.subject} declares path {self.declared!r}, which "
+            f"{self.fault.value}{hint}{self.remedy}"
+        )
+
+
+def _path_complaints(app: BaseApplication, project_root: Path) -> list[str]:
+    """Every declared source path in *app* that names no readable file under *project_root*,
+    worded for the agent's retry."""
+    complaints: list[_PathComplaint] = []
+    for c in app.components:
+        if isinstance(c, SourceExplicitContract | ExistingFromSource):
+            fault = _path_fault(project_root, c.path)
+            if fault is not None:
+                complaints.append(
+                    _PathComplaint(f"Contract {c.solidity_identifier}", c.path, fault)
+                )
+        elif isinstance(c, SourceExternalActor) and c.path is not None:
+            fault = _path_fault(project_root, c.path)
+            if fault is not None:
+                complaints.append(_PathComplaint(
+                    f"External actor {c.name}", c.path, fault,
+                    remedy=" If this actor has no interface file in the source tree, omit the path"
+                           " instead.",
+                ))
+    wanted = {
+        PurePosixPath(complaint.declared).name
+        for complaint in complaints if complaint.fault is _PathFault.MISSING
+    }
+    same_named = _readable_files_named(project_root, wanted) if wanted else {}
+    return [complaint.render(same_named) for complaint in complaints]
+
+
 def validate_solidity_connectivity(
-    app: BaseApplication, expected_main_id: SourceIdentifier | None
+    app: BaseApplication, expected_main_id: SourceIdentifier | None, project_root: Path | None
 ) -> str | None:
     """Connectivity/shape validation for the Solidity model *family*: typed over
     ``BaseApplication`` because it checks only the contract/actor/interaction graph that
     ``Application``, ``SourceApplication``, ``HarnessedApplication``, and
     ``FromSourceApplication`` all share. Both callers name it directly; neither can use the
-    other's ``Ecosystem.validate_analysis``, which is narrowed to one ``system_model``."""
-    errors: list[str] = []
+    other's ``Ecosystem.validate_analysis``, which is narrowed to one ``system_model``.
+
+    The source-carrying subtypes additionally declare project-root-relative paths, and
+    ``project_root`` is the tree those are required to name a file in; ``None`` means the run has
+    no source tree, where no component declares a path in the first place. Path complaints join
+    the same accumulated message as the graph ones, so a submission wrong in both ways is
+    corrected in a single retry."""
+    # The path complaints lead: they are gathered in one go so the tree behind the relocation
+    # hints is walked once, and whether there are any decides if the reference block below
+    # carries the path frame.
+    path_errors: list[str] = [] if project_root is None else _path_complaints(app, project_root)
+    errors: list[str] = list(path_errors)
     known_components: dict[str, set[str]] = {}
     known_external: set[str] = set()
     known_solidity_ids : set[str] = set()
@@ -102,6 +263,8 @@ def validate_solidity_connectivity(
     for contract_name, subs in sorted(known_components.items()):
         reference_lines.append(f"- Components of {contract_name}: {_fmt(subs)}")
     reference = "\n\nFor reference, the names you declared in your submission:\n" + "\n".join(reference_lines)
+    if path_errors:
+        reference += _PATH_FRAME
 
     if len(errors) == 1:
         return errors[0] + reference
@@ -115,9 +278,10 @@ async def run_component_analysis[T: BaseApplication](
     extra_input: list[str | dict],
     expected_main_id: SourceIdentifier | None = None,
     *,
+    project_root: Path | None,
     system_template: TypedTemplate[AnalysisPromptParams],
     initial_template: TypedTemplate[AnalysisPromptParams],
-    validate: Callable[[T, SourceIdentifier | None], str | None],
+    validate: Callable[[T, SourceIdentifier | None, Path | None], str | None],
 ) -> T | None:
     """Analyze application components from a system doc and optionally source code.
 
@@ -126,9 +290,26 @@ async def run_component_analysis[T: BaseApplication](
     ``has_doc`` below reflects whether a design document is actually present, not
     merely whether an ``input`` object was passed, so a source-only run renders the
     no-doc prompt branch and never dereferences a missing ``content``.
+
+    ``project_root`` is the tree the validator resolves any source paths the model declares
+    against; it is required (not defaulted) so a new call site has to say what the model's paths
+    mean, and is ``None`` only when the run has no source tree.
+
+    The cache is the other way into an analyzed model, so a hit is held to the same validation a
+    freshly generated model is. Its key covers the project and the contract, nothing about the
+    source tree or the checks in force, so an entry outlives any rule added after it was written.
+    An entry that fails validation is a stale entry: re-deriving it is what replaces it, through
+    the ``cache_put`` at the end of the generation path.
     """
+
+    def _check(app: T) -> str | None:
+        return validate(app, expected_main_id, project_root)
+
     if (cached := await child_ctxt.cache_get(ty)) is not None:
-        return cached
+        stale = _check(cached)
+        if stale is None:
+            return cached
+        _logger.info("Re-deriving the cached component analysis, which fails validation: %s", stale)
 
     has_doc = input is not None and input.content is not None
     # greenfield has no source tools, so a design doc is mandatory there.
@@ -146,7 +327,7 @@ async def run_component_analysis[T: BaseApplication](
     def _validation_wrapper(
         _: Any, app: T
     ) -> str | None:
-        return validate(app, expected_main_id)
+        return _check(app)
 
     prompt_params: AnalysisPromptParams = {"sort": env.sort, "has_doc": has_doc}
     b = bind_standard(

--- a/composer/spec/system_model.py
+++ b/composer/spec/system_model.py
@@ -101,11 +101,21 @@ class ExplicitContract(BaseModel):
     description : str = Field(description="A short description of what this contract's role is in the system")
     components : list[ContractComponent] = Field(description="Components making up this contract.")
 
+#: The frame every LLM-authored path field in this module is written in. Stated once and
+#: spliced into each such description so the three of them cannot drift apart.
+PROJECT_RELATIVE = (
+    "The path is relative to the project root — the directory the file tools list and read "
+    "from, not the directory the contract happens to sit in."
+)
+
 class SourceExplicitContract(ExplicitContract):
     """
     A concrete contract type in the system.
     """
-    path: str = Field(description="The relative path to the file which defines the contract type this represents")
+    path: str = Field(description=(
+        "The relative path to the file which defines the contract type this represents. "
+        + PROJECT_RELATIVE
+    ))
 
 class HarnessDefinition(BaseModel):
     path: str
@@ -128,7 +138,10 @@ class SourceExternalActor(ExternalActor):
     Some "external actor" to the system. This may be an administrator, an EOA,
     or some off-chain component, or a contract deployed and managed by someone else.
     """
-    path : str | None = Field(description="The relative path to the interface describing this external actor, if relevant.")
+    path : str | None = Field(description=(
+        "The relative path to the interface describing this external actor, if relevant. "
+        + PROJECT_RELATIVE
+    ))
 
 type SystemComponent = ExternalActor | ExplicitContract
 
@@ -191,7 +204,9 @@ class FromSourceContract(ExplicitContract):
 
 class ExistingFromSource(FromSourceContract):
     """An already-present contract in the source tree."""
-    path: str = Field(description="The relative path to the file defining this contract.")
+    path: str = Field(description=(
+        "The relative path to the file defining this contract. " + PROJECT_RELATIVE
+    ))
     tag: Literal["unchanged", "edited"] = Field(description=(
         "Relationship of this contract to the change being built: "
         "'unchanged' if it's an existing dependency left as-is, "

--- a/composer/spec/util.py
+++ b/composer/spec/util.py
@@ -105,6 +105,19 @@ def _is_generated_bundle(path: PurePath) -> bool:
     return path.suffix == ".js" and path.stem.endswith(_BUNDLE_STEM_SUFFIXES)
 
 
+def fs_withheld_subtree(path: PurePath) -> bool:
+    """True when nothing under the project-root-relative directory *path* is readable, so a
+    walk of the tree can prune it instead of testing every file beneath it.
+
+    Only the whole-withheld directories qualify: everywhere else the Solidity carve-out below
+    keeps .sol readable, so a directory named there still holds files the agent may open.
+    """
+    parts = path.parts
+    return bool(_WITHHELD_WHOLE_DIRS.intersection(parts)) or (
+        bool(parts) and parts[0].startswith(_REPORT_DIR_PREFIX)
+    )
+
+
 def fs_forbidden_read(path: PurePath) -> bool:
     """True to withhold *path* from the agent's source tools (``list_files`` /
     ``get_file`` / ``grep_files``). Paths are project-root-relative.
@@ -115,15 +128,12 @@ def fs_forbidden_read(path: PurePath) -> bool:
     contracts in ``lib/`` and ``test/``. The one exception is the whole-withheld
     directories, which is why they are tested before the carve-out.
     """
-    parts = path.parts
-    if _WITHHELD_WHOLE_DIRS.intersection(parts):
-        return True
-    if parts and parts[0].startswith(_REPORT_DIR_PREFIX):
+    if fs_withheld_subtree(path):
         return True
     if path.suffix == ".sol":
         return False
     return (
-        bool(_NON_SOLIDITY_DIRS.intersection(parts))
+        bool(_NON_SOLIDITY_DIRS.intersection(path.parts))
         or path.suffix in _GENERATED_SUFFIXES
         or _is_generated_bundle(path)
     )

--- a/composer/templates/application_analysis_prompt.j2
+++ b/composer/templates/application_analysis_prompt.j2
@@ -1,4 +1,4 @@
-{% from "shared/analysis_macros.j2" import input_phrase with context %}
+{% from "shared/analysis_macros.j2" import input_phrase, path_convention with context %}
 
 # Background
 
@@ -57,7 +57,8 @@ its role within the larger application.
 
 {% if sort != "greenfield" %}
 If application/possible, provide the relative path to the Solidity file which contains the definition of the interface
-describing this external actor.
+describing this external actor. {{ path_convention() }}
+If you cannot locate that file, omit the path rather than guessing at one.
 {% endif %}
 
 Finally, for each such external actor, extract the assumptions/requirements about the external actors behavior.
@@ -108,7 +109,7 @@ of `registerNewMarket(address marketProxy)`) then the classification should be `
 
 {% if sort != "greenfield" %}
 As part of your extraction, provide the relative path to the Solidity file which contains the definition of the
-contract you are describing.
+contract you are describing. {{ path_convention() }}
 {% endif %}
 
 In addition, each explicit contract should have an associated list of "Contract Components" that comprise it.

--- a/composer/templates/shared/analysis_macros.j2
+++ b/composer/templates/shared/analysis_macros.j2
@@ -20,3 +20,19 @@ system/design document
 {{ impl_noun }}
 {%- endif -%}
 {%- endmacro %}
+
+{#- The path convention every path field in the analysis result is written in. The system model's
+    ``path`` descriptions state the same frame; this macro is where the agent is told how to
+    *obtain* a conforming path, which the field description has no room for.
+
+    IMPORT WITH CONTEXT: {% raw %}{% from "shared/analysis_macros.j2" import path_convention with context %}{% endraw %}
+    for the same reason ``input_phrase`` is imported that way — the macro's callers are all inside
+    ``sort != "greenfield"`` branches, and a context-free import leaves the render params Undefined
+    for anything added here later. -#}
+{% macro path_convention() -%}
+Paths are relative to the **project root** — exactly the paths `list_files` prints and `get_file`
+accepts. Copy the path out of your own tool output rather than assembling one from an import
+statement, a remappings entry, or a build tool's configured source directory. The project root is
+not necessarily the directory the build is configured in: a repository may hold the build project
+one or more directories down, and every path you report still carries that leading directory.
+{%- endmacro %}

--- a/composer/testing/ui_harness_autoprove_Counter.py
+++ b/composer/testing/ui_harness_autoprove_Counter.py
@@ -221,8 +221,9 @@ rule incrementOther_credits_target_when_distinct {
 #
 # Shape must satisfy pydantic validation of
 # ``composer.spec.system_model.SourceApplication`` AND the
-# ``validate_solidity_connectivity`` validator: unique names + all referenced
-# components / external actors exist. One SourceExplicitContract ("Counter")
+# ``validate_solidity_connectivity`` validator: unique names, all referenced
+# components / external actors exist, and every declared ``path`` names a real
+# file under the scenario's project root. One SourceExplicitContract ("Counter")
 # with one ContractComponent ("Increment"), no interactions, no external
 # actors — minimal valid shape.
 
@@ -400,9 +401,9 @@ _SYSTEM_ANALYSIS_TAPE: list[BaseMessage] = [
     # Tools available: memory, write_rough_draft, read_rough_draft,
     #   source_tools = list_files, get_file, grep_files, code_explorer,
     #                  code_document_ref.
-    # Validator: validate_solidity_connectivity (graph wellformedness only; no
-    #   did_read requirement — we can hit `result` at any time once the
-    #   application shape is correct).
+    # Validator: validate_solidity_connectivity (graph wellformedness plus the
+    #   existence of every declared source path; no did_read requirement — we can
+    #   hit `result` at any time once the application shape is correct).
 
     # P1.1 — exercise memory + list_files + get_file. Memory paths must sit
     # under /memories; `view /memories` is the harmless exercise.
@@ -485,7 +486,7 @@ _SYSTEM_ANALYSIS_TAPE: list[BaseMessage] = [
 
     # P1.5 — emit the SourceApplication. Satisfies validate_solidity_connectivity
     # (unique names, no dangling interaction references since there are no
-    # interactions).
+    # interactions, and a declared path that exists in the scenario tree).
     _ai(
         "Application model ready.",
         _tc("result", **_APP_RESULT),

--- a/docs/ecosystem-abstraction.md
+++ b/docs/ecosystem-abstraction.md
@@ -65,7 +65,8 @@ class Ecosystem[App: BaseApplication, Main, Unit: FeatureUnit]:
     system_model: type[App]                          # the pydantic type analysis produces
     analysis_prompts: PromptPair                      # (system, initial) template names
     property_prompts: PromptPair
-    validate_analysis: Callable[[BaseApplication, SourceIdentifier | None, Path | None], str | None]
+    validate_analysis: Callable[[BaseApplication, SourceIdentifier | None,
+                                 Path | None, GlobalExcludeArg], str | None]
     locate_main: Callable[[App, SourceCode], Main]    # find the "main" contract/program
     units: Callable[[Main], list[Unit]]               # split into per-unit extraction items
     analysis_extra_input: Callable[[SourceCode], list[str | dict]]
@@ -176,10 +177,11 @@ SOLANA: Ecosystem[SolanaApplication, SolanaProgramInstance, SolanaComponentInsta
   are *references* the unit wrapper resolves, so a name that doesn't resolve silently drops an
   instruction's account detail from the extraction prompt — and an instruction no component
   claims is an entry point no property will ever cover.
-  Validators also receive the run's project root, so an ecosystem whose model carries source file
-  paths can require those paths to name a real file — the agent then corrects them inside its own
-  retry loop instead of the bad path reaching a downstream tool. That is EVM's rule; the Solana
-  and Soroban models carry no paths and ignore the argument.
+  Validators also receive the surface the run's source is served through: the project root, and the
+  `forbidden_read` narrowing it. An ecosystem whose model carries source file paths can then require
+  those paths to name a file the agent's own tools hand back, so the agent corrects them inside its
+  retry loop instead of the bad path reaching a downstream tool. That is EVM's rule; the Solana and
+  Soroban models carry no paths and ignore both arguments.
 
 ### Prompt composition — the shared Rust fragment
 
@@ -287,8 +289,8 @@ async def run_pipeline[..., U, Main, App](
   Solidity-only otherwise (solc, CVL, interface/stub generation). Its analyzed model comes from
   its `MentalModel` — `Application` / `FromSourceApplication`, siblings of `EVM.system_model`
   under `BaseApplication` rather than subtypes — so `ecosystem.validate_analysis` does not
-  typecheck there and it names `validate_solidity_connectivity` directly, passing its
-  `MentalModel`'s source root as the project root (`None` in greenfield, which declares no paths).
+  typecheck there and it names `validate_solidity_connectivity` directly, passing the source root
+  and `forbidden_read` off its `MentalModel` (both `None` in greenfield, which declares no paths).
 - **`_extract_all`** iterates `ecosystem.units(main)`, running one property-inference agent per
   unit — one per component for EVM, Solana, and Soroban.
 

--- a/docs/ecosystem-abstraction.md
+++ b/docs/ecosystem-abstraction.md
@@ -65,7 +65,7 @@ class Ecosystem[App: BaseApplication, Main, Unit: FeatureUnit]:
     system_model: type[App]                          # the pydantic type analysis produces
     analysis_prompts: PromptPair                      # (system, initial) template names
     property_prompts: PromptPair
-    validate_analysis: Callable[[BaseApplication, SourceIdentifier | None], str | None]
+    validate_analysis: Callable[[BaseApplication, SourceIdentifier | None, Path | None], str | None]
     locate_main: Callable[[App, SourceCode], Main]    # find the "main" contract/program
     units: Callable[[Main], list[Unit]]               # split into per-unit extraction items
     analysis_extra_input: Callable[[SourceCode], list[str | dict]]
@@ -176,6 +176,10 @@ SOLANA: Ecosystem[SolanaApplication, SolanaProgramInstance, SolanaComponentInsta
   are *references* the unit wrapper resolves, so a name that doesn't resolve silently drops an
   instruction's account detail from the extraction prompt — and an instruction no component
   claims is an entry point no property will ever cover.
+  Validators also receive the run's project root, so an ecosystem whose model carries source file
+  paths can require those paths to name a real file — the agent then corrects them inside its own
+  retry loop instead of the bad path reaching a downstream tool. That is EVM's rule; the Solana
+  and Soroban models carry no paths and ignore the argument.
 
 ### Prompt composition — the shared Rust fragment
 
@@ -283,7 +287,8 @@ async def run_pipeline[..., U, Main, App](
   Solidity-only otherwise (solc, CVL, interface/stub generation). Its analyzed model comes from
   its `MentalModel` — `Application` / `FromSourceApplication`, siblings of `EVM.system_model`
   under `BaseApplication` rather than subtypes — so `ecosystem.validate_analysis` does not
-  typecheck there and it names `validate_solidity_connectivity` directly.
+  typecheck there and it names `validate_solidity_connectivity` directly, passing its
+  `MentalModel`'s source root as the project root (`None` in greenfield, which declares no paths).
 - **`_extract_all`** iterates `ecosystem.units(main)`, running one property-inference agent per
   unit — one per component for EVM, Solana, and Soroban.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ authors = [
 ]
 
 dependencies = [
-    "graphcore @ git+ssh://git@github.com/Certora/graphcore.git@54a6852eac72896d17d3bc4f3068a775f9200d1f",
+    "graphcore @ git+ssh://git@github.com/Certora/graphcore.git@7a2f876ac275513b5eb9b633bb3c442d1533fdc9",
     "aiohttp>=3.13",
     "attrs>=26.1",
     "Jinja2>=3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ authors = [
 ]
 
 dependencies = [
-    "graphcore @ git+ssh://git@github.com/Certora/graphcore.git@7a2f876ac275513b5eb9b633bb3c442d1533fdc9",
+    "graphcore @ git+ssh://git@github.com/Certora/graphcore.git@2177f57929c1a9a2052013cf0754e55b0c8f2790",
     "aiohttp>=3.13",
     "attrs>=26.1",
     "Jinja2>=3.1",

--- a/tests/test_analysis_input_phrase.py
+++ b/tests/test_analysis_input_phrase.py
@@ -51,3 +51,36 @@ def test_the_input_phrase_carries_no_article_of_its_own(template: str, has_doc: 
     # it — which is exactly what the broken no-document branch used to produce.
     rendered = load_jinja_template(template, sort="existing", has_doc=has_doc)
     assert "the the" not in rendered
+
+
+# The ``path_convention`` macro states the frame the analysis validator enforces on every
+# declared source path. Only the initial prompt asks for paths, and only outside greenfield —
+# where there is no source tree and ``env.analysis_tools`` is empty, so naming ``list_files``
+# there would promise a tool the agent does not have.
+PATH_TEMPLATE = "application_analysis_prompt.j2"
+CONVENTION = "Paths are relative to the **project root**"
+
+
+@pytest.mark.parametrize("sort", ["existing", "update"])
+def test_both_requested_paths_are_framed_against_the_project_root(sort: str) -> None:
+    # Two sentences ask for a path — one per component kind — and each is anchored on its own
+    # sentence, so dropping the convention from either is a failure rather than a silent pass.
+    rendered = load_jinja_template(PATH_TEMPLATE, sort=sort, has_doc=True)
+    assert rendered.count(CONVENTION) == 2
+    assert f"describing this external actor. {CONVENTION}" in rendered
+    assert f"contract you are describing. {CONVENTION}" in rendered
+    assert "`list_files`" in rendered
+
+
+@pytest.mark.parametrize("sort", ["existing", "update"])
+def test_an_actor_path_that_cannot_be_found_is_to_be_omitted(sort: str) -> None:
+    # The actor's path is optional, and the validator's own complaint offers the same way out, so
+    # the prompt has to name it before the agent invents a path to fill the field.
+    rendered = load_jinja_template(PATH_TEMPLATE, sort=sort, has_doc=True)
+    assert "omit the path rather than guessing" in rendered
+
+
+@pytest.mark.parametrize("template", EVM_TEMPLATES)
+def test_greenfield_states_no_path_convention(template: str) -> None:
+    rendered = load_jinja_template(template, sort="greenfield", has_doc=True)
+    assert CONVENTION not in rendered

--- a/tests/test_pipeline_overlap.py
+++ b/tests/test_pipeline_overlap.py
@@ -14,6 +14,7 @@ Stubs throughout — no LLM, no DB, no backend wheel.
 """
 
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -24,7 +25,7 @@ from composer.pipeline.ecosystem import EVM
 # The driver needs *an* ecosystem to reach the overlap under test, but never exercises this one:
 # the analysis and extraction it feeds are both monkeypatched below. EVM is the convenient real
 # value — ``supports_greenfield=True`` clears the driver's greenfield assert without a live
-# ``env``, and its ``analysis_extra_input`` reads only the two fields ``_Source`` supplies.
+# ``env``, and its ``analysis_extra_input`` reads only fields ``_Source`` supplies.
 ECOSYSTEM = EVM
 
 pytestmark = pytest.mark.asyncio
@@ -103,10 +104,12 @@ class _Ctx:
 
 
 class _Source:
-    """The two source fields the shared front half puts in the analysis prompt."""
+    """The source fields the shared front half reads: two that go into the analysis prompt, and
+    the project root the analysis validator resolves declared paths against."""
 
     contract_name = "Counter"
     relative_path = "src/Counter.sol"
+    project_root = "/nonexistent/project"
 
 
 class _Run:
@@ -133,8 +136,12 @@ async def _drive(
 ) -> dict:
     """Run the driver with stubbed analysis + extraction; report the outcome and the backend."""
     analysis = analysis or _Step(0, None, "analyzed")
+    backend = _Backend(_Prepared(prep), preflight)
+    seen: dict = {"backend": backend}
 
     async def fake_analysis(*_a, **_kw):
+        # What the driver resolved the source's project root to, for the analysis validator.
+        seen["project_root"] = _kw.get("project_root")
         return await analysis.run()
 
     async def fake_extract_all(*_a, **_kw):
@@ -143,8 +150,6 @@ async def _drive(
 
     monkeypatch.setattr(core, "run_component_analysis", fake_analysis)
     monkeypatch.setattr(core, "_extract_all", fake_extract_all)
-    backend = _Backend(_Prepared(prep), preflight)
-    seen: dict = {"backend": backend}
     try:
         await run_pipeline(backend, _Run(), max_bug_rounds=1, ecosystem=ECOSYSTEM)  # type: ignore[arg-type]
     except BaseException as exc:  # noqa: BLE001 — the outcome under test
@@ -276,5 +281,8 @@ async def test_both_succeeding_still_reaches_the_drivers_own_checks(monkeypatch)
 
     assert extract.finished and not extract.cancelled
     assert prep.finished
+    # The analysis validator resolves the model's declared source paths against this root, so the
+    # driver has to hand it the source's own, not a default.
+    assert seen["project_root"] == Path(_Source.project_root)
     assert isinstance(seen["raised"], ValueError)
     assert "No properties extracted" in str(seen["raised"])

--- a/tests/test_pipeline_overlap.py
+++ b/tests/test_pipeline_overlap.py
@@ -21,6 +21,7 @@ import pytest
 import composer.pipeline.core as core
 from composer.pipeline.core import run_pipeline
 from composer.pipeline.ecosystem import EVM
+from composer.spec.util import fs_forbidden_read
 
 # The driver needs *an* ecosystem to reach the overlap under test, but never exercises this one:
 # the analysis and extraction it feeds are both monkeypatched below. EVM is the convenient real
@@ -105,11 +106,12 @@ class _Ctx:
 
 class _Source:
     """The source fields the shared front half reads: two that go into the analysis prompt, and
-    the project root the analysis validator resolves declared paths against."""
+    the surface the analysis validator resolves declared paths against."""
 
     contract_name = "Counter"
     relative_path = "src/Counter.sol"
     project_root = "/nonexistent/project"
+    forbidden_read = staticmethod(fs_forbidden_read)
 
 
 class _Run:
@@ -140,8 +142,9 @@ async def _drive(
     seen: dict = {"backend": backend}
 
     async def fake_analysis(*_a, **_kw):
-        # What the driver resolved the source's project root to, for the analysis validator.
+        # The source surface the driver resolved for the analysis validator.
         seen["project_root"] = _kw.get("project_root")
+        seen["forbidden_read"] = _kw.get("forbidden_read")
         return await analysis.run()
 
     async def fake_extract_all(*_a, **_kw):
@@ -281,8 +284,9 @@ async def test_both_succeeding_still_reaches_the_drivers_own_checks(monkeypatch)
 
     assert extract.finished and not extract.cancelled
     assert prep.finished
-    # The analysis validator resolves the model's declared source paths against this root, so the
-    # driver has to hand it the source's own, not a default.
+    # The analysis validator resolves the model's declared source paths against this surface, so
+    # the driver has to hand it the source's own, not a default.
     assert seen["project_root"] == Path(_Source.project_root)
+    assert seen["forbidden_read"] is fs_forbidden_read
     assert isinstance(seen["raised"], ValueError)
     assert "No properties extracted" in str(seen["raised"])

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -139,6 +139,7 @@ class _Source:
     contract_name = "Vault"
     relative_path = "programs/vault/src/lib.rs"
     project_root = "/nonexistent/project"
+    forbidden_read = None
 
 
 class _Run:

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -138,6 +138,7 @@ class _FeatCtx:
 class _Source:
     contract_name = "Vault"
     relative_path = "programs/vault/src/lib.rs"
+    project_root = "/nonexistent/project"
 
 
 class _Run:

--- a/tests/test_solana_component_grouping.py
+++ b/tests/test_solana_component_grouping.py
@@ -209,6 +209,7 @@ async def test_component_grouping_on_a_real_program(pg_container: "PostgresConta
                 env=env,
                 extra_input=list(SOLANA.analysis_extra_input(source)),
                 expected_main_id=source.contract_name,
+                project_root=Path(source.project_root),
                 system_template=SOLANA.analysis_prompts.system,
                 initial_template=SOLANA.analysis_prompts.initial,
                 validate=SOLANA.validate_analysis,
@@ -223,4 +224,4 @@ async def test_component_grouping_on_a_real_program(pg_container: "PostgresConta
     # analysis loop already enforced via retry — re-asserted here so a regression is loud).
     main = next(p for p in analyzed.programs if p.program_identifier == main_id)
     assert main.components, "the main program came back with no components"
-    assert SOLANA.validate_analysis(analyzed, source.contract_name) is None
+    assert SOLANA.validate_analysis(analyzed, source.contract_name, None) is None

--- a/tests/test_solana_component_grouping.py
+++ b/tests/test_solana_component_grouping.py
@@ -210,6 +210,7 @@ async def test_component_grouping_on_a_real_program(pg_container: "PostgresConta
                 extra_input=list(SOLANA.analysis_extra_input(source)),
                 expected_main_id=source.contract_name,
                 project_root=Path(source.project_root),
+                forbidden_read=source.forbidden_read,
                 system_template=SOLANA.analysis_prompts.system,
                 initial_template=SOLANA.analysis_prompts.initial,
                 validate=SOLANA.validate_analysis,
@@ -224,4 +225,4 @@ async def test_component_grouping_on_a_real_program(pg_container: "PostgresConta
     # analysis loop already enforced via retry — re-asserted here so a regression is loud).
     main = next(p for p in analyzed.programs if p.program_identifier == main_id)
     assert main.components, "the main program came back with no components"
-    assert SOLANA.validate_analysis(analyzed, source.contract_name, None) is None
+    assert SOLANA.validate_analysis(analyzed, source.contract_name, None, None) is None

--- a/tests/test_solana_components.py
+++ b/tests/test_solana_components.py
@@ -113,11 +113,11 @@ def test_interaction_union_discriminates_by_shape():
 
 
 def test_well_formed_application_validates():
-    assert _solana_validate(_app(), VAULT_ID) is None
+    assert _solana_validate(_app(), VAULT_ID, None) is None
 
 
 def test_expected_main_is_still_required():
-    problem = _solana_validate(_app(), RustIdentifier("not_the_vault"))
+    problem = _solana_validate(_app(), RustIdentifier("not_the_vault"), None)
     assert problem is not None and "not_the_vault" in problem
 
 
@@ -128,7 +128,7 @@ def test_duplicate_component_names_rejected():
     def dup(raw):
         _components(raw)[1]["name"] = "Deposits"
 
-    problem = _solana_validate(_app(dup), VAULT_ID)
+    problem = _solana_validate(_app(dup), VAULT_ID, None)
     assert problem is not None and "Duplicate component names in Vault: Deposits" in problem
 
 
@@ -137,7 +137,7 @@ def test_component_slug_collision_rejected():
     def collide(raw):
         _components(raw)[1]["name"] = "Deposits!"
 
-    problem = _solana_validate(_app(collide), VAULT_ID)
+    problem = _solana_validate(_app(collide), VAULT_ID, None)
     assert problem is not None and "filename slug" in problem
 
 
@@ -145,7 +145,7 @@ def test_unknown_instruction_reference_rejected():
     def typo(raw):
         _components(raw)[0]["instructions"] = ["initialize", "depsoit"]
 
-    problem = _solana_validate(_app(typo), VAULT_ID)
+    problem = _solana_validate(_app(typo), VAULT_ID, None)
     assert problem is not None
     assert "lists an instruction 'depsoit' that Vault does not declare" in problem
 
@@ -154,7 +154,7 @@ def test_instruction_belonging_to_no_component_rejected():
     def orphan(raw):
         _components(raw)[0]["instructions"] = ["initialize"]  # drops `deposit`
 
-    problem = _solana_validate(_app(orphan), VAULT_ID)
+    problem = _solana_validate(_app(orphan), VAULT_ID, None)
     assert problem is not None and "'deposit'" in problem and "belong to no component" in problem
 
 
@@ -162,7 +162,7 @@ def test_an_instruction_may_serve_two_components():
     def overlap(raw):
         _components(raw)[1]["instructions"] = ["withdraw", "initialize"]
 
-    assert _solana_validate(_app(overlap), VAULT_ID) is None
+    assert _solana_validate(_app(overlap), VAULT_ID, None) is None
 
 
 def test_a_program_with_no_instructions_needs_no_components():
@@ -170,7 +170,7 @@ def test_a_program_with_no_instructions_needs_no_components():
         _program(raw)["instructions"] = []
         _program(raw)["components"] = []
 
-    assert _solana_validate(_app(empty), VAULT_ID) is None
+    assert _solana_validate(_app(empty), VAULT_ID, None) is None
 
 
 # --- validation: interactions --------------------------------------------------------
@@ -194,7 +194,7 @@ def test_unresolvable_interactions_rejected(interaction, expected):
     def point_nowhere(raw):
         _components(raw)[0]["interactions"] = [interaction]
 
-    problem = _solana_validate(_app(point_nowhere), VAULT_ID)
+    problem = _solana_validate(_app(point_nowhere), VAULT_ID, None)
     assert problem is not None and expected in problem
 
 
@@ -206,7 +206,7 @@ def test_a_forward_reference_between_components_is_fine():
             {"program": "Vault", "component": "Withdrawals", "description": "hands off"}
         ]
 
-    assert _solana_validate(_app(forward), VAULT_ID) is None
+    assert _solana_validate(_app(forward), VAULT_ID, None) is None
 
 
 # --- validation: the retry feedback --------------------------------------------------
@@ -216,7 +216,7 @@ def test_feedback_lists_the_declared_names_for_the_retry():
     def typo(raw):
         _components(raw)[0]["instructions"] = ["initialize", "depsoit"]
 
-    problem = _solana_validate(_app(typo), VAULT_ID)
+    problem = _solana_validate(_app(typo), VAULT_ID, None)
     assert problem is not None
     assert "For reference, the names you declared in your submission:" in problem
     assert "- Declared programs: Vault" in problem
@@ -229,7 +229,7 @@ def test_multiple_errors_are_all_reported():
         _components(raw)[1]["name"] = "Deposits"
         _components(raw)[0]["interactions"] = [{"authority": "Pyth", "description": "x"}]
 
-    problem = _solana_validate(_app(two_problems), VAULT_ID)
+    problem = _solana_validate(_app(two_problems), VAULT_ID, None)
     assert problem is not None
     assert problem.startswith("Multiple validation errors")
     assert "Duplicate component names" in problem and "Pyth" in problem

--- a/tests/test_solana_components.py
+++ b/tests/test_solana_components.py
@@ -113,11 +113,11 @@ def test_interaction_union_discriminates_by_shape():
 
 
 def test_well_formed_application_validates():
-    assert _solana_validate(_app(), VAULT_ID, None) is None
+    assert _solana_validate(_app(), VAULT_ID, None, None) is None
 
 
 def test_expected_main_is_still_required():
-    problem = _solana_validate(_app(), RustIdentifier("not_the_vault"), None)
+    problem = _solana_validate(_app(), RustIdentifier("not_the_vault"), None, None)
     assert problem is not None and "not_the_vault" in problem
 
 
@@ -128,7 +128,7 @@ def test_duplicate_component_names_rejected():
     def dup(raw):
         _components(raw)[1]["name"] = "Deposits"
 
-    problem = _solana_validate(_app(dup), VAULT_ID, None)
+    problem = _solana_validate(_app(dup), VAULT_ID, None, None)
     assert problem is not None and "Duplicate component names in Vault: Deposits" in problem
 
 
@@ -137,7 +137,7 @@ def test_component_slug_collision_rejected():
     def collide(raw):
         _components(raw)[1]["name"] = "Deposits!"
 
-    problem = _solana_validate(_app(collide), VAULT_ID, None)
+    problem = _solana_validate(_app(collide), VAULT_ID, None, None)
     assert problem is not None and "filename slug" in problem
 
 
@@ -145,7 +145,7 @@ def test_unknown_instruction_reference_rejected():
     def typo(raw):
         _components(raw)[0]["instructions"] = ["initialize", "depsoit"]
 
-    problem = _solana_validate(_app(typo), VAULT_ID, None)
+    problem = _solana_validate(_app(typo), VAULT_ID, None, None)
     assert problem is not None
     assert "lists an instruction 'depsoit' that Vault does not declare" in problem
 
@@ -154,7 +154,7 @@ def test_instruction_belonging_to_no_component_rejected():
     def orphan(raw):
         _components(raw)[0]["instructions"] = ["initialize"]  # drops `deposit`
 
-    problem = _solana_validate(_app(orphan), VAULT_ID, None)
+    problem = _solana_validate(_app(orphan), VAULT_ID, None, None)
     assert problem is not None and "'deposit'" in problem and "belong to no component" in problem
 
 
@@ -162,7 +162,7 @@ def test_an_instruction_may_serve_two_components():
     def overlap(raw):
         _components(raw)[1]["instructions"] = ["withdraw", "initialize"]
 
-    assert _solana_validate(_app(overlap), VAULT_ID, None) is None
+    assert _solana_validate(_app(overlap), VAULT_ID, None, None) is None
 
 
 def test_a_program_with_no_instructions_needs_no_components():
@@ -170,7 +170,7 @@ def test_a_program_with_no_instructions_needs_no_components():
         _program(raw)["instructions"] = []
         _program(raw)["components"] = []
 
-    assert _solana_validate(_app(empty), VAULT_ID, None) is None
+    assert _solana_validate(_app(empty), VAULT_ID, None, None) is None
 
 
 # --- validation: interactions --------------------------------------------------------
@@ -194,7 +194,7 @@ def test_unresolvable_interactions_rejected(interaction, expected):
     def point_nowhere(raw):
         _components(raw)[0]["interactions"] = [interaction]
 
-    problem = _solana_validate(_app(point_nowhere), VAULT_ID, None)
+    problem = _solana_validate(_app(point_nowhere), VAULT_ID, None, None)
     assert problem is not None and expected in problem
 
 
@@ -206,7 +206,7 @@ def test_a_forward_reference_between_components_is_fine():
             {"program": "Vault", "component": "Withdrawals", "description": "hands off"}
         ]
 
-    assert _solana_validate(_app(forward), VAULT_ID, None) is None
+    assert _solana_validate(_app(forward), VAULT_ID, None, None) is None
 
 
 # --- validation: the retry feedback --------------------------------------------------
@@ -216,7 +216,7 @@ def test_feedback_lists_the_declared_names_for_the_retry():
     def typo(raw):
         _components(raw)[0]["instructions"] = ["initialize", "depsoit"]
 
-    problem = _solana_validate(_app(typo), VAULT_ID, None)
+    problem = _solana_validate(_app(typo), VAULT_ID, None, None)
     assert problem is not None
     assert "For reference, the names you declared in your submission:" in problem
     assert "- Declared programs: Vault" in problem
@@ -229,7 +229,7 @@ def test_multiple_errors_are_all_reported():
         _components(raw)[1]["name"] = "Deposits"
         _components(raw)[0]["interactions"] = [{"authority": "Pyth", "description": "x"}]
 
-    problem = _solana_validate(_app(two_problems), VAULT_ID, None)
+    problem = _solana_validate(_app(two_problems), VAULT_ID, None, None)
     assert problem is not None
     assert problem.startswith("Multiple validation errors")
     assert "Duplicate component names" in problem and "Pyth" in problem

--- a/tests/test_solidity_component_paths.py
+++ b/tests/test_solidity_component_paths.py
@@ -1,0 +1,362 @@
+"""``validate_solidity_connectivity`` over the source paths the analysis agent authors.
+
+The component-analysis agent writes each contract's ``path`` field by hand, and everything
+downstream — the harness builder, the summarizer, the verification config — treats it as a real
+file. The validator is the one place that resolves those strings against the project tree, and it
+runs inside the agent's own retry loop, so a wrong path comes back as feedback the agent can act
+on rather than as a failure hours later.
+
+The tree these tests build puts the build project one directory below the project root, which is
+the layout that makes a path easy to get wrong: the agent sees the build's own source directory
+and can report a path missing the leading directory that the file tools show.
+"""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from composer.spec.system_analysis import (
+    ANALYSIS_INITIAL_TEMPLATE,
+    ANALYSIS_SYSTEM_TEMPLATE,
+    run_component_analysis,
+    validate_solidity_connectivity,
+)
+from composer.spec.system_model import (
+    Application,
+    FromSourceApplication,
+    SourceApplication,
+)
+from composer.spec.types import SourceIdentifier
+
+MAIN_ID = SourceIdentifier("Vault")
+
+#: Where the build project sits inside the project root — one directory down, so a path that
+#: drops its leading component still names something plausible.
+BUILD_DIR = "pkg"
+VAULT_PATH = f"{BUILD_DIR}/core/src/Vault.sol"
+LEDGER_PATH = f"{BUILD_DIR}/core/src/ledger/Ledger.sol"
+ORACLE_PATH = f"{BUILD_DIR}/core/src/interfaces/IOracle.sol"
+#: The same filename elsewhere in the tree, so a relocation hint has to narrow by path tail and
+#: not merely by basename.
+DECOY_LEDGER_PATH = f"{BUILD_DIR}/legacy/Ledger.sol"
+#: A third copy, under a directory the agent's file tools withhold whole. Real trees carry these:
+#: every prover run leaves its own copy of the sources under ``.certora_internal``.
+WITHHELD_LEDGER_PATH = ".certora_internal/latest/run/Ledger.sol"
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A project root whose Foundry project is one directory down. Returns the root — the
+    directory the agent's file tools list from, and the frame every declared path is read in."""
+    root = tmp_path / "repo"
+    for rel in (VAULT_PATH, LEDGER_PATH, ORACLE_PATH, DECOY_LEDGER_PATH, WITHHELD_LEDGER_PATH):
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("// solidity\n")
+    return root
+
+
+def _component(name: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "description": f"What {name} does.",
+        "external_entry_points": [],
+        "state_variables": [],
+        "interactions": [],
+        "requirements": [],
+    }
+
+
+def _contract(name: str, path: str) -> dict[str, Any]:
+    return {
+        "sort": "singleton",
+        "name": name,
+        "solidity_identifier": name,
+        "description": f"The {name} contract.",
+        "path": path,
+        "components": [_component(f"{name} Core")],
+    }
+
+
+def _raw() -> dict[str, Any]:
+    """A ``SourceApplication`` payload whose every path is correct, mutated per case."""
+    return {
+        "application_type": "Vault",
+        "description": "A vault with a ledger, priced by an oracle.",
+        "components": [
+            _contract("Vault", VAULT_PATH),
+            _contract("Ledger", LEDGER_PATH),
+            {
+                "name": "Oracle",
+                "description": "A price feed owned by someone else.",
+                "assumptions": ["Reports a fresh price."],
+                "path": ORACLE_PATH,
+            },
+        ],
+    }
+
+
+def _app(raw: dict[str, Any]) -> SourceApplication:
+    return SourceApplication.model_validate(raw)
+
+
+def _contract_named(raw: dict[str, Any], name: str) -> dict[str, Any]:
+    return next(c for c in raw["components"] if c["name"] == name)
+
+
+def test_declared_paths_that_exist_are_accepted(project: Path) -> None:
+    assert validate_solidity_connectivity(_app(_raw()), MAIN_ID, project) is None
+
+
+def test_a_path_missing_its_leading_directory_is_rejected(project: Path) -> None:
+    # The dropped-leading-directory case: a path written as the build project sees it, missing
+    # the directory the build project itself lives in.
+    raw = _raw()
+    dropped = LEDGER_PATH.split("/", 1)[1]
+    _contract_named(raw, "Ledger")["path"] = dropped
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert "Contract Ledger declares path" in result
+    assert repr(dropped) in result
+    # Narrowed by path tail, so the decoy of the same name is not offered.
+    assert LEDGER_PATH in result
+    assert DECOY_LEDGER_PATH not in result
+    assert "relative to the project root" in result
+
+
+def test_several_files_share_the_name(project: Path) -> None:
+    # A bare filename tail-matches both copies, so neither can be singled out.
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = "Ledger.sol"
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert LEDGER_PATH in result
+    assert DECOY_LEDGER_PATH in result
+    # The copy under the withheld directory is not one the agent could open, so offering it would
+    # send the retry at a path the next validation rejects again.
+    assert WITHHELD_LEDGER_PATH not in result
+
+
+def test_a_declared_path_under_a_withheld_directory_is_rejected(project: Path) -> None:
+    # The file is there, but the agent's file tools do not hand it back — the same surface the
+    # relocation hints are drawn from, so accepting it would be the validator disagreeing with
+    # itself about what counts as a source file.
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = WITHHELD_LEDGER_PATH
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert "Contract Ledger declares path" in result
+    assert "not readable through your file tools" in result
+
+
+def test_no_file_of_that_name_anywhere(project: Path) -> None:
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = f"{BUILD_DIR}/core/src/Absent.sol"
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert "No file named 'Absent.sol' is readable anywhere in the project" in result
+    assert "grep_files" in result
+
+
+def test_a_directory_is_reported_as_a_directory(project: Path) -> None:
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = f"{BUILD_DIR}/core/src/ledger"
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert "is a directory, not a Solidity file" in result
+    assert "does not exist" not in result
+
+
+@pytest.mark.parametrize("escaping", ["/etc/hosts", "../outside.sol"])
+def test_absolute_and_escaping_paths_are_rejected(project: Path, escaping: str) -> None:
+    # Containment is decided lexically, so it holds even when the escaping path names a file that
+    # really is there.
+    (project.parent / "outside.sol").write_text("// solidity\n")
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = escaping
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert "does not name a file under the project root" in result
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation needs elevation on Windows")
+def test_a_symlinked_dependency_is_accepted(project: Path) -> None:
+    # Vendored dependency trees are routinely symlinked into a project, and their Solidity is
+    # readable through the agent's file tools, so a path leading through one is a legitimate
+    # answer. Resolving the path before the containment check would reject it with nothing the
+    # agent could say instead.
+    external = project.parent / "external"
+    (external / "src").mkdir(parents=True)
+    (external / "src" / "Dep.sol").write_text("// solidity\n")
+    lib = project / BUILD_DIR / "core" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "dep").symlink_to(external, target_is_directory=True)
+
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = f"{BUILD_DIR}/core/lib/dep/src/Dep.sol"
+
+    assert validate_solidity_connectivity(_app(raw), MAIN_ID, project) is None
+
+
+def test_every_bad_path_is_reported_in_one_message(project: Path) -> None:
+    raw = _raw()
+    _contract_named(raw, "Vault")["path"] = "core/src/Vault.sol"
+    _contract_named(raw, "Ledger")["path"] = "core/src/ledger/Ledger.sol"
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert result.startswith("Multiple validation errors found; fix all of them before resubmitting:")
+    assert result.count("declares path") == 2
+    assert "For reference, the names you declared in your submission:" in result
+    # The frame paragraph hangs off the reference block, so it is stated once however many paths
+    # are wrong.
+    assert result.count("list_files") == 1
+
+
+def test_graph_errors_and_path_errors_arrive_together(project: Path) -> None:
+    # One round trip fixes both kinds of mistake; sequencing the two checks would cost two.
+    raw = _raw()
+    raw["components"].append(_contract("Ledger", LEDGER_PATH))
+    _contract_named(raw, "Vault")["path"] = "core/src/Vault.sol"
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert "Duplicate contract names: Ledger" in result
+    assert "Contract Vault declares path" in result
+
+
+def test_an_external_actor_without_a_path_is_accepted(project: Path) -> None:
+    raw = _raw()
+    next(c for c in raw["components"] if c["name"] == "Oracle")["path"] = None
+
+    assert validate_solidity_connectivity(_app(raw), MAIN_ID, project) is None
+
+
+def test_an_external_actor_with_a_missing_path_is_rejected(project: Path) -> None:
+    raw = _raw()
+    next(c for c in raw["components"] if c["name"] == "Oracle")["path"] = "core/src/interfaces/IOracle.sol"
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert "External actor Oracle declares path" in result
+    # The actor's path is optional, so dropping it is a way out the contract case does not have.
+    assert "omit the path instead" in result
+
+
+def test_no_project_root_means_no_path_check(project: Path) -> None:
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = "nowhere/at/all/Ledger.sol"
+
+    assert validate_solidity_connectivity(_app(raw), MAIN_ID, None) is None
+
+
+def test_greenfield_application_is_unaffected(project: Path) -> None:
+    # A greenfield ``Application`` declares no paths at all; handing it a real root changes nothing.
+    raw = _raw()
+    for component in raw["components"]:
+        component.pop("path", None)
+
+    assert validate_solidity_connectivity(Application.model_validate(raw), MAIN_ID, project) is None
+
+
+def test_from_source_paths_are_checked_and_new_contracts_are_not(project: Path) -> None:
+    raw = _raw()
+    _contract_named(raw, "Vault")["tag"] = "edited"
+    ledger = _contract_named(raw, "Ledger")
+    ledger["tag"] = "unchanged"
+    ledger["path"] = "core/src/ledger/Ledger.sol"
+    fresh = _contract("Router", "")
+    del fresh["path"]
+    fresh["tag"] = "new"
+    raw["components"].append(fresh)
+
+    result = validate_solidity_connectivity(FromSourceApplication.model_validate(raw), MAIN_ID, project)
+
+    assert result is not None
+    assert "Contract Ledger declares path" in result
+    assert "Vault" not in result.split("For reference")[0]
+    assert "Router" not in result.split("For reference")[0]
+
+
+# --- the cache, the other way into an analyzed model ---------------------------------
+
+
+class _StopAtGeneration(Exception):
+    """Raised where ``run_component_analysis`` begins assembling the agent — as far past a cache
+    miss as these tests need to go, and with no LLM, store, or template rendering behind it."""
+
+
+class _Ctx:
+    """Enough ``WorkflowContext`` for the cache branch: it always hits, with the model it was
+    built on. ``get_memory_tool`` is the first call past the cache exit, so raising there is how
+    a fall-through to generation is observed."""
+
+    recursion_limit = 10
+
+    def __init__(self, cached: SourceApplication) -> None:
+        self.cached = cached
+
+    async def cache_get(self, _ty: type) -> SourceApplication:
+        return self.cached
+
+    def get_memory_tool(self) -> Any:
+        raise _StopAtGeneration()
+
+
+class _Env:
+    """A ``ServiceHost`` stub: the workflow sort is all the cache branch reads off it."""
+
+    sort = "existing"
+
+
+async def _analyze(ctx: _Ctx, project: Path) -> SourceApplication | None:
+    return await run_component_analysis(
+        SourceApplication,
+        ctx,  # type: ignore[arg-type]
+        None,
+        _Env(),  # type: ignore[arg-type]
+        [],
+        MAIN_ID,
+        project_root=project,
+        system_template=ANALYSIS_SYSTEM_TEMPLATE,
+        initial_template=ANALYSIS_INITIAL_TEMPLATE,
+        validate=validate_solidity_connectivity,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_cached_analysis_that_validates_is_returned(project: Path) -> None:
+    ctx = _Ctx(_app(_raw()))
+
+    assert await _analyze(ctx, project) is ctx.cached
+
+
+@pytest.mark.asyncio
+async def test_a_cached_analysis_with_a_bad_path_is_re_derived(project: Path) -> None:
+    # The cache key covers the project and the contract, not the source tree or the checks in
+    # force, so an entry stands for as long as the repo does. Replaying one the validator would
+    # reject puts a bad path downstream on every rerun, which is the one place the agent's own
+    # retry loop cannot reach.
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = "core/src/ledger/Ledger.sol"
+    ctx = _Ctx(_app(raw))
+
+    with pytest.raises(_StopAtGeneration):
+        await _analyze(ctx, project)

--- a/tests/test_solidity_component_paths.py
+++ b/tests/test_solidity_component_paths.py
@@ -12,7 +12,7 @@ and can report a path missing the leading directory that the file tools show.
 """
 
 import os
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any
 
 import pytest
@@ -29,6 +29,7 @@ from composer.spec.system_model import (
     SourceApplication,
 )
 from composer.spec.types import SourceIdentifier
+from composer.spec.util import fs_forbidden_read
 
 MAIN_ID = SourceIdentifier("Vault")
 
@@ -107,7 +108,7 @@ def _contract_named(raw: dict[str, Any], name: str) -> dict[str, Any]:
 
 
 def test_declared_paths_that_exist_are_accepted(project: Path) -> None:
-    assert validate_solidity_connectivity(_app(_raw()), MAIN_ID, project) is None
+    assert validate_solidity_connectivity(_app(_raw()), MAIN_ID, project, fs_forbidden_read) is None
 
 
 def test_a_path_missing_its_leading_directory_is_rejected(project: Path) -> None:
@@ -117,7 +118,7 @@ def test_a_path_missing_its_leading_directory_is_rejected(project: Path) -> None
     dropped = LEDGER_PATH.split("/", 1)[1]
     _contract_named(raw, "Ledger")["path"] = dropped
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert "Contract Ledger declares path" in result
@@ -133,7 +134,7 @@ def test_several_files_share_the_name(project: Path) -> None:
     raw = _raw()
     _contract_named(raw, "Ledger")["path"] = "Ledger.sol"
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert LEDGER_PATH in result
@@ -150,18 +151,79 @@ def test_a_declared_path_under_a_withheld_directory_is_rejected(project: Path) -
     raw = _raw()
     _contract_named(raw, "Ledger")["path"] = WITHHELD_LEDGER_PATH
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert "Contract Ledger declares path" in result
     assert "not readable through your file tools" in result
 
 
+def _withholds_the_ledger_directory(path: PurePath) -> bool:
+    """A run whose own rule withholds a directory the Solidity default hands back."""
+    return "ledger" in path.parts
+
+
+def test_the_runs_own_rule_decides_what_is_readable(project: Path) -> None:
+    # The check asks the question the run's file tools answer, so a file the Solidity default
+    # allows is still withheld when this run would not serve it.
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = LEDGER_PATH
+
+    result = validate_solidity_connectivity(
+        _app(raw), MAIN_ID, project, _withholds_the_ledger_directory
+    )
+
+    assert result is not None
+    assert "not readable through your file tools" in result
+
+
+def test_a_forbidden_read_written_as_a_regex_is_read_the_same_way(project: Path) -> None:
+    # A run started from the command line supplies its exclusion as a pattern rather than a
+    # predicate, and both forms mean the same thing here.
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = LEDGER_PATH
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, r".*/ledger/.*")
+
+    assert result is not None
+    assert "not readable through your file tools" in result
+
+
+def test_relocation_hints_are_drawn_from_the_same_rule(project: Path) -> None:
+    # The hint has to name a file the agent can then open, so the walk behind it withholds what
+    # the run withholds. Only the decoy is left to offer.
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = "core/src/ledger/Ledger.sol"
+
+    result = validate_solidity_connectivity(
+        _app(raw), MAIN_ID, project, _withholds_the_ledger_directory
+    )
+
+    assert result is not None
+    assert LEDGER_PATH not in result
+    assert DECOY_LEDGER_PATH in result
+
+
+def test_prover_scratch_stays_off_the_walk(project: Path) -> None:
+    # ``fs_withheld_subtree`` prunes prover and VCS scratch to keep the walk cheap, which is a
+    # separate matter from what the run withholds: a run that withholds nothing still gets no hint
+    # pointing into a prover's own working directory.
+    scratch = project / ".certora_internal" / "latest" / "run" / "Scratch.sol"
+    scratch.write_text("// solidity\n")
+    raw = _raw()
+    _contract_named(raw, "Ledger")["path"] = f"{BUILD_DIR}/core/src/Scratch.sol"
+
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, None)
+
+    assert result is not None
+    assert "No file named 'Scratch.sol' is readable anywhere in the project" in result
+
+
 def test_no_file_of_that_name_anywhere(project: Path) -> None:
     raw = _raw()
     _contract_named(raw, "Ledger")["path"] = f"{BUILD_DIR}/core/src/Absent.sol"
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert "No file named 'Absent.sol' is readable anywhere in the project" in result
@@ -172,7 +234,7 @@ def test_a_directory_is_reported_as_a_directory(project: Path) -> None:
     raw = _raw()
     _contract_named(raw, "Ledger")["path"] = f"{BUILD_DIR}/core/src/ledger"
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert "is a directory, not a Solidity file" in result
@@ -187,7 +249,7 @@ def test_absolute_and_escaping_paths_are_rejected(project: Path, escaping: str) 
     raw = _raw()
     _contract_named(raw, "Ledger")["path"] = escaping
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert "does not name a file under the project root" in result
@@ -209,7 +271,7 @@ def test_a_symlinked_dependency_is_accepted(project: Path) -> None:
     raw = _raw()
     _contract_named(raw, "Ledger")["path"] = f"{BUILD_DIR}/core/lib/dep/src/Dep.sol"
 
-    assert validate_solidity_connectivity(_app(raw), MAIN_ID, project) is None
+    assert validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read) is None
 
 
 def test_every_bad_path_is_reported_in_one_message(project: Path) -> None:
@@ -217,7 +279,7 @@ def test_every_bad_path_is_reported_in_one_message(project: Path) -> None:
     _contract_named(raw, "Vault")["path"] = "core/src/Vault.sol"
     _contract_named(raw, "Ledger")["path"] = "core/src/ledger/Ledger.sol"
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert result.startswith("Multiple validation errors found; fix all of them before resubmitting:")
@@ -234,7 +296,7 @@ def test_graph_errors_and_path_errors_arrive_together(project: Path) -> None:
     raw["components"].append(_contract("Ledger", LEDGER_PATH))
     _contract_named(raw, "Vault")["path"] = "core/src/Vault.sol"
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert "Duplicate contract names: Ledger" in result
@@ -245,14 +307,14 @@ def test_an_external_actor_without_a_path_is_accepted(project: Path) -> None:
     raw = _raw()
     next(c for c in raw["components"] if c["name"] == "Oracle")["path"] = None
 
-    assert validate_solidity_connectivity(_app(raw), MAIN_ID, project) is None
+    assert validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read) is None
 
 
 def test_an_external_actor_with_a_missing_path_is_rejected(project: Path) -> None:
     raw = _raw()
     next(c for c in raw["components"] if c["name"] == "Oracle")["path"] = "core/src/interfaces/IOracle.sol"
 
-    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(_app(raw), MAIN_ID, project, fs_forbidden_read)
 
     assert result is not None
     assert "External actor Oracle declares path" in result
@@ -264,7 +326,7 @@ def test_no_project_root_means_no_path_check(project: Path) -> None:
     raw = _raw()
     _contract_named(raw, "Ledger")["path"] = "nowhere/at/all/Ledger.sol"
 
-    assert validate_solidity_connectivity(_app(raw), MAIN_ID, None) is None
+    assert validate_solidity_connectivity(_app(raw), MAIN_ID, None, fs_forbidden_read) is None
 
 
 def test_greenfield_application_is_unaffected(project: Path) -> None:
@@ -273,7 +335,9 @@ def test_greenfield_application_is_unaffected(project: Path) -> None:
     for component in raw["components"]:
         component.pop("path", None)
 
-    assert validate_solidity_connectivity(Application.model_validate(raw), MAIN_ID, project) is None
+    assert validate_solidity_connectivity(
+        Application.model_validate(raw), MAIN_ID, project, fs_forbidden_read
+    ) is None
 
 
 def test_from_source_paths_are_checked_and_new_contracts_are_not(project: Path) -> None:
@@ -287,7 +351,9 @@ def test_from_source_paths_are_checked_and_new_contracts_are_not(project: Path) 
     fresh["tag"] = "new"
     raw["components"].append(fresh)
 
-    result = validate_solidity_connectivity(FromSourceApplication.model_validate(raw), MAIN_ID, project)
+    result = validate_solidity_connectivity(
+        FromSourceApplication.model_validate(raw), MAIN_ID, project, fs_forbidden_read
+    )
 
     assert result is not None
     assert "Contract Ledger declares path" in result
@@ -335,6 +401,7 @@ async def _analyze(ctx: _Ctx, project: Path) -> SourceApplication | None:
         [],
         MAIN_ID,
         project_root=project,
+        forbidden_read=fs_forbidden_read,
         system_template=ANALYSIS_SYSTEM_TEMPLATE,
         initial_template=ANALYSIS_INITIAL_TEMPLATE,
         validate=validate_solidity_connectivity,

--- a/tests/test_soroban_components.py
+++ b/tests/test_soroban_components.py
@@ -164,11 +164,11 @@ def test_unit_resolves_functions_and_durability_tagged_storage():
 
 
 def test_well_formed_application_validates():
-    assert _soroban_validate(_app(), VAULT_ID) is None
+    assert _soroban_validate(_app(), VAULT_ID, None) is None
 
 
 def test_expected_main_is_required():
-    problem = _soroban_validate(_app(), RustIdentifier("not_the_vault"))
+    problem = _soroban_validate(_app(), RustIdentifier("not_the_vault"), None)
     assert problem is not None and "not_the_vault" in problem
 
 
@@ -176,7 +176,7 @@ def test_duplicate_component_names_rejected():
     def dup(raw):
         _components(raw)[1]["name"] = "Deposits"
 
-    problem = _soroban_validate(_app(dup), VAULT_ID)
+    problem = _soroban_validate(_app(dup), VAULT_ID, None)
     assert problem is not None and "Duplicate component names in Vault: Deposits" in problem
 
 
@@ -184,7 +184,7 @@ def test_component_slug_collision_rejected():
     def collide(raw):
         _components(raw)[1]["name"] = "Deposits!"
 
-    problem = _soroban_validate(_app(collide), VAULT_ID)
+    problem = _soroban_validate(_app(collide), VAULT_ID, None)
     assert problem is not None and "filename slug" in problem
 
 
@@ -192,7 +192,7 @@ def test_unknown_function_reference_rejected():
     def typo(raw):
         _components(raw)[0]["functions"] = ["initialize", "depsoit"]
 
-    problem = _soroban_validate(_app(typo), VAULT_ID)
+    problem = _soroban_validate(_app(typo), VAULT_ID, None)
     assert problem is not None
     assert "lists a function 'depsoit' that Vault does not declare" in problem
 
@@ -201,7 +201,7 @@ def test_function_belonging_to_no_component_rejected():
     def orphan(raw):
         _components(raw)[0]["functions"] = ["initialize"]  # drops `deposit`
 
-    problem = _soroban_validate(_app(orphan), VAULT_ID)
+    problem = _soroban_validate(_app(orphan), VAULT_ID, None)
     assert problem is not None and "'deposit'" in problem and "belong to no component" in problem
 
 
@@ -209,7 +209,7 @@ def test_a_function_may_serve_two_components():
     def overlap(raw):
         _components(raw)[1]["functions"] = ["withdraw", "initialize"]
 
-    assert _soroban_validate(_app(overlap), VAULT_ID) is None
+    assert _soroban_validate(_app(overlap), VAULT_ID, None) is None
 
 
 def test_a_contract_with_no_functions_needs_no_components():
@@ -217,7 +217,7 @@ def test_a_contract_with_no_functions_needs_no_components():
         _contract(raw)["functions"] = []
         _contract(raw)["components"] = []
 
-    assert _soroban_validate(_app(empty), VAULT_ID) is None
+    assert _soroban_validate(_app(empty), VAULT_ID, None) is None
 
 
 @pytest.mark.parametrize(
@@ -239,7 +239,7 @@ def test_unresolvable_interactions_rejected(interaction, expected):
     def point_nowhere(raw):
         _components(raw)[0]["interactions"] = [interaction]
 
-    problem = _soroban_validate(_app(point_nowhere), VAULT_ID)
+    problem = _soroban_validate(_app(point_nowhere), VAULT_ID, None)
     assert problem is not None and expected in problem
 
 
@@ -262,7 +262,7 @@ def test_unknown_storage_key_reference_rejected():
     def typo(raw):
         _components(raw)[1]["storage_keys"] = ["Blance(Address)"]
 
-    problem = _soroban_validate(_app(typo), VAULT_ID)
+    problem = _soroban_validate(_app(typo), VAULT_ID, None)
     assert problem is not None
     assert "lists a storage key 'Blance(Address)'" in problem
 
@@ -278,7 +278,7 @@ def test_a_key_declared_under_two_durabilities_rejected():
             }
         )
 
-    problem = _soroban_validate(_app(shadow), VAULT_ID)
+    problem = _soroban_validate(_app(shadow), VAULT_ID, None)
     assert problem is not None
     assert "declared twice in Vault" in problem and "separate key spaces" in problem
 
@@ -287,7 +287,7 @@ def test_a_component_need_not_claim_every_storage_key():
     def drop(raw):
         _components(raw)[0]["storage_keys"] = []
 
-    assert _soroban_validate(_app(drop), VAULT_ID) is None
+    assert _soroban_validate(_app(drop), VAULT_ID, None) is None
 
 
 def test_soroban_is_registered_and_locates_its_main():

--- a/tests/test_soroban_components.py
+++ b/tests/test_soroban_components.py
@@ -164,11 +164,11 @@ def test_unit_resolves_functions_and_durability_tagged_storage():
 
 
 def test_well_formed_application_validates():
-    assert _soroban_validate(_app(), VAULT_ID, None) is None
+    assert _soroban_validate(_app(), VAULT_ID, None, None) is None
 
 
 def test_expected_main_is_required():
-    problem = _soroban_validate(_app(), RustIdentifier("not_the_vault"), None)
+    problem = _soroban_validate(_app(), RustIdentifier("not_the_vault"), None, None)
     assert problem is not None and "not_the_vault" in problem
 
 
@@ -176,7 +176,7 @@ def test_duplicate_component_names_rejected():
     def dup(raw):
         _components(raw)[1]["name"] = "Deposits"
 
-    problem = _soroban_validate(_app(dup), VAULT_ID, None)
+    problem = _soroban_validate(_app(dup), VAULT_ID, None, None)
     assert problem is not None and "Duplicate component names in Vault: Deposits" in problem
 
 
@@ -184,7 +184,7 @@ def test_component_slug_collision_rejected():
     def collide(raw):
         _components(raw)[1]["name"] = "Deposits!"
 
-    problem = _soroban_validate(_app(collide), VAULT_ID, None)
+    problem = _soroban_validate(_app(collide), VAULT_ID, None, None)
     assert problem is not None and "filename slug" in problem
 
 
@@ -192,7 +192,7 @@ def test_unknown_function_reference_rejected():
     def typo(raw):
         _components(raw)[0]["functions"] = ["initialize", "depsoit"]
 
-    problem = _soroban_validate(_app(typo), VAULT_ID, None)
+    problem = _soroban_validate(_app(typo), VAULT_ID, None, None)
     assert problem is not None
     assert "lists a function 'depsoit' that Vault does not declare" in problem
 
@@ -201,7 +201,7 @@ def test_function_belonging_to_no_component_rejected():
     def orphan(raw):
         _components(raw)[0]["functions"] = ["initialize"]  # drops `deposit`
 
-    problem = _soroban_validate(_app(orphan), VAULT_ID, None)
+    problem = _soroban_validate(_app(orphan), VAULT_ID, None, None)
     assert problem is not None and "'deposit'" in problem and "belong to no component" in problem
 
 
@@ -209,7 +209,7 @@ def test_a_function_may_serve_two_components():
     def overlap(raw):
         _components(raw)[1]["functions"] = ["withdraw", "initialize"]
 
-    assert _soroban_validate(_app(overlap), VAULT_ID, None) is None
+    assert _soroban_validate(_app(overlap), VAULT_ID, None, None) is None
 
 
 def test_a_contract_with_no_functions_needs_no_components():
@@ -217,7 +217,7 @@ def test_a_contract_with_no_functions_needs_no_components():
         _contract(raw)["functions"] = []
         _contract(raw)["components"] = []
 
-    assert _soroban_validate(_app(empty), VAULT_ID, None) is None
+    assert _soroban_validate(_app(empty), VAULT_ID, None, None) is None
 
 
 @pytest.mark.parametrize(
@@ -239,7 +239,7 @@ def test_unresolvable_interactions_rejected(interaction, expected):
     def point_nowhere(raw):
         _components(raw)[0]["interactions"] = [interaction]
 
-    problem = _soroban_validate(_app(point_nowhere), VAULT_ID, None)
+    problem = _soroban_validate(_app(point_nowhere), VAULT_ID, None, None)
     assert problem is not None and expected in problem
 
 
@@ -262,7 +262,7 @@ def test_unknown_storage_key_reference_rejected():
     def typo(raw):
         _components(raw)[1]["storage_keys"] = ["Blance(Address)"]
 
-    problem = _soroban_validate(_app(typo), VAULT_ID, None)
+    problem = _soroban_validate(_app(typo), VAULT_ID, None, None)
     assert problem is not None
     assert "lists a storage key 'Blance(Address)'" in problem
 
@@ -278,7 +278,7 @@ def test_a_key_declared_under_two_durabilities_rejected():
             }
         )
 
-    problem = _soroban_validate(_app(shadow), VAULT_ID, None)
+    problem = _soroban_validate(_app(shadow), VAULT_ID, None, None)
     assert problem is not None
     assert "declared twice in Vault" in problem and "separate key spaces" in problem
 
@@ -287,7 +287,7 @@ def test_a_component_need_not_claim_every_storage_key():
     def drop(raw):
         _components(raw)[0]["storage_keys"] = []
 
-    assert _soroban_validate(_app(drop), VAULT_ID, None) is None
+    assert _soroban_validate(_app(drop), VAULT_ID, None, None) is None
 
 
 def test_soroban_is_registered_and_locates_its_main():

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -130,16 +130,16 @@ async def test_token_usage_persisted_to_run_meta_tags():
 # --------------------------------------------------------------------------- #
 
 def _fake_model(callbacks):
+    # ``usage_metadata`` reports one inclusive input total, so the 107 here is 100 fresh input
+    # plus the two cache buckets, and that is what the callback is expected to break back out.
     resp = AIMessage(
         content="ok",
-        response_metadata={
-            "model_name": "claude-test",
-            "usage": {
-                "input_tokens": 100,
-                "output_tokens": 10,
-                "cache_read_input_tokens": 5,
-                "cache_creation_input_tokens": 2,
-            },
+        response_metadata={"model_name": "claude-test"},
+        usage_metadata={
+            "input_tokens": 107,
+            "output_tokens": 10,
+            "total_tokens": 117,
+            "input_token_details": {"cache_read": 5, "cache_creation": 2},
         },
     )
     return FakeMessagesListChatModel(responses=[resp, resp], callbacks=callbacks)


### PR DESCRIPTION
## What

The `path` fields on `SourceExplicitContract`, `SourceExternalActor` and `ExistingFromSource` are
written by the component-analysis agent. Nothing checked them against the filesystem.
`validate_solidity_connectivity` covered names, duplicates and the interaction graph, and it was
typed over `BaseApplication` with no project root to check anything against.

So a declared path that resolves to nothing travels a long way before anyone notices. It goes
through `run_setup_part1`'s `name_to_path`, into the transitive closure, into `extra_files` in
`run_autosetup_phase`, and finally into the AutoSetup subprocess argv, where `parse_contract_files`
raises `File ... does not exist`. By then an hour has passed and several analysis and bug-analysis
phases have run.

The shape that prompted this: a repository whose build project sits one or more directories below
the repository root. Paths are project-root-relative, so every declared path has to carry that
leading directory. A path assembled from an import statement or from a build tool's source
directory instead of from the agent's own file-tool output loses it, and every contract in the
submission loses it the same way.

## How

The validator takes a third `project_root: Path | None` and checks the declared paths inside its
existing single pass over components. Path complaints join the same accumulated message as the
graph ones, so a submission that is wrong in both ways is corrected in one retry instead of two.
`project_root` threads through `Ecosystem.validate_analysis`, which follows the existing
`locate_main` precedent of handing ecosystem callables the run's facts. Solana and Soroban take an
ignored parameter; nothing in their models carries a source path.

Containment is lexical, meaning relative and never stepping up out of the root. Resolving instead
would follow symlinks, and the forbidden-read predicate deliberately keeps `.sol` readable under
`lib/` and `node_modules/`, which are routinely symlinked. The agent is entitled to name a file
there and has no way to restate it as a non-symlinked path, so a resolving check would reject it
with no way to comply. There is a test pinning that.

The error says where to look instead. One walk of the tree collects readable files carrying the
declared name, narrowed to those whose path ends with the declared path, so the dropped-directory
case names exactly one real file rather than reporting "not found". One walk covers every bad path
in the submission, and wholly withheld directories are pruned during descent rather than filtered
out afterwards, because this runs while the agent waits on its retry.

Cache hits get the same check. `root_cache_key` is
`sha256(project_root | doc_hash | relative_path | contract_name)`, which covers neither the source
tree nor the rules in force, and the cloud namespaces the cache per user and repository. Without
this, a model written before the check existed is replayed unvalidated on every rerun and the gate
never fires at all. An entry that fails validation is stale, so it is re-derived and the existing
`cache_put` replaces it.

The prompt and the `path` field descriptions now state the convention the validator enforces. They
reject nothing on their own; they say what the check requires.

## Scope note for reviewers

`SourceExternalActor.path` is checked too, which is wider than the failure above. It is the same
class of unchecked agent-written string and it reaches the summarizer prompt. The error offers
"omit the path instead" as the remedy, and an actor with no path is passed over silently
downstream, so a repository that passes today can start reporting a validation error. That is
intended, not a regression.

## Testing

`tests/test_solidity_component_paths.py` is new: 17 tests over acceptance, a path missing its
leading directory (asserting the hint names the one real file), several files sharing a name, no
file of that name anywhere, a directory, absolute and escaping paths, a path under a withheld
directory, a symlinked dependency being accepted, several bad paths arriving in one message, graph
errors and path errors arriving together, the external actor with and without a path,
`project_root=None`, greenfield, and `FromSourceApplication` where the existing contract is checked
and the fresh one is not. Two more cover the cache branch in both directions.

`tests/test_analysis_input_phrase.py` gained rendering assertions for the two path bullets and the
omit-the-path clause. `tests/test_pipeline_overlap.py` now asserts the driver forwards a real
project root.

Each new test was checked by breaking the code it covers and confirming it fails.

Targeted run: 91 passed. `pyright composer/ analyzer sanity_analyzer certora_autosetup`: 0 errors.


## Review round

`forbidden_read` now comes off the pipeline input rather than the module-level `fs_forbidden_read`,
so the check asks the question the run's own file tools answer. It threads beside `project_root`
through `Ecosystem.validate_analysis`, and natspec carries it on its `MentalModel`. Normalizing the
two surface forms of a `GlobalExcludeArg` uses `make_exclude_pred`, exported from graphcore in
Certora/graphcore#37, now merged, and the pin sits on graphcore master.

The directory prune in the relocation walk stays on `fs_withheld_subtree`, which is a walk-cost
measure over prover and VCS scratch rather than a readability rule. A prune cannot be derived from
an arbitrary exclusion: `lib/` is excluded whole while the `.sol` under it stays readable. Four new
tests pin the split, including the regex form of `forbidden_read` and a hint that must not name a
file the run withholds.

Advancing the graphcore pin also brings its token-usage accounting fix, so the fake message in
`tests/test_token_usage.py` carries `usage_metadata`, whose input total includes the cache buckets.

