### PR TITLE
Cancel the rest of a concurrent group when one member fails

### DIFF
--- a/composer/diagnostics/timing.py
+++ b/composer/diagnostics/timing.py
@@ -7,6 +7,7 @@ invocations) report their wall-clock numbers into it. At end-of-run the
 summary is formatted into a per-phase table.
 """
 
+import asyncio
 from contextlib import asynccontextmanager, contextmanager
 import os
 from logging import Logger
@@ -60,6 +61,11 @@ class TokenTotals:
             "cache_read": self.cache_read,
             "cache_write": self.cache_write,
         }
+
+
+#: ``PhaseRecord.error`` of a task stopped by a sibling's failure. It is an outcome worth showing
+#: per row, but not a failure of its own: the failure it was stopped for has its own row.
+CANCELLED = "cancelled"
 
 
 @dataclass
@@ -318,7 +324,7 @@ def _format_summary(summary: RunSummary) -> str:
         out.append("Final prover runs:")
         for p in linked:
             out.append(f"  {p.label}: {p.final_link}")
-    failures = [p for p in summary.phases if p.error is not None]
+    failures = [p for p in summary.phases if p.error is not None and p.error != CANCELLED]
     if failures:
         out.append("")
         out.append(f"Failures ({len(failures)}):")
@@ -352,12 +358,32 @@ async def task_logger(
     t_request = time.perf_counter()
     log = _TaskLog()
     tok = _current_task_id.set(task_id)
+
+    def timings() -> tuple[float, float]:
+        """Wall time so far, and how much of it was spent queued — all of it for a task that
+        never reached RUNNING."""
+        elapsed = time.perf_counter() - t_request
+        return elapsed, (log.t_running - t_request) if log.t_running is not None else elapsed
+
     try:
          yield log
+    except asyncio.CancelledError:
+        # A gated task is stopped by a sibling's failure with its tokens already spent, so it
+        # reports like any other outcome: record_phase is what folds a task's in-flight token
+        # bucket into the per-phase breakdown.
+        elapsed, queue_wait = timings()
+        logger.info(
+            f"task cancelled: phase={phase_name} task_id={task_id} "
+            f"wall={elapsed:.2f}s queue_wait={queue_wait:.2f}s"
+        )
+        summary.record_phase(
+            task_id=task_id, label=label, phase=phase_name,
+            wall_s=elapsed, queue_wait_s=queue_wait, error=CANCELLED,
+        )
+        raise
     except Exception as exc:
         err_name = type(exc).__name__
-        elapsed = time.perf_counter() - t_request
-        queue_wait = (log.t_running - t_request) if log.t_running is not None else elapsed
+        elapsed, queue_wait = timings()
         logger.exception(
             f"task failed: phase={phase_name} task_id={task_id} "
             f"wall={elapsed:.2f}s queue_wait={queue_wait:.2f}s error={err_name}"
@@ -368,8 +394,7 @@ async def task_logger(
         )
         raise exc
     else:
-        elapsed = time.perf_counter() - t_request
-        queue_wait = (log.t_running - t_request) if log.t_running is not None else 0.0
+        elapsed, queue_wait = timings()
         logger.info(
             f"task done: phase={phase_name} task_id={task_id} "
             f"wall={elapsed:.2f}s queue_wait={queue_wait:.2f}s"

--- a/composer/io/multi_job.py
+++ b/composer/io/multi_job.py
@@ -79,6 +79,34 @@ async def maybe_semaphore(
         async with sem:
             yield
 
+
+@asynccontextmanager
+async def gated_group() -> AsyncIterator[asyncio.TaskGroup]:
+    """A task group whose members gate each other: the first failure cancels the rest.
+
+    Use it wherever concurrent work shares one fate — a failure on either side means the run
+    can no longer complete, so the sibling is stopped rather than left to spend on it.
+
+    The caller sees the failure itself rather than a wrapper: a cancelled member contributes
+    nothing to the group, so the usual case has a single exception to unwrap. Members that
+    fail at once (before either cancellation lands) are the one case with two real errors,
+    and there the group is raised as-is because neither is *the* cause.
+    """
+    unwrapped: BaseException | None = None
+    try:
+        async with asyncio.TaskGroup() as tg:
+            yield tg
+    except BaseExceptionGroup as eg:
+        if len(eg.exceptions) != 1:
+            raise
+        unwrapped = eg.exceptions[0]
+    # Raised outside the handler, where no exception is being handled: the member arrives at the
+    # caller with its own ``raise X from Y`` chain intact, which for a wrapper whose message only
+    # points at its cause is the whole of the diagnostic.
+    if unwrapped is not None:
+        raise unwrapped
+
+
 type TaskCallable[T] = Callable[[], Awaitable[T]] | Callable[[ConversationContextProvider], Awaitable[T]]
 
 async def run_task[P: HasName, T, H](

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -9,10 +9,11 @@ a constructor dependency rather than a call-order convention; there is no half-i
 
 Two links are *overlapped* with the LLM steps they don't depend on, since both are usually builds:
 ``preflight`` runs alongside system analysis, and ``prepare_formalization`` alongside property
-extraction. ``preflight`` is additionally a *gate*: it and the analysis run in a task group, so a
-failure on either side cancels the other rather than letting it spend on a run that can no longer
-complete — a broken toolchain does not wait out the analysis agent, and a failed analysis does not
-wait out the workspace build. The second pair is simply awaited in turn.
+extraction. Each pair is also a *gate*: the two sides share a task group, so a failure on either
+cancels the other rather than letting it spend on a run that can no longer complete — a broken
+toolchain does not wait out the analysis agent, a failed analysis does not wait out the workspace
+build, and a failed setup does not wait out the extraction agents whose properties it would have
+formalized.
 
 A backend whose units all build on one *shared* artifact inserts a link rather than a call-order
 convention: ``prepare_formalization`` returns a :class:`StagedFormalizer`, and its ``begin`` — handed
@@ -39,7 +40,7 @@ from abc import ABC, abstractmethod
 from contextlib import nullcontext
 
 
-from composer.io.multi_job import TaskInfo
+from composer.io.multi_job import TaskInfo, gated_group
 from composer.spec.artifacts import ArtifactStore
 from composer.spec.context import (
     WorkflowContext, ComponentGroup
@@ -501,17 +502,9 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
                 ),
             )
 
-    try:
-        async with asyncio.TaskGroup() as overlap:
-            preflight_task = overlap.create_task(backend.preflight(run))
-            analysis_task = overlap.create_task(_run_analysis())
-    except BaseExceptionGroup as eg:
-        # Callers expect the failure itself, not a wrapper, so unwrap the usual case: one side
-        # failed and the other was cancelled, and a cancelled task adds nothing to the group.
-        # Both failing at once is the only case with two real errors; keep the group there.
-        if len(eg.exceptions) == 1:
-            raise eg.exceptions[0] from None
-        raise
+    async with gated_group() as overlap:
+        preflight_task = overlap.create_task(backend.preflight(run))
+        analysis_task = overlap.create_task(_run_analysis())
     preflight, analyzed = preflight_task.result(), analysis_task.result()
     if analyzed is None:
         raise ValueError("System analysis produced no result.")
@@ -521,30 +514,34 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
         prepared = await backend.prepare_system(analyzed, run, preflight)
 
     # 3. Pre-formalization setup runs CONCURRENTLY with extraction (neither needs the other) —
-    #    this preserves the prover's autosetup ∥ bug-analysis overlap, generically.
+    #    this preserves the prover's autosetup ∥ bug-analysis overlap, generically. The pair is
+    #    also a gate: extraction's properties have nowhere to be formalized if the setup fails,
+    #    and a setup nobody will read is worth no more minutes, so whichever side breaks first
+    #    cancels the other instead of letting it spend on a run that can no longer complete.
     #    The budget scope is entered inside the coroutine (not around create_task) so the
     #    cost-center binding lives in the spawned task's own context.
     async def _prepare_formalization() -> Formalizer[FormT, U] | StagedFormalizer[FormT, U]:
         with named_budget_or_nop("formalization_preparation"):
             return await prepared.prepare_formalization(run)
-    staged_task = asyncio.create_task(_prepare_formalization())
 
-    batches: list[_Batch[U]] = await _extract_all(
-        backend.analysis_spec.properties_key,
-        prepared.main,
-        backend.backend_guidance,
-        run,
-        phases["extraction"],
-        interactive,
-        threat_model,
-        extra_context,
-        max_bug_rounds,
-        ecosystem,
-        plugin_manager.bind_phase(
-            phases.get("extraction_plugin") or phases["extraction"],
-        )
-    )
-    staged = await staged_task
+    async with gated_group() as overlap:
+        staged_task = overlap.create_task(_prepare_formalization())
+        extract_task = overlap.create_task(_extract_all(
+            backend.analysis_spec.properties_key,
+            prepared.main,
+            backend.backend_guidance,
+            run,
+            phases["extraction"],
+            interactive,
+            threat_model,
+            extra_context,
+            max_bug_rounds,
+            ecosystem,
+            plugin_manager.bind_phase(
+                phases.get("extraction_plugin") or phases["extraction"],
+            )
+        ))
+    staged, batches = staged_task.result(), extract_task.result()
     if not batches:
         raise ValueError("No properties extracted from any component.")
 
@@ -741,12 +738,13 @@ async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
                 feat, runner.bind(str(feat.unit_index), ctxt)
             )
 
-        got = await asyncio.gather(*[
-            run_one(r) for r in plugins.runners(
-                sub_phase_id="pre-inference", sub_phase_label="Property Pre-Inference"
-            )
-        ])
-        return [t for t in got if t is not None]
+        async with gated_group() as fanout:
+            hooks = [
+                fanout.create_task(run_one(r)) for r in plugins.runners(
+                    sub_phase_id="pre-inference", sub_phase_label="Property Pre-Inference"
+                )
+            ]
+        return [t for h in hooks if (t := h.result()) is not None]
 
     async def _post_plugin_props(
         feat: U, props: list[PropertyFormulation]
@@ -811,8 +809,9 @@ async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
         with named_budget_or_nop("property_extraction"):
             return await _one(u)
 
-    got = await asyncio.gather(*[budgeted_task(u) for u in ecosystem.units(main)])
-    return [b for b in got if b is not None]
+    async with gated_group() as fanout:
+        tasks = [fanout.create_task(budgeted_task(u)) for u in ecosystem.units(main)]
+    return [b for t in tasks if (b := t.result()) is not None]
 
 
 def _tally[FormT: BackendResult, U: FeatureUnit](

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -26,7 +26,7 @@ from typing import override, Sequence
 
 from langchain_core.tools import BaseTool
 
-from composer.io.multi_job import TaskInfo
+from composer.io.multi_job import TaskInfo, gated_group
 from composer.spec.context import WorkflowContext, CVLGeneration
 from composer.spec.types import PropertyFormulation, PropertyTitle
 from composer.spec.gen_types import CVLResource, SPECS_DIR, certora_relative_to_project
@@ -208,10 +208,14 @@ class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, Con
     @override
     async def prepare_formalization(self, run: PipelineRun) -> Formalizer[GeneratedCVL, ContractComponentInstance]:
         # AutoSetup (+ custom summaries) ∥ structural-invariant formulation; both
-        # depend only on the harnessed app, so they run concurrently.
-        (setup_config, resources), invariants = await asyncio.gather(
-            self._autosetup(run), self._invariants(run),
-        )
+        # depend only on the harnessed app, so they run concurrently. The two sides gate
+        # each other: every spec is written against AutoSetup's config, so an invariants
+        # agent with nowhere to deliver is stopped rather than left to spend, and a setup
+        # whose invariants have failed stops building a config nothing will use.
+        async with gated_group() as fanout:
+            setup_task = fanout.create_task(self._autosetup(run))
+            inv_task = fanout.create_task(self._invariants(run))
+        (setup_config, resources), invariants = setup_task.result(), inv_task.result()
 
         invariant: tuple[list[PropertyFormulation], InvariantResult] | None = None
         if invariants.inv:

--- a/tests/test_cancelled_task_accounting.py
+++ b/tests/test_cancelled_task_accounting.py
@@ -1,0 +1,72 @@
+"""Tests for how ``task_logger`` accounts for a task the gate cancelled.
+
+A cancelled task has usually already spent tokens, so it gets a row of its own with the tokens it
+spent — but the failure it was stopped for is the one the end-of-run summary reports, and a
+cancellation is not a second failure beside it.
+
+Stubs only — no LLM, no DB, no backend wheel.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from composer.diagnostics.timing import (
+    CANCELLED,
+    RunSummary,
+    TokenTotals,
+    install_run_summary,
+    task_logger,
+)
+from graphcore.utils import TokenUsageDict
+
+pytestmark = pytest.mark.asyncio
+
+_LOG = logging.getLogger(__name__)
+
+
+def _usage(model: str, i: int, o: int, cr: int, cw: int) -> TokenUsageDict:
+    return {
+        "input_tokens": i,
+        "output_tokens": o,
+        "cache_read_input_tokens": cr,
+        "cache_creation_input_tokens": cw,
+        "model_name": model,
+    }
+
+
+async def _cancel_one_task(summary: RunSummary) -> None:
+    """One running, token-spending task, cancelled where the gate would cancel it."""
+    install_run_summary(summary)
+    with pytest.raises(asyncio.CancelledError):
+        async with task_logger("extract-0", "component", "extraction", _LOG) as log:
+            log.task_started()
+            summary.record_token_usage(_usage("opus", 100, 10, 5, 2))
+            raise asyncio.CancelledError
+
+
+async def test_a_cancelled_task_is_recorded_with_the_tokens_it_spent():
+    # The spend is real whether or not the task got to finish, so it belongs to that task's row
+    # rather than being stranded in the in-flight bucket and reported by nobody.
+    summary = RunSummary()
+    await _cancel_one_task(summary)
+
+    record = summary.phases[0]
+    assert (record.task_id, record.phase, record.error) == ("extract-0", "extraction", CANCELLED)
+    assert sum(record.token_usage_by_model.values(), TokenTotals()).input == 100
+    assert summary.token_usage_summary()["by_phase"] == [
+        {"task_id": "extract-0", "phase": "extraction",
+         "input": 100, "output": 10, "cache_read": 5, "cache_write": 2}
+    ]
+
+
+async def test_a_cancellation_shows_as_a_status_but_not_as_a_failure():
+    # One real failure in a fan-out cancels every sibling; counting those as failures would report
+    # the run as N broken tasks instead of the one that broke.
+    summary = RunSummary()
+    await _cancel_one_task(summary)
+
+    out = summary.format()
+    assert CANCELLED in out
+    assert "Failures" not in out

--- a/tests/test_extraction_fanout_gate.py
+++ b/tests/test_extraction_fanout_gate.py
@@ -1,0 +1,184 @@
+"""Tests for the two fan-outs inside ``_extract_all`` (``composer/pipeline/core.py``).
+
+Property extraction runs one agent per unit, and each unit first runs its plugins' pre-inference
+hooks concurrently. Both fan-outs are gates: extraction is where a run's money goes, so when one
+member fails the rest stop instead of spending out a run that can no longer complete, and the
+caller gets that member's own error rather than a group to unpack.
+
+Stubs only — no LLM, no DB, no backend wheel: the driver's real fan-out code runs, with the agent
+call at the bottom of it replaced.
+"""
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+import composer.pipeline.core as core
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Step:
+    """A stub async step that takes ``delay`` seconds and then fails or returns ``value``."""
+
+    def __init__(self, delay: float, error: Exception | None, value: object = None):
+        self.delay, self.error, self.value = delay, error, value
+        self.finished = False
+        self.cancelled = False
+        #: Set once the step is running, so a test that cancels mid-flight can wait for the
+        #: thing it means to cancel instead of guessing how long the driver takes to get there.
+        self.started = asyncio.Event()
+
+    async def run(self):
+        self.started.set()
+        try:
+            await asyncio.sleep(self.delay)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        if self.error is not None:
+            raise self.error
+        self.finished = True
+        return self.value
+
+
+class _Unit:
+    """A feature unit that is nothing but its identity — the driver keys and labels by it."""
+
+    def __init__(self, index: int):
+        self.unit_index = index
+        self.display_name = f"unit-{index}"
+        self.slug = f"unit-{index}"
+
+    def cache_material(self) -> str:
+        return f"unit-{self.unit_index}"
+
+    def context_tag(self) -> dict[str, object]:
+        return {"unit": self.unit_index}
+
+
+class _Ctx:
+    """A workflow context that hands back itself for any child scope, sync or async."""
+
+    def child(self, *_a, **_kw):
+        return _AsyncCtx()
+
+
+class _AsyncCtx:
+    async def child(self, *_a, **_kw):
+        return self
+
+
+class _Source:
+    #: No design doc, so the driver adds nothing to the plugins' pre-inference input.
+    content = None
+
+
+class _Run:
+    """Just enough ``PipelineRun`` for extraction: a runner that awaits the job inline."""
+
+    source = _Source()
+    env = None
+    ctx = _Ctx()
+
+    async def runner(self, _task_info, job):
+        return await job(None)
+
+
+class _Prompts:
+    """The property-prompt pair, read as arguments of the (stubbed) inference call."""
+
+    system = "system-prompt"
+    render_initial = None
+
+
+class _Ecosystem:
+    def __init__(self, units: list[_Unit]):
+        self._units = units
+        self.property_prompts = _Prompts()
+
+    def units(self, _main) -> list[_Unit]:
+        return self._units
+
+
+class _Plugin:
+    def __init__(self, step: _Step):
+        self.step = step
+
+    async def property_inference_input_hook(self, _feat, _runner):
+        return await self.step.run()
+
+
+class _Runner:
+    """A plugin phase runner bound to one pre-inference hook."""
+
+    def __init__(self, plugin_id: str, step: _Step):
+        self.plugin_id = plugin_id
+        self.plugin = _Plugin(step)
+
+    def bind(self, *_a, **_kw):
+        return self
+
+
+class _Plugins:
+    """A plugin phase manager offering ``pre_runners`` for the pre-inference sub-phase."""
+
+    plugin_digest = None
+    plugin_manifest: dict[str, object] = {}
+
+    def __init__(self, pre_runners: list[_Runner] | None = None):
+        self._pre_runners = pre_runners or []
+
+    def runners(self, *, sub_phase_id: str, **_kw) -> list[_Runner]:
+        return self._pre_runners if sub_phase_id == "pre-inference" else []
+
+
+async def _extract(monkeypatch, *, units: list[_Unit], plugins: _Plugins, inference: _Step | None,
+                   per_unit: dict[int, _Step] | None = None) -> BaseException:
+    """Run the real ``_extract_all`` over ``units``; hand back what it raised."""
+    steps = per_unit or {}
+
+    async def fake_inference(_ctx, _env, feat, **_kw):
+        step = steps.get(feat.unit_index) or inference
+        assert step is not None
+        return await step.run()
+
+    monkeypatch.setattr(core, "run_property_inference", fake_inference)
+    with pytest.raises(BaseException) as caught:  # noqa: PT011 — the outcome under test
+        await core._extract_all(
+            "properties-key", "main-unit", "guidance", cast(Any, _Run()), phase=1,
+            interactive=False, threat_model=None, extra_context=[], max_rounds=1,
+            ecosystem=cast(Any, _Ecosystem(units)), plugins=cast(Any, plugins),
+        )
+    return caught.value
+
+
+async def test_one_units_failure_cancels_the_other_units_agents(monkeypatch):
+    # The per-unit fan-out is the run's biggest concurrent spend, so a unit whose failure ends the
+    # run must not leave its siblings running: they stop, and its own error is what surfaces.
+    boom = RuntimeError("property inference blew up")
+    sibling = _Step(30, None)
+
+    raised = await _extract(
+        monkeypatch, units=[_Unit(0), _Unit(1)], plugins=_Plugins(), inference=None,
+        per_unit={0: _Step(0.01, boom), 1: sibling},
+    )
+
+    assert raised is boom
+    assert sibling.cancelled and not sibling.finished
+
+
+async def test_one_pre_inference_hook_failure_cancels_the_other_hooks(monkeypatch):
+    # Same gate one level down: a unit's plugin hooks feed a single inference call, so once one of
+    # them has failed the others are working towards a call that will never happen.
+    boom = RuntimeError("a pre-inference hook blew up")
+    sibling = _Step(30, None)
+    plugins = _Plugins([_Runner("failing", _Step(0.01, boom)), _Runner("slow", sibling)])
+
+    raised = await _extract(
+        monkeypatch, units=[_Unit(0)], plugins=plugins, inference=_Step(30, None),
+    )
+
+    assert raised is boom
+    assert sibling.cancelled and not sibling.finished

--- a/tests/test_gated_group.py
+++ b/tests/test_gated_group.py
@@ -1,0 +1,110 @@
+"""Tests for ``gated_group``, the shared primitive behind every concurrency point that shares one
+fate: the first failure cancels the siblings, and the caller sees that failure itself.
+
+Stubs only — no LLM, no DB, no backend wheel.
+"""
+
+import asyncio
+import traceback
+
+import pytest
+
+from composer.io.multi_job import gated_group
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Step:
+    """A stub async step that takes ``delay`` seconds and then fails or returns ``value``."""
+
+    def __init__(self, delay: float, error: Exception | None, value: object = None):
+        self.delay, self.error, self.value = delay, error, value
+        self.finished = False
+        self.cancelled = False
+        #: Set once the step is running, so a test that cancels mid-flight can wait for the
+        #: thing it means to cancel instead of guessing how long the driver takes to get there.
+        self.started = asyncio.Event()
+
+    async def run(self):
+        self.started.set()
+        try:
+            await asyncio.sleep(self.delay)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        if self.error is not None:
+            raise self.error
+        self.finished = True
+        return self.value
+
+
+async def test_a_failure_cancels_the_sibling_and_surfaces_itself():
+    # The whole point of the gate: the sibling stops the moment the run is doomed, and the caller
+    # gets the exception it would have got from a plain await, not a wrapper it has to unpack.
+    boom = RuntimeError("one member failed")
+    sibling = _Step(30, None, "value")
+
+    with pytest.raises(RuntimeError) as caught:
+        async with gated_group() as group:
+            group.create_task(_Step(0.01, boom).run())
+            group.create_task(sibling.run())
+
+    assert caught.value is boom
+    assert sibling.cancelled and not sibling.finished
+
+
+async def test_a_double_failure_keeps_the_group():
+    # Two members raise before either cancellation lands, so neither is "the" cause and both
+    # exceptions reach the caller.
+    first = RuntimeError("first member failed")
+    second = RuntimeError("second member failed")
+
+    with pytest.raises(BaseExceptionGroup) as caught:
+        async with gated_group() as group:
+            group.create_task(_Step(0, first).run())
+            group.create_task(_Step(0, second).run())
+
+    assert set(caught.value.exceptions) == {first, second}
+
+
+async def test_cancelling_the_holder_cancels_the_members():
+    # A caller that goes away (Ctrl-C, an enclosing timeout) takes the whole group with it.
+    members = [_Step(30, None), _Step(30, None)]
+
+    async def hold():
+        async with gated_group() as group:
+            for m in members:
+                group.create_task(m.run())
+
+    holder = asyncio.create_task(hold())
+    await asyncio.gather(*(m.started.wait() for m in members))
+    holder.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await holder
+
+    assert all(m.cancelled and not m.finished for m in members)
+
+
+async def test_the_surfaced_failure_keeps_its_cause():
+    # A member that wraps its root cause is common — a wrapper's message is often only a pointer at
+    # the cause it was raised from — so the chain has to survive the unwrap, and the group must not
+    # appear in the rendered traceback either.
+    root = ValueError("the root cause")
+
+    async def wrap():
+        try:
+            raise root
+        except ValueError as exc:
+            raise RuntimeError("the wrapper") from exc
+
+    with pytest.raises(RuntimeError) as caught:
+        async with gated_group() as group:
+            group.create_task(wrap())
+            group.create_task(_Step(30, None).run())
+
+    assert caught.value.__cause__ is root
+    rendered = "".join(
+        traceback.format_exception(type(caught.value), caught.value, caught.value.__traceback__)
+    )
+    assert "the root cause" in rendered
+    assert "ExceptionGroup" not in rendered

--- a/tests/test_pipeline_overlap.py
+++ b/tests/test_pipeline_overlap.py
@@ -6,9 +6,9 @@ don't depend on them.
 * ``backend.preflight`` (Crucible's program build + harness-skeleton build) with **system analysis**;
 * ``prepared.prepare_formalization`` (the prover's autosetup) with **property extraction**.
 
-Neither side of either pair needs the other. The preflight is additionally a *gate*: it shares a task
-group with the analysis, so a failure on either side cancels the other rather than letting it spend
-on a run that can no longer complete. Nothing else is cancelled — the second pair is awaited in turn.
+Neither side of either pair needs the other. Each pair is additionally a *gate*: the two sides share
+a task group, so a failure on either cancels the other rather than letting it spend on a run that can
+no longer complete.
 
 Stubs throughout — no LLM, no DB, no backend wheel.
 """
@@ -46,8 +46,12 @@ class _Step:
         self.delay, self.error, self.value = delay, error, value
         self.finished = False
         self.cancelled = False
+        #: Set once the step is running, so a test that cancels mid-flight can wait for the
+        #: thing it means to cancel instead of guessing how long the driver takes to get there.
+        self.started = asyncio.Event()
 
     async def run(self):
+        self.started.set()
         try:
             await asyncio.sleep(self.delay)
         except asyncio.CancelledError:
@@ -225,7 +229,7 @@ async def test_cancelling_the_run_cancels_the_steps_it_was_waiting_on(monkeypatc
             max_bug_rounds=1, ecosystem=ECOSYSTEM,
         )
     )
-    await asyncio.sleep(0.05)  # both overlapped steps are now in flight
+    await asyncio.gather(analysis.started.wait(), preflight.started.wait())
     driver.cancel()
     with pytest.raises(asyncio.CancelledError):
         await driver
@@ -246,26 +250,56 @@ async def test_the_preflight_result_is_handed_to_prepare_system(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-async def test_a_setup_failure_ends_the_run_once_extraction_is_done(monkeypatch):
-    # This pair is only overlapped, not gated: extraction runs to completion, and setup's failure is
-    # then reported as itself — not as a downstream "no properties extracted", which is what an
-    # entirely *unobserved* setup failure would look like.
-    boom = RuntimeError("cargo-build-sbf failed (exit 101)")
-    extract = _Step(0.03, None)
+async def test_a_setup_failure_cancels_extraction(monkeypatch):
+    # Extraction is where the money goes, and its properties have nowhere to be formalized once the
+    # setup is dead: the agents stop the moment the setup fails, and that failure is what surfaces —
+    # not a downstream "no properties extracted", which is what an *unobserved* setup failure would
+    # eventually look like.
+    boom = RuntimeError("the formalization setup failed")
+    extract = _Step(30, None)
     seen = await _drive(monkeypatch, prep=_Step(0.01, boom), extract=extract)
 
     assert seen["raised"] is boom
-    assert extract.finished and not extract.cancelled
+    assert extract.cancelled and not extract.finished
 
 
-async def test_an_extraction_failure_ends_the_run_with_its_own_error(monkeypatch):
-    # The other direction: extraction is awaited first, so its failure is what surfaces.
+async def test_an_extraction_failure_cancels_the_setup(monkeypatch):
+    # Symmetric: a setup whose properties will never arrive is stopped rather than run out its
+    # build, and the extraction error is what the caller sees.
     boom = RuntimeError("extraction blew up")
-    prep = _Step(0, None)
+    prep = _Step(30, None)
     seen = await _drive(monkeypatch, prep=prep, extract=_Step(0.01, boom))
 
     assert seen["raised"] is boom
-    assert prep.finished
+    assert prep.cancelled and not prep.finished
+
+
+async def test_cancelling_the_run_cancels_the_second_pair_too(monkeypatch):
+    # As with the first pair, a caller that goes away takes both sides with it: neither the setup
+    # nor the extraction agents outlive the run that started them.
+    prep = _Step(30, None)
+    extract = _Step(30, None)
+
+    async def fake_analysis(*_a, **_kw):
+        return "analyzed"
+
+    async def fake_extract_all(*_a, **_kw):
+        return await extract.run()
+
+    monkeypatch.setattr(core, "run_component_analysis", fake_analysis)
+    monkeypatch.setattr(core, "_extract_all", fake_extract_all)
+    driver = asyncio.create_task(
+        run_pipeline(  # type: ignore[arg-type]
+            _Backend(_Prepared(prep)), _Run(), max_bug_rounds=1, ecosystem=ECOSYSTEM,
+        )
+    )
+    await asyncio.gather(prep.started.wait(), extract.started.wait())
+    driver.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await driver
+
+    assert prep.cancelled and not prep.finished
+    assert extract.cancelled and not extract.finished
 
 
 async def test_both_succeeding_still_reaches_the_drivers_own_checks(monkeypatch):

--- a/tests/test_prover_prepare_formalization_gate.py
+++ b/tests/test_prover_prepare_formalization_gate.py
@@ -1,0 +1,91 @@
+"""Tests for the prover's pre-formalization fan-out (``ProverPrepared.prepare_formalization``).
+
+Setup and structural-invariant formulation run concurrently and gate each other: every spec is
+written against the setup's config, so neither side outlives the other's failure.
+
+Stubs only — the two sides are monkeypatched, and execution never reaches past the fan-out on
+either path, so no run, no LLM and no prover are needed.
+"""
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from composer.spec.source.pipeline import ProverPrepared
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Step:
+    """A stub async step that takes ``delay`` seconds and then fails or returns ``value``."""
+
+    def __init__(self, delay: float, error: Exception | None, value: object = None):
+        self.delay, self.error, self.value = delay, error, value
+        self.finished = False
+        self.cancelled = False
+        #: Set once the step is running, so a test that cancels mid-flight can wait for the
+        #: thing it means to cancel instead of guessing how long the driver takes to get there.
+        self.started = asyncio.Event()
+
+    async def run(self):
+        self.started.set()
+        try:
+            await asyncio.sleep(self.delay)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        if self.error is not None:
+            raise self.error
+        self.finished = True
+        return self.value
+
+
+def _prepared() -> ProverPrepared:
+    """A ``ProverPrepared`` whose fields are all unreachable: both sides of the fan-out are
+    replaced, and nothing below it runs."""
+    none = cast(Any, None)
+    return ProverPrepared(
+        main=none, _sys_desc=none, _harnessed=none, _prover_tool=none, _analyzed=none, _deps=none,
+    )
+
+
+async def _fan_out(monkeypatch, *, setup: _Step, invariants: _Step) -> BaseException:
+    """Run the fan-out with both sides stubbed; hand back what it raised."""
+    prepared = _prepared()
+
+    # Patched on the class, so each stub takes the instance the driver calls it on.
+    async def fake_autosetup(_self, _run):
+        return await setup.run()
+
+    async def fake_invariants(_self, _run):
+        return await invariants.run()
+
+    monkeypatch.setattr(ProverPrepared, "_autosetup", fake_autosetup)
+    monkeypatch.setattr(ProverPrepared, "_invariants", fake_invariants)
+    with pytest.raises(BaseException) as caught:  # noqa: PT011 — the outcome under test
+        await prepared.prepare_formalization(cast(Any, None))
+    return caught.value
+
+
+async def test_a_setup_failure_cancels_the_invariants(monkeypatch):
+    # The invariants agent has nowhere to deliver once the setup is dead, so it stops there instead
+    # of spending out its own run — and the caller sees the setup's own error, not a group.
+    boom = RuntimeError("the setup failed")
+    invariants = _Step(30, None)
+
+    raised = await _fan_out(monkeypatch, setup=_Step(0.01, boom), invariants=invariants)
+
+    assert raised is boom
+    assert invariants.cancelled and not invariants.finished
+
+
+async def test_an_invariants_failure_cancels_the_setup(monkeypatch):
+    # Symmetric: the setup builds a config the failed side's specs would have been written against.
+    boom = RuntimeError("invariant formulation failed")
+    setup = _Step(30, None)
+
+    raised = await _fan_out(monkeypatch, setup=setup, invariants=_Step(0.01, boom))
+
+    assert raised is boom
+    assert setup.cancelled and not setup.finished


### PR DESCRIPTION
## What

`run_pipeline_inner` started the pre-formalization work with a bare `asyncio.create_task` and did
not await it until after the whole property-extraction fan-out had finished. A fatal error inside
it was stored on the task object and sat there unobserved for as long as extraction took. In one
run that was 41 minutes and four bug-analysis agents' worth of spend on a run that could no longer
produce anything, and none of it was kept: extraction batches are only persisted downstream of the
await.

`prepare_formalization`'s own `asyncio.gather` had the other half of the problem. Without
`return_exceptions`, gather propagates the first child's exception to its awaiter immediately and
does not cancel the remaining children. It only cancels them when the gathering future itself is
cancelled. So the sibling detached and ran to completion too. Fixing one level leaves the other,
which is why both are here.

The driver already had the right shape one step earlier. The preflight and the system analysis
share a task group, and the comment there states the policy: neither side outlives the other's
failure. This applies that policy at the concurrency points that were missing it.

## How

`gated_group()` in `composer/io/multi_job.py` yields an `asyncio.TaskGroup` and unwraps the
resulting `BaseExceptionGroup`, so the caller sees the failure itself when only one member really
failed and keeps the group when two fail at once. It sits beside `maybe_semaphore`, and both edit
sites already import from that module, so there are no new import edges.

Five call sites use it: the preflight and analysis overlap, whose now-duplicated inline unwrap is
deleted rather than left beside the helper; the pre-formalization and extraction overlap; the
per-unit extraction fan-out; the plugin pre-inference fan-out; and the AutoSetup and invariants
pair. Task objects are held rather than completion order, so callers that depend on result order
still get it.

The unwrap re-raises outside the `except` block. `raise exc from None` would clear `__cause__` and
suppress `__context__`, which matters for a wrapper whose message only points at the exception it
wraps.

`task_logger` gains a `CancelledError` branch, so a cancelled task's tokens are folded into the
per-phase breakdown instead of being left in the in-flight map. Cancellations appear in the
per-row status but are excluded from the failure roll-up, so one real failure in an N-unit fan-out
does not print as N failures.

## Deliberately unchanged

The per-component `asyncio.gather(..., return_exceptions=True)` stays as it is. Per-component
failure isolation is the opposite policy on purpose.

The four bare fatal gathers in the natspec driver are the same class in a different pipeline, and
are left for a follow-up.

## Known gap

A cancelled task does not fire its handler's `on_error`, because `run_task` catches `Exception` and
`CancelledError` is not one, so its row stays at RUNNING until the process exits. This predates the
change, since the first overlap already cancelled, but gating the extraction fan-out turns it from
a one-row artefact into a many-row one. Widening the handler touches three UI factories, so it is
out of scope here.

## Testing

Four new test modules. `tests/test_gated_group.py` covers the primitive: a failure cancels a 30s
sibling and surfaces itself, a double failure keeps the group, cancelling the holder cancels the
members, and a member raised with `from` keeps its cause through the unwrap.
`tests/test_extraction_fanout_gate.py` drives the real `_extract_all` with only the LLM call
stubbed, covering both fan-outs inside it. `tests/test_prover_prepare_formalization_gate.py` covers
the AutoSetup and invariants pair in both directions. `tests/test_cancelled_task_accounting.py`
covers the new accounting branch and the roll-up.

`tests/test_pipeline_overlap.py`'s module docstring and its two second-pair tests described the old
behaviour as intended, so they are rewritten to state the policy, with a non-zero delay on the
surviving side so they assert cancellation rather than winning a race. A third test covers
caller-side cancellation reaching the second pair. Those three tests waited a fixed interval before
cancelling and were flaky under parallel load; they now wait on an event the stub sets when it
starts.

Each new test was checked by putting `asyncio.gather` back in place of the gate and confirming it
fails.

Targeted run: 35 passed. `pyright composer/ analyzer sanity_analyzer certora_autosetup`: 0 errors.
