### PR TITLE
Bound the AutoSetup wait, and stop the task holding it from outliving the run

### DIFF
--- a/composer/cli/console_autoprove.py
+++ b/composer/cli/console_autoprove.py
@@ -1,12 +1,15 @@
 """Entry point for the auto-prove pipeline — console (no TUI) mode."""
 
 import asyncio
+import logging
 
 import composer.bind as _
 
 from composer.diagnostics.timing import RunSummary
 from composer.ui.autoprove_console import AutoProveConsoleHandler
 from composer.spec.source.autoprove_common import _entry_point
+
+_logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -32,6 +35,30 @@ async def _main() -> int:
         return 0
 
 
+def _name_pending(loop: asyncio.AbstractEventLoop) -> None:
+    """Say what the loop still holds before it is asked to close.
+
+    Closing cancels whatever is left and then waits for all of it, with no bound. Anything named
+    here is something that wait can be spent on.
+    """
+    pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+    if pending:
+        _logger.info(
+            "%d task(s) still running at shutdown: %s",
+            len(pending),
+            ", ".join(sorted(t.get_name() for t in pending)),
+        )
+
+
 def main() -> int:
-    return asyncio.run(_main())
+    runner = asyncio.Runner()
+    try:
+        try:
+            return runner.run(_main())
+        finally:
+            _logger.info("pipeline returned; shutting the event loop down")
+            _name_pending(runner.get_loop())
+    finally:
+        runner.close()
+        _logger.info("event loop closed")
 

--- a/composer/pipeline/cli.py
+++ b/composer/pipeline/cli.py
@@ -1,5 +1,6 @@
 from typing import Protocol, AsyncIterator, TYPE_CHECKING
 import json
+import logging
 import sys
 import pathlib
 import enum
@@ -51,6 +52,8 @@ if TYPE_CHECKING:
 
 from composer.spec.util import fs_forbidden_read
 import hashlib
+
+_logger = logging.getLogger(__name__)
 
 
 def autoprover_version() -> str:
@@ -443,3 +446,4 @@ async def cli_pipeline[P: enum.Enum, H](
                     await at_exit(init_source, data_logger)
                 except Exception:
                     pass
+                _logger.info("run exit handlers done")

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -36,7 +36,8 @@ from typing import (
     Protocol, Any, ClassVar, Concatenate, cast, Awaitable, Sequence, Callable, ContextManager, overload
 )
 from abc import ABC, abstractmethod
-from contextlib import nullcontext
+from contextlib import nullcontext, asynccontextmanager
+from collections.abc import AsyncIterator, Coroutine
 
 
 from composer.io.multi_job import TaskInfo
@@ -458,6 +459,24 @@ async def _run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: Artifact
             extra_context=extra_context, max_bug_rounds=max_bug_rounds, ecosystem=ecosystem,
         )
 
+
+@asynccontextmanager
+async def _alongside[T](coro: Coroutine[Any, Any, T]) -> AsyncIterator[asyncio.Task[T]]:
+    """Run ``coro`` beside the body, and end it with the body rather than letting it outlive it.
+
+    A task still running when its scope is left is reachable only by ``asyncio.run``'s teardown,
+    which cancels it after the run's exit handlers have finished and then waits for it with no
+    bound of its own. Whatever the task is holding at that point is held there.
+    """
+    task = asyncio.create_task(coro)
+    try:
+        yield task
+    except BaseException:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        raise
+
+
 # ---- the driver --------------------------------------------------------------
 async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactIdentifier, U: FeatureUnit, Main, App: BaseApplication, Pre](
     backend: PipelineBackend[P, FormT, H, A, U, Main, App, Pre],
@@ -527,23 +546,22 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
     async def _prepare_formalization() -> Formalizer[FormT, U] | StagedFormalizer[FormT, U]:
         with named_budget_or_nop("formalization_preparation"):
             return await prepared.prepare_formalization(run)
-    staged_task = asyncio.create_task(_prepare_formalization())
-
-    batches: list[_Batch[U]] = await _extract_all(
-        backend.analysis_spec.properties_key,
-        prepared.main,
-        backend.backend_guidance,
-        run,
-        phases["extraction"],
-        interactive,
-        threat_model,
-        extra_context,
-        max_bug_rounds,
-        ecosystem,
-        plugin_manager.bind_phase(
-            phases.get("extraction_plugin") or phases["extraction"],
+    async with _alongside(_prepare_formalization()) as staged_task:
+        batches: list[_Batch[U]] = await _extract_all(
+            backend.analysis_spec.properties_key,
+            prepared.main,
+            backend.backend_guidance,
+            run,
+            phases["extraction"],
+            interactive,
+            threat_model,
+            extra_context,
+            max_bug_rounds,
+            ecosystem,
+            plugin_manager.bind_phase(
+                phases.get("extraction_plugin") or phases["extraction"],
+            )
         )
-    )
     staged = await staged_task
     if not batches:
         raise ValueError("No properties extracted from any component.")

--- a/composer/spec/source/autosetup.py
+++ b/composer/spec/source/autosetup.py
@@ -85,6 +85,36 @@ async def _drain(
         sink(buf)
 
 
+#: How long to give the AutoSetup child to exit before we stop waiting on it. The wait below sits
+#: in a ``finally`` that a cancellation also travels through, so it has to be bounded: an
+#: unbounded wait there parks the whole run behind one subprocess, with no timeout above it that
+#: can help and nothing left running to say why.
+_REAP_TIMEOUT_S = 30.0
+
+
+async def _reap(proc: asyncio.subprocess.Process) -> int | None:
+    """Wait for ``proc`` to exit, escalating to a kill, and stop waiting rather than block forever.
+
+    Returns the exit status, or ``None`` if the child could not be reaped at all — a child that
+    will not die tells us nothing about whether AutoSetup succeeded, so the caller treats that as
+    a failure.
+    """
+    for escalate in (False, True):
+        if escalate and proc.returncode is None:
+            _logger.warning(
+                "AutoSetup child still alive after %.0fs, killing it", _REAP_TIMEOUT_S
+            )
+            proc.kill()
+        try:
+            async with asyncio.timeout(_REAP_TIMEOUT_S):
+                # Shielded: the timeout must cancel our wait, not the child's exit plumbing.
+                return await asyncio.shield(proc.wait())
+        except TimeoutError:
+            continue
+    _logger.error("AutoSetup child outlived a kill, giving up on it and continuing")
+    return proc.returncode
+
+
 async def run_autosetup(
     project_root: Path,
     relative_path: str,
@@ -176,7 +206,12 @@ async def run_autosetup(
             raise
         finally:
             _logger.debug("AutoSetup process complete, waiting for exit")
-            returncode = await proc.wait()
+            returncode = await _reap(proc)
+        if returncode is None:
+            return SetupFailure(
+                error="AutoSetup did not exit",
+                stderr="\n".join(stderr_lines),
+            )
         cb.log_complete(returncode)
         if returncode != 0:
             return SetupFailure(

--- a/composer/spec/source/autosetup.py
+++ b/composer/spec/source/autosetup.py
@@ -10,6 +10,7 @@ import logging
 import re
 import sys
 import tempfile
+import time
 from collections.abc import Callable
 from pydantic import BaseModel, Field
 from pathlib import Path
@@ -99,6 +100,7 @@ async def _reap(proc: asyncio.subprocess.Process) -> int | None:
     will not die tells us nothing about whether AutoSetup succeeded, so the caller treats that as
     a failure.
     """
+    started = time.monotonic()
     for escalate in (False, True):
         if escalate and proc.returncode is None:
             _logger.warning(
@@ -108,10 +110,19 @@ async def _reap(proc: asyncio.subprocess.Process) -> int | None:
         try:
             async with asyncio.timeout(_REAP_TIMEOUT_S):
                 # Shielded: the timeout must cancel our wait, not the child's exit plumbing.
-                return await asyncio.shield(proc.wait())
+                returncode = await asyncio.shield(proc.wait())
         except TimeoutError:
             continue
-    _logger.error("AutoSetup child outlived a kill, giving up on it and continuing")
+        # Logged where it ends, not only where it begins: a wait that says nothing on the way out
+        # cannot be told apart, afterwards, from one that never returned.
+        _logger.info(
+            "AutoSetup child exited %d after %.1fs", returncode, time.monotonic() - started
+        )
+        return returncode
+    _logger.error(
+        "AutoSetup child outlived a kill after %.1fs, giving up on it and continuing",
+        time.monotonic() - started,
+    )
     return proc.returncode
 
 

--- a/tests/test_autosetup_reap.py
+++ b/tests/test_autosetup_reap.py
@@ -1,0 +1,38 @@
+"""Tests for the bounded reap of the AutoSetup subprocess (``composer/spec/source/autosetup.py``).
+
+The wait for the child sits in a ``finally``, which is also the path a cancelled run takes on its
+way out. Whatever the child is doing, that wait has to end.
+"""
+
+import asyncio
+import sys
+
+import pytest
+
+from composer.spec.source import autosetup
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spawn(code: str) -> asyncio.subprocess.Process:
+    return await asyncio.create_subprocess_exec(
+        sys.executable, "-c", code,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        stdin=asyncio.subprocess.DEVNULL,
+    )
+
+
+async def test_a_child_that_exits_reports_its_status():
+    proc = await _spawn("raise SystemExit(3)")
+    assert await autosetup._reap(proc) == 3
+
+
+async def test_a_child_that_will_not_exit_is_killed(monkeypatch):
+    monkeypatch.setattr(autosetup, "_REAP_TIMEOUT_S", 0.2)
+    # Ignores SIGTERM, so only the kill ends it.
+    proc = await _spawn(
+        "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(300)"
+    )
+    returncode = await asyncio.wait_for(autosetup._reap(proc), timeout=10)
+    assert returncode is not None and returncode < 0

--- a/tests/test_autosetup_reap.py
+++ b/tests/test_autosetup_reap.py
@@ -36,3 +36,39 @@ async def test_a_child_that_will_not_exit_is_killed(monkeypatch):
     )
     returncode = await asyncio.wait_for(autosetup._reap(proc), timeout=10)
     assert returncode is not None and returncode < 0
+
+
+async def test_the_reap_ends_inside_a_cancelled_task(monkeypatch):
+    """The shape a run takes on its way out: the wait sits in a ``finally`` of a cancelled task.
+
+    ``asyncio.timeout`` there has to raise ``TimeoutError`` off its own timer rather than pass the
+    task's pending cancellation through, or the escalation never happens and the task never
+    finishes unwinding.
+    """
+    monkeypatch.setattr(autosetup, "_REAP_TIMEOUT_S", 0.2)
+    proc = await _spawn(
+        "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(300)"
+    )
+    reaped: list[int | None] = []
+
+    async def run_and_reap() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            reaped.append(await autosetup._reap(proc))
+
+    task = asyncio.create_task(run_and_reap())
+    await asyncio.sleep(0.05)
+    task.cancel()
+
+    _, pending = await asyncio.wait({task}, timeout=10)
+    assert not pending, "the reap never returned inside a cancelled task"
+    assert task.cancelled()
+    assert reaped and reaped[0] is not None and reaped[0] < 0
+
+
+async def test_the_reap_says_how_it_ended(caplog):
+    proc = await _spawn("raise SystemExit(0)")
+    with caplog.at_level("INFO", logger="composer.spec.source.autosetup"):
+        assert await autosetup._reap(proc) == 0
+    assert any("AutoSetup child exited 0" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## What went wrong

Two cloud runs sat for 22 hours until the job's hard time cap killed them, and that cap skips the results upload, so both were a total loss.

An Anthropic API error killed one extraction task in each run. The failure unwound out of the pipeline, the run's exit handlers ran, and then `asyncio.run`'s teardown cancelled what was left and waited for it. One of the two runs had an AutoSetup subprocess live inside an orphaned task at that moment; its log ends with the `CancelledError` coming out of `_drain` and then the debug line in the `finally`, so it was last seen going into `await proc.wait()` with nothing bounding it. The other had finished AutoSetup cleanly twelve seconds earlier and froze at the same point in teardown with no subprocess anywhere on its stack.

So this PR is not the fix for the incident. The process-level backstop is AIAutoProver#80.

## The change

**`_reap`**: wait up to 30s, kill the child, wait another 30s, then give up and let the run continue. Nothing is killed on the normal path, where the first wait returns as soon as the pipes are at EOF. A child that could not be reaped is reported as a failed AutoSetup. The bound is a loop timer rather than anything about the child, so it holds whether or not the child can be reaped.

**The orphan**: the formalization task is started to overlap with extraction and awaited after it, and nothing cancels it in between. An extraction that raises therefore leaves it running into teardown. `_alongside` ties it to the block it accompanies, so it is cancelled and awaited while the loop is still healthy rather than after the exit handlers have run.

**The log**: the reap said where it began and nothing on the way out, which is why the incident logs are ambiguous about whether the wait ever returned. It now reports the exit status and how long it took. `console-autoprove` drives the loop through an explicit `Runner`, which gives the close a before and an after and a place to name the tasks still running when it starts; those are what the unbounded cancel-and-wait inside `close()` is spent on.

## Tests

`tests/test_autosetup_reap.py`: a child that exits reports its status, a child that ignores SIGTERM is killed and reaped within the bound, the reap ends when it runs in the `finally` of an already-cancelled task, and it says how it ended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
