### PR TITLE
cache key: invalidate on the AutoProver build (fold tool version into root_cache_key)

### DIFF
--- a/composer/cli/cache_autoprove.py
+++ b/composer/cli/cache_autoprove.py
@@ -41,7 +41,7 @@ from composer.spec.source.harness import (
     AgentSystemDescription,
     HarnessResult,
 )
-from composer.pipeline.cli import root_cache_key, user_ns
+from composer.pipeline.cli import autoprover_version, root_cache_key, user_ns
 from composer.pipeline.keys import (
     AGENT_RESULT_KEY, AGENT_ROUND_KEY, BUG_ANALYSIS_KEY,
     COMMON_SYSTEM_CACHE_KEY, COMPONENT_KEY, FORMALIZATION_KEY,
@@ -473,7 +473,7 @@ def _resolve_from_inputs(args: argparse.Namespace) -> AutoProveCacheTags | None:
 
     root_ns = user_ns(
         args.cache_ns,
-        root_cache_key(str(project_root), sys_path, relative_path, contract_name),
+        root_cache_key(str(project_root), sys_path, relative_path, contract_name, autoprover_version()),
     )
     memory_ns = args.memory_ns
     if memory_ns:

--- a/composer/pipeline/cli.py
+++ b/composer/pipeline/cli.py
@@ -53,11 +53,28 @@ from composer.spec.util import fs_forbidden_read
 import hashlib
 
 
+def autoprover_version() -> str:
+    """The git commit recorded for a ``git+``-installed ``ai-composer`` (its ``direct_url.json``),
+    else the package version, else ``"unknown"``."""
+    try:
+        from importlib.metadata import distribution
+        dist = distribution("ai-composer")
+        raw = dist.read_text("direct_url.json")
+        if raw:
+            commit = json.loads(raw).get("vcs_info", {}).get("commit_id")
+            if commit:
+                return str(commit)
+        return dist.version
+    except Exception:
+        return "unknown"
+
+
 def root_cache_key(
     project_root: str,
     system_doc_path: pathlib.Path | None,
     relative_path: str,
     contract_name: str,
+    tool_version: str,
 ):
     # A source-only run (no design doc) hashes a fixed sentinel in place of the doc
     # bytes, so it gets a stable key that is distinct from any real document.
@@ -66,7 +83,7 @@ def root_cache_key(
         if system_doc_path is not None
         else "no-design-doc"
     )
-    combined = "|".join([project_root, doc_hash, relative_path, contract_name])
+    combined = "|".join([project_root, doc_hash, relative_path, contract_name, tool_version])
     return hashlib.sha256(combined.encode()).hexdigest()
 
 
@@ -334,7 +351,8 @@ async def cli_pipeline[P: enum.Enum, H](
                 project_root=str(project_root),
                 contract_name=contract_name,
                 relative_path=relative_path,
-                system_doc_path=system_doc
+                system_doc_path=system_doc,
+                tool_version=autoprover_version(),
             )
             cache_root = user_ns(args.cache_ns, root_key) if args.cache_ns is not None else None
 

--- a/composer/rustapp/entry.py
+++ b/composer/rustapp/entry.py
@@ -44,7 +44,7 @@ from composer.input.types import (
 )
 from composer.io.multi_job import HandlerFactory, TaskInfo, run_task
 from composer.io.thread_logging import default_logging_ns, thread_logger
-from composer.pipeline.cli import root_cache_key
+from composer.pipeline.cli import autoprover_version, root_cache_key
 from composer.pipeline.core import CorePipelineResult, DEFAULT_MAX_CPU_TASKS
 from composer.pipeline.ecosystem import Ecosystem
 from composer.rag.models import DefaultEmbedder, get_model
@@ -143,6 +143,7 @@ def _root_cache_key(
         system_doc_path=system_doc_path,
         relative_path=relative_path,
         contract_name=contract_name,
+        tool_version=autoprover_version(),
     )
 
 

--- a/tests/test_root_cache_key.py
+++ b/tests/test_root_cache_key.py
@@ -1,0 +1,42 @@
+"""The root cache key must fold in the AutoProver build (`tool_version`).
+
+Without it, re-running the same repo+doc+contract with a NEW prover/detector build reuses a prior
+run's cached CVL + proof results (a "SUCCEEDED with 0 prover calls" no-op). These tests pin that the
+build perturbs the key, that the historical inputs still do, and that the version helper is robust.
+"""
+
+import pathlib
+
+from composer.pipeline.cli import autoprover_version, root_cache_key
+
+
+def _key(tmp: pathlib.Path, *, tool_version: str = "v1", doc: str = "D") -> str:
+    p = tmp / "design.md"
+    p.write_text(doc)
+    return root_cache_key(
+        project_root=str(tmp),
+        system_doc_path=p,
+        relative_path="src/Router.sol",
+        contract_name="Router",
+        tool_version=tool_version,
+    )
+
+
+def test_same_inputs_same_key(tmp_path: pathlib.Path) -> None:
+    assert _key(tmp_path) == _key(tmp_path)
+
+
+def test_tool_version_perturbs_the_key(tmp_path: pathlib.Path) -> None:
+    # A new prover/detector build must NOT reuse a prior build's cached CVL.
+    assert _key(tmp_path, tool_version="build-A") != _key(tmp_path, tool_version="build-B")
+
+
+def test_doc_and_contract_still_perturb_the_key(tmp_path: pathlib.Path) -> None:
+    # The historical inputs remain part of the key.
+    assert _key(tmp_path, doc="one") != _key(tmp_path, doc="two")
+
+
+def test_autoprover_version_is_a_nonempty_string() -> None:
+    # Best-effort identity of the running build; never raises, always a usable key component.
+    v = autoprover_version()
+    assert isinstance(v, str) and v


### PR DESCRIPTION
## Problem

Re-running autoprove on the same repo + design-doc + contract reused a prior
run's cached CVL **and proof results**, "SUCCEEDING" in a few minutes with
**0 prover calls** — the `CVL_GEN` phase never even entered the DAG (on a cache
hit the `TaskInfo` is never created). A new prover/detector build was silently
ignored: nothing was re-proved, yet the run reported success.

Root cause: `root_cache_key` hashed only `(project_root, design-doc bytes,
relative_path, contract_name)` — **nothing that identifies the prover build** —
so a new AutoProver/composer version keys into the same cache entry and serves
the previous run's CVL.

## Fix

Fold a `tool_version` — the identity of the running AutoProver/`ai-composer`
build — into `root_cache_key`. A new build now produces a different key and
does not reuse stale CVL/proofs.

`autoprover_version()` derives it best-effort:
- the git commit recorded for a `git+`-installed `ai-composer` (PEP 610
  `direct_url.json`), which is how the package is installed in the deployed
  environment;
- else the package version;
- else `"unknown"`.

Callers updated: `console/tui` (`cli.py`), `cache-autoprove`, and `rustapp`.
New unit test pins that the build and the design doc both perturb the key and
that the helper never raises.

## Why `direct_url.json` (and the follow-up)

The idiomatic source of a version is `importlib.metadata.version("ai-composer")`
— but AutoProver's version is **static** (`version = "0.1.0"` in `pyproject.toml`),
so it's identical across builds and useless for cache invalidation. As a
pragmatic stand-in this reads the install-source commit from `direct_url.json`,
which is populated because the package is installed from a `git+…@<commit>`
pin. It falls back to the static version on a wheel/editable install (where it
wouldn't invalidate — not a concern for the git-pinned deployment, but worth
naming).

**Future change (separate PR):** switch AutoProver to VCS-derived versioning
(`hatch-vcs`: `dynamic = ["version"]`, drop the static `version =`). Then
`importlib.metadata.version("ai-composer")` encodes the commit
(`0.1.0.dev4+g<sha>`), `autoprover_version()` collapses to a one-liner reading
the real package version, and "the cache key" and "what `--version` reports"
become the same thing — working for any install shape. Deferred here because it
touches the build system / CI / the `.version` artifact and deserves its own PR.

## Scope note — this is the *build*-invalidation half

Invalidating on a new **source commit** of the verified repo is a companion
change and lands separately (sources are staged as a `.git`-less bundle, so the
commit has to be plumbed in): the cloud entry point folds the workflow's git
commit into `--cache-ns`, and the job launcher passes it into the executor env.

This PR is independent and stands alone — `tool_version` self-derives from the
installed package, so it fixes the invalidation bug with no launcher changes.