### PR TITLE
Retry a rejected report grouping instead of falling back

### DIFF
--- a/composer/spec/source/report/grouping.py
+++ b/composer/spec/source/report/grouping.py
@@ -1,23 +1,32 @@
 """LLM-driven grouping of inferred properties into high-level audit claims.
 
-A single structured LLM call takes the `FormalizedProperty` list and partitions it into high-level
+A structured LLM call takes the `FormalizedProperty` list and partitions it into high-level
 `PropertyGroup`s (the "P-NN" headings) — each property in exactly one group, while the rules those
 properties are formalized by may surface under several groups. Each group's status is rolled up from
 its members' rules' verdicts. Groups are identified by the slug the LLM assigns — a per-run snapshot.
 
+A response that misses the schema costs the report every heading it has, so two things stand
+between a malformed answer and the fallback: a grouping the model serialized into a string is
+decoded rather than rejected, and a response that still does not validate is retried once with the
+rejection appended.
+
 A single ``general`` fallback group (every property in one group) is used by `build` when the LLM
 call raises, validation rejects the grouping, or the grouping covers no properties.
 """
+import json
+import logging
 from typing import Iterable
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from composer.templates.loader import load_jinja_template
 from composer.spec.source.report.schema import (
     FormalizedProperty, GroupStatus, Outcome, PropertyGroup, PropertyKey, RuleRef,
 )
+
+_log = logging.getLogger(__name__)
 
 FALLBACK_SLUG = "general"
 FALLBACK_TITLE = "General"
@@ -72,15 +81,43 @@ class GroupingResult(BaseModel):
         "exactly once."
     )
 
+    @field_validator("groups", mode="before")
+    @classmethod
+    def _decode_serialized_groups(cls, v: object) -> object:
+        """Accept a grouping the model serialized into a string instead of returning as a list.
+
+        Structured output sometimes arrives with the whole result document JSON-encoded into the
+        one field meant to hold the list, or with the list itself encoded. The grouping in it is
+        complete; only the envelope is wrong, so decode it rather than throwing away a usable
+        answer and heading for the single-bucket fallback. Anything that does not decode is
+        handed back untouched for pydantic to reject as it normally would."""
+        if not isinstance(v, str):
+            return v
+        try:
+            decoded = json.loads(v)
+        except json.JSONDecodeError:
+            return v
+        if isinstance(decoded, dict) and "groups" in decoded:
+            return decoded["groups"]
+        return decoded
+
 
 async def call_grouping_llm(
     *,
     llm: BaseChatModel,
     contract_name: str,
     properties: list[FormalizedProperty],
+    max_attempts: int = 2,
 ) -> GroupingResult:
     """One structured LLM call: the property list in, a `GroupingResult` out, via langchain's
-    `with_structured_output`. The model + token budget come from the passed `llm`."""
+    `with_structured_output`. The model + token budget come from the passed `llm`.
+
+    A response that does not match the schema is retried once with the rejection appended, the
+    way `spec/prioritize.py` corrects a ranking. Without it a single malformed response costs the
+    report every heading it has, and the caller's fallback is meant for a grouping that could not
+    be obtained at all, not for one the model would have got right on a second look. The
+    correction is appended to the original request rather than sent as a follow-up turn, so the
+    retry stays one self-contained user message."""
     system = load_jinja_template("autoprove_report_grouping_system.j2")
     user = load_jinja_template(
         "autoprove_report_grouping_prompt.j2",
@@ -88,9 +125,23 @@ async def call_grouping_llm(
         properties=properties,
     )
     bound = llm.with_structured_output(GroupingResult)
-    result = await bound.ainvoke([SystemMessage(system), HumanMessage(user)])
-    assert isinstance(result, GroupingResult)
-    return result
+
+    prompt = user
+    for attempt in range(max_attempts):
+        try:
+            result = await bound.ainvoke([SystemMessage(system), HumanMessage(prompt)])
+        except ValidationError as e:
+            if attempt == max_attempts - 1:
+                raise
+            _log.warning("report grouping rejected (attempt %d): %s", attempt + 1, e)
+            prompt = (
+                f"{user}\n\nA previous attempt was rejected:\n\n{e}\n\n"
+                "Return the corrected grouping as structured output matching the schema."
+            )
+            continue
+        assert isinstance(result, GroupingResult)
+        return result
+    raise AssertionError("unreachable: the loop returns or raises")
 
 
 def build_groups(

--- a/composer/spec/source/report/grouping.py
+++ b/composer/spec/source/report/grouping.py
@@ -5,21 +5,18 @@ A structured LLM call takes the `FormalizedProperty` list and partitions it into
 properties are formalized by may surface under several groups. Each group's status is rolled up from
 its members' rules' verdicts. Groups are identified by the slug the LLM assigns — a per-run snapshot.
 
-A response that misses the schema costs the report every heading it has, so two things stand
-between a malformed answer and the fallback: a grouping the model serialized into a string is
-decoded rather than rejected, and a response that still does not validate is retried once with the
-rejection appended.
+A response that misses the schema costs the report every heading it has, so one thing stands
+between a malformed answer and the fallback: the call is retried once with the rejection appended.
 
 A single ``general`` fallback group (every property in one group) is used by `build` when the LLM
 call raises, validation rejects the grouping, or the grouping covers no properties.
 """
-import json
 import logging
 from typing import Iterable
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, ValidationError
 
 from composer.templates.loader import load_jinja_template
 from composer.spec.source.report.schema import (
@@ -80,26 +77,6 @@ class GroupingResult(BaseModel):
         description="The high-level property groups; collectively they cover every input property "
         "exactly once."
     )
-
-    @field_validator("groups", mode="before")
-    @classmethod
-    def _decode_serialized_groups(cls, v: object) -> object:
-        """Accept a grouping the model serialized into a string instead of returning as a list.
-
-        Structured output sometimes arrives with the whole result document JSON-encoded into the
-        one field meant to hold the list, or with the list itself encoded. The grouping in it is
-        complete; only the envelope is wrong, so decode it rather than throwing away a usable
-        answer and heading for the single-bucket fallback. Anything that does not decode is
-        handed back untouched for pydantic to reject as it normally would."""
-        if not isinstance(v, str):
-            return v
-        try:
-            decoded = json.loads(v)
-        except json.JSONDecodeError:
-            return v
-        if isinstance(decoded, dict) and "groups" in decoded:
-            return decoded["groups"]
-        return decoded
 
 
 async def call_grouping_llm(

--- a/tests/test_autoprove_report.py
+++ b/tests/test_autoprove_report.py
@@ -11,9 +11,11 @@ which is how a caller hands a gap to the report layer).
 """
 from types import SimpleNamespace
 from typing import Any, cast
+import json
 import pathlib
 
 import pytest
+from pydantic import ValidationError as PydanticValidationError
 from prover_output_utility.models import NodeStatus
 from prover_output_utility import ProverOutputAPI
 from langchain_core.language_models import BaseChatModel
@@ -30,6 +32,7 @@ from composer.spec.source.artifacts import ProverArtifactStore
 from composer.spec.source.report import build
 from composer.spec.source.report.collect import ReportComponentInput, collect
 from composer.spec.source.report.coverage import ValidationError, validate
+from composer.spec.source.report import grouping
 from composer.spec.source.report.grouping import (
     FALLBACK_SLUG, GroupingResult, PropertyGroupDraft, aggregate_status,
     build_fallback_grouping, build_groups,
@@ -590,6 +593,87 @@ async def test_build_groups_properties(tmp_path):
     assert [g.slug for g in report.groups] == ["g"]
     assert {p.title for p in report.properties} == {"p1", "p2"}
     assert report.coverage.property_coverage_complete is True
+
+
+def test_grouping_result_decodes_a_string_wrapped_document():
+    # Observed in a cloud run: the model serialized the whole result into the one field meant to
+    # hold the list. The grouping was complete, so it must not cost the report its headings.
+    payload = json.dumps({"groups": [
+        {"slug": "g", "title": "G", "description": "d", "members": [["C", "p1"], ["C", "p2"]]}
+    ]})
+    r = GroupingResult.model_validate({"groups": payload})
+    assert [g.slug for g in r.groups] == ["g"]
+    assert r.groups[0].members == [("C", "p1"), ("C", "p2")]
+
+
+def test_grouping_result_decodes_a_string_wrapped_list():
+    payload = json.dumps([
+        {"slug": "g", "title": "G", "description": "d", "members": [["C", "p1"]]}
+    ])
+    assert [g.slug for g in GroupingResult.model_validate({"groups": payload}).groups] == ["g"]
+
+
+def test_grouping_result_still_rejects_a_string_that_is_not_a_grouping():
+    with pytest.raises(PydanticValidationError):
+        GroupingResult.model_validate({"groups": "not json at all"})
+
+
+class _FlakyStructuredModel(_StructuredStubModel):
+    """Raises the given exceptions on successive calls, then returns `output`. Records how many
+    times the structured binding was invoked."""
+    failures: list[Exception]
+    calls: list[str] = []
+
+    def with_structured_output(self, schema, **kwargs) -> Runnable:  # type: ignore[override]
+        out, failures, calls = self.output, self.failures, self.calls
+
+        def _invoke(messages):
+            calls.append(messages[-1].content)
+            if failures:
+                raise failures.pop(0)
+            return out
+
+        return RunnableLambda(_invoke)
+
+
+def _schema_error() -> PydanticValidationError:
+    try:
+        GroupingResult.model_validate({"groups": 17})
+    except PydanticValidationError as e:
+        return e
+    raise AssertionError("expected a validation error")
+
+
+@pytest.mark.asyncio
+async def test_grouping_retries_once_with_the_rejection_appended():
+    good = GroupingResult(groups=[PropertyGroupDraft(
+        slug="g", title="G", description="d", members=[("C", "p1")])])
+    llm = _FlakyStructuredModel(output=good, failures=[_schema_error()], calls=[])
+
+    result = await grouping.call_grouping_llm(
+        llm=llm, contract_name="C", properties=[_fp("C", "p1", [])],
+    )
+
+    assert [g.slug for g in result.groups] == ["g"]
+    assert len(llm.calls) == 2
+    # The retry carries the rejection, and still stands alone as one request.
+    assert "A previous attempt was rejected" in llm.calls[1]
+    assert "A previous attempt was rejected" not in llm.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_grouping_gives_up_after_the_retry_so_the_caller_can_fall_back():
+    llm = _FlakyStructuredModel(
+        output=GroupingResult(groups=[]),
+        failures=[_schema_error(), _schema_error()],
+        calls=[],
+    )
+
+    with pytest.raises(PydanticValidationError):
+        await grouping.call_grouping_llm(
+            llm=llm, contract_name="C", properties=[_fp("C", "p1", [])],
+        )
+    assert len(llm.calls) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_autoprove_report.py
+++ b/tests/test_autoprove_report.py
@@ -11,7 +11,6 @@ which is how a caller hands a gap to the report layer).
 """
 from types import SimpleNamespace
 from typing import Any, cast
-import json
 import pathlib
 
 import pytest
@@ -593,29 +592,6 @@ async def test_build_groups_properties(tmp_path):
     assert [g.slug for g in report.groups] == ["g"]
     assert {p.title for p in report.properties} == {"p1", "p2"}
     assert report.coverage.property_coverage_complete is True
-
-
-def test_grouping_result_decodes_a_string_wrapped_document():
-    # Observed in a cloud run: the model serialized the whole result into the one field meant to
-    # hold the list. The grouping was complete, so it must not cost the report its headings.
-    payload = json.dumps({"groups": [
-        {"slug": "g", "title": "G", "description": "d", "members": [["C", "p1"], ["C", "p2"]]}
-    ]})
-    r = GroupingResult.model_validate({"groups": payload})
-    assert [g.slug for g in r.groups] == ["g"]
-    assert r.groups[0].members == [("C", "p1"), ("C", "p2")]
-
-
-def test_grouping_result_decodes_a_string_wrapped_list():
-    payload = json.dumps([
-        {"slug": "g", "title": "G", "description": "d", "members": [["C", "p1"]]}
-    ])
-    assert [g.slug for g in GroupingResult.model_validate({"groups": payload}).groups] == ["g"]
-
-
-def test_grouping_result_still_rejects_a_string_that_is_not_a_grouping():
-    with pytest.raises(PydanticValidationError):
-        GroupingResult.model_validate({"groups": "not json at all"})
 
 
 class _FlakyStructuredModel(_StructuredStubModel):


### PR DESCRIPTION
Fixes #211.

A cloud run produced a report whose `coverage.warnings` began with `FALLBACK
GROUPING APPLIED`, collapsing all 11 formalized properties into the single
`general` bucket. The cause:

```
report: grouping failed: 1 validation error for GroupingResult
groups
  Input should be a valid list [type=list_type, input_value='{"groups":[...]}', input_type=str]
```

The model serialized the whole `GroupingResult` document into the one field
meant to hold the list. The grouping was complete and correct; only the
encoding was wrong, and it landed in the same bucket as a transport failure.

## What changes

Grouping gets the corrective retry the ranker already has.
`call_grouping_llm` previously made one structured call and let any schema miss
reach `build`'s fallback. It now retries once with the rejection appended,
mirroring `rank_properties` in `composer/spec/prioritize.py`. The correction is
appended to the original request rather than sent as a second turn, so each
attempt stays one self-contained user message.

The single-bucket fallback is unchanged and still covers a grouping that could
not be obtained at all.

## Tests

Two added, both failing if `max_attempts` drops to 1:

- the retry fires once, carries the rejection, and the first attempt does not
- after the retry it raises, so the caller's fallback still applies

1200 pass, pyright clean.
