### PR TITLE
Check the budget while polling a cloud prover job

### DIFF
--- a/composer/diagnostics/budget.py
+++ b/composer/diagnostics/budget.py
@@ -305,6 +305,16 @@ def budget_pressure() -> bool:
     return any(r.pressured() for r in res)
 
 
+def exhausted_constraint() -> ConstraintType | None:
+    """The sort of the first active constraint that is past 100%, or ``None``.
+
+    ``budget_monitor`` only samples the budget between agent turns, so a single
+    long-blocking tool call runs unchecked however far past the deadline it goes.
+    Callers that wait on external work poll this themselves.
+    """
+    return next((r.sort for r in _get_constraints() if r.overbudget()), None)
+
+
 def pressure_abort_monitor() -> StateMonitor[MessagesState]:
     """Monitor for auxiliary agents (feedback judges) that should not outlive
     the main agent's wrap-up window: raises ``BudgetPressureAbort`` between

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -47,6 +47,7 @@ from composer.diagnostics.stream import (
 )
 from composer.authoring.state import make_validation_stamper, spec_digest
 from composer.spec.cvl_generation import CVLGenerationState
+from composer.diagnostics.budget import exhausted_constraint, raise_budget_exceeded
 from composer.diagnostics.timing import RunSummary, get_run_summary
 from graphcore.graph import tool_state_update
 from composer.spec.util import temp_certora_file
@@ -303,6 +304,18 @@ class _SpecCallbacks(ProverEventCallbacks):
             f"cloud poll tool_call={self._tool_call_id} status={status} "
             f"elapsed={elapsed:.1f}s msg={message}"
         )
+        # A cloud prover job is the longest single wait in the run, and waiting for one
+        # is a tool call: the author's monitor gets no turn to sample the budget while it
+        # blocks, so a run can sit here hours past its deadline. Poll the budget on each
+        # status tick instead. The author catches BudgetExceeded and curtails, the same
+        # way it does when its monitor trips; the job itself is left to finish in the
+        # cloud, since its link is already recorded.
+        if (sort := exhausted_constraint()) is not None:
+            _logger.info(
+                f"budget exhausted while polling tool_call={self._tool_call_id} "
+                f"sort={sort} elapsed={elapsed:.1f}s"
+            )
+            raise_budget_exceeded(sort)
         await super().on_cloud_poll(
             status, message
         )

--- a/tests/test_budget_poll_check.py
+++ b/tests/test_budget_poll_check.py
@@ -1,0 +1,47 @@
+"""Tests for the budget check on the cloud-poll callback.
+
+Waiting on a cloud prover job is one tool call, so the author's monitor gets no turn
+to sample the budget while it blocks. The callback samples it on every status tick
+instead.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from composer.diagnostics.budget import (
+    BudgetExceeded,
+    exhausted_constraint,
+    time_budget,
+)
+from composer.diagnostics.timing import RunSummary, install_run_summary
+from composer.spec.source.prover import _SpecCallbacks
+
+
+def _callbacks(summary: RunSummary) -> _SpecCallbacks:
+    return _SpecCallbacks(lambda _e: None, "toolu_test", summary, {})
+
+
+def _summary_started_ago(seconds: float) -> RunSummary:
+    """A run summary whose clock already reads ``seconds`` of wall time."""
+    return RunSummary(started_at_mono=time.perf_counter() - seconds)
+
+
+def test_no_budget_installed_never_raises() -> None:
+    install_run_summary(_summary_started_ago(10_000))
+    assert exhausted_constraint() is None
+
+
+def test_poll_raises_once_the_time_budget_is_spent() -> None:
+    summary = _summary_started_ago(7_300)
+    install_run_summary(summary)
+    with time_budget(7_200), pytest.raises(BudgetExceeded, match="Time budget"):
+        asyncio.run(_callbacks(summary).on_cloud_poll("RUNNING", "Cloud job 0059382f: RUNNING"))
+
+
+def test_poll_is_quiet_while_inside_the_budget() -> None:
+    summary = _summary_started_ago(60)
+    install_run_summary(summary)
+    with time_budget(7_200):
+        asyncio.run(_callbacks(summary).on_cloud_poll("RUNNING", "Cloud job 0059382f: RUNNING"))


### PR DESCRIPTION
`budget_monitor` only samples the budget between agent turns. A cloud prover job is the longest single wait in a run and it happens inside one tool call, so nothing checks the budget for its entire duration.

Seen on a dev run with a 7200s budget: still polling a prover job three hours in, no wrap-up warning, no curtailment, because the run never left the tool call.

- `exhausted_constraint()` mirrors the existing `budget_pressure()` and returns the sort of the first constraint past 100%.
- `_SpecCallbacks.on_cloud_poll` checks it on each status tick (~10s) and calls `raise_budget_exceeded`. The author catches that at `composer/spec/source/author.py:800` and returns `Curtailed`, the same path as when its monitor trips between turns.

The cloud job is left running and its link is already recorded, so nothing recoverable is thrown away.

Not addressed here: a run can still overshoot inside any other long blocking tool call, and agents that do not pass `on_overbudget` ignore the budget entirely. One check at phase boundaries would cover both, but that is a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)