### PR TITLE
Multi-spec buffers: parallel, per-precision CVL verification

### DIFF
--- a/certora_autosetup/cache/content_cache.py
+++ b/certora_autosetup/cache/content_cache.py
@@ -15,6 +15,19 @@ from certora_autosetup.cache.cache_fs import cache_path, get_fs
 from certora_autosetup.utils.constants import DIR_CERTORA_INTERNAL, DIR_CONTENT_CACHE
 
 
+def hash_text(text: str) -> str:
+    """SHA-256 of a string's UTF-8 bytes (first 16 hex chars) — the in-memory analog of
+    :meth:`ContentCache._hash_file`, for content that isn't on disk (e.g. an in-state spec buffer)."""
+    return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
+def hash_content_parts(parts: list[str]) -> str:
+    """Combine already-hashed content parts (e.g. ``"name:<hash>"`` and ``"extra:<flag>"`` strings)
+    into one 32-char cache key. The final step shared by :meth:`ContentCache.compute_cache_key` and
+    any in-memory content digest."""
+    return hashlib.sha256("\n".join(parts).encode()).hexdigest()[:32]
+
+
 class ContentCache:
     """Content-hash-based cache for arbitrary data keyed by file contents.
 
@@ -72,8 +85,7 @@ class ContentCache:
             for part in extra_key_parts:
                 parts.append(f"extra:{part}")
 
-        combined = "\n".join(parts)
-        return hashlib.sha256(combined.encode()).hexdigest()[:32]
+        return hash_content_parts(parts)
 
     def get(self, cache_key: str) -> dict[str, Any] | None:
         """Retrieve cached data for the given key.

--- a/certora_autosetup/parsers/spec_imports.py
+++ b/certora_autosetup/parsers/spec_imports.py
@@ -1,9 +1,61 @@
 """Utilities for parsing CVL spec file imports."""
-import re
 from collections import deque
 from pathlib import Path
 
 from certora_autosetup.utils.logger import logger
+
+
+def imports_in_cvl(text: str) -> list[str]:
+    """Every ``import "<target>"`` target in CVL ``text``, in source order.
+
+    A char-level port of the CVL lexer's import rule: a string literal is one whole token and
+    comments are trivia, so an ``import`` written inside a string or a ``//`` / ``/* */`` comment is
+    never a real import — exactly the property that makes the parser AST robust where a line regex is
+    not (the parser's `Ast.importedSpecFiles` is built the same way; see EVMVerifier `cvl.jflex` /
+    `com.certora.certoraprover.cvl.JavaAst`). We reproduce that rule in Python rather than shelling
+    out to the CVL parser because this runs on hot paths (per-job cache keys, per-edit buffer
+    digests) where a JVM subprocess per call is untenable. Not line-limited, so multiple imports on
+    one line and an import after an inline block comment are all found. Soundness matters: callers
+    hash a spec's imports to invalidate caches, so a missed import would let a stale result survive an
+    edit to that import.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':  # string literal — skip it, honoring backslash escapes
+            i += 1
+            while i < n and text[i] != '"':
+                i += 2 if text[i] == '\\' else 1
+            i += 1
+            continue
+        if c == '/' and i + 1 < n and text[i + 1] == '/':  # line comment
+            nl = text.find('\n', i)
+            i = n if nl == -1 else nl + 1
+            continue
+        if c == '/' and i + 1 < n and text[i + 1] == '*':  # block comment
+            end = text.find('*/', i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        if text.startswith('import', i) and (i == 0 or not (text[i - 1].isalnum() or text[i - 1] == '_')):
+            j = i + len('import')
+            # A keyword here, not the prefix of an identifier like `importFoo`.
+            if j < n and not (text[j].isalnum() or text[j] == '_'):
+                k = j
+                while k < n and text[k] in ' \t\r\n':
+                    k += 1
+                if k < n and text[k] == '"':  # import "<target>"
+                    m, buf = k + 1, []
+                    while m < n and text[m] != '"':
+                        if text[m] == '\\' and m + 1 < n:
+                            buf.append(text[m + 1]); m += 2
+                        else:
+                            buf.append(text[m]); m += 1
+                    out.append(''.join(buf))
+                    i = m + 1
+                    continue
+        i += 1
+    return out
 
 
 def parse_imports_from_spec(spec_path: Path, recursive: bool = True) -> list[Path]:
@@ -21,18 +73,12 @@ def parse_imports_from_spec(spec_path: Path, recursive: bool = True) -> list[Pat
     def _parse_direct_imports(path: Path) -> list[Path]:
         """Parse direct imports from a single spec file."""
         imports = []
-        with open(path, "r") as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith("import") and '"' in line:
-                    import_match = re.search(r'import\s+"([^"]+)"', line)
-                    if import_match:
-                        import_path = import_match.group(1)
-                        resolved_path = (path.parent / import_path).resolve()
-                        if resolved_path.exists():
-                            imports.append(resolved_path)
-                        else:
-                            logger.warning(f"Could not resolve import '{import_path}' from {path}")
+        for import_path in imports_in_cvl(path.read_text()):
+            resolved_path = (path.parent / import_path).resolve()
+            if resolved_path.exists():
+                imports.append(resolved_path)
+            else:
+                logger.warning(f"Could not resolve import '{import_path}' from {path}")
         return imports
 
     if not recursive:

--- a/certora_autosetup/setup/sanity.py
+++ b/certora_autosetup/setup/sanity.py
@@ -9,6 +9,7 @@ High-level approach:
 
 import asyncio
 import json
+import os
 import re
 import time
 import uuid
@@ -191,7 +192,23 @@ class SanityResult(Enum):
 
 
 # Per-job prover timeout (seconds) applied to the exploratory sanity runs.
-SANITY_GLOBAL_TIMEOUT = 1200
+SANITY_TIMEOUT_ENV = "AUTOPROVER_SANITY_TIMEOUT"
+DEFAULT_SANITY_TIMEOUT = 1200
+
+
+def sanity_global_timeout() -> int:
+    """The per-job prover timeout (seconds) for the exploratory sanity runs: ``DEFAULT_SANITY_TIMEOUT``,
+    or the integer value of ``AUTOPROVER_SANITY_TIMEOUT`` when set (a non-integer or <1 value is ignored
+    with a warning). Mirrors ``AUTOPROVER_GLOBAL_PROVER_TIMEOUT`` for the sanity phase."""
+    raw = os.environ.get(SANITY_TIMEOUT_ENV)
+    if raw is None:
+        return DEFAULT_SANITY_TIMEOUT
+    try:
+        n = int(raw)
+    except ValueError:
+        logger.warning(f"Ignoring non-integer {SANITY_TIMEOUT_ENV}={raw!r}")
+        return DEFAULT_SANITY_TIMEOUT
+    return n if n >= 1 else DEFAULT_SANITY_TIMEOUT
 
 
 @dataclass
@@ -213,7 +230,7 @@ class BoundConfiguration:
             # excluded from the analysis), so the rule_sanity sub-checks are pure wasted runtime here.
             "rule_sanity": "none",
             # Cap the exploratory sanity runs; only applied to these transient conf copies.
-            "global_timeout": str(SANITY_GLOBAL_TIMEOUT),
+            "global_timeout": str(sanity_global_timeout()),
         }
         if self.hashing_bound is not None:
             properties["hashing_length_bound"] = self.hashing_bound
@@ -579,7 +596,7 @@ class SanityPhase:
                     "coverage_info": "advanced",
                     "method": [method],
                     "rule_sanity": "none",
-                    "global_timeout": str(SANITY_GLOBAL_TIMEOUT),
+                    "global_timeout": str(sanity_global_timeout()),
                 },
                 f"_coverage_rerun_{i}",
                 target_dir=self._internal_confs_dir,
@@ -709,7 +726,7 @@ class SanityPhase:
 
             # Cap the detection run; global_timeout is a top-level property, not a prover arg.
             self.config_manager.update_config_with_properties(
-                bound_detection_config.path, {"global_timeout": str(SANITY_GLOBAL_TIMEOUT)}
+                bound_detection_config.path, {"global_timeout": str(sanity_global_timeout())}
             )
 
             # Submit bound detection job

--- a/composer/authoring/tools.py
+++ b/composer/authoring/tools.py
@@ -259,7 +259,7 @@ def _verify_attempts(state: GatedGiveUpState) -> int:
         for msg in state.get("messages", [])
         if isinstance(msg, AIMessage)
         for call in msg.tool_calls
-        if call["name"] == "verify_spec"
+        if call["name"] == "submit_buffer"
     )
 
 

--- a/composer/certora_env.py
+++ b/composer/certora_env.py
@@ -28,12 +28,32 @@ class CertoraEnvironmentError(Exception):
     """
 
 
-def certora_home() -> Path | None:
-    """The Certora source checkout pointed to by ``$CERTORA``.
+# Overrides ``$CERTORA`` for AutoProver's own Certora resolution, set by
+# console-autoprove's ``--certora-run-command``. The sentinel ``"pip"`` forces
+# the pip-installed CLI. This lets a session keep ``$CERTORA`` pointed at a local
+# build (for direct local-prover work) while AutoProver dispatches its cloud jobs
+# through the pip ``certora_cli``: a source checkout is not a pip distribution, so
+# ``get_package_and_version`` reports "not installed" and a cloud submission
+# aborts demanding ``prover_version``/``commit_sha1`` — whereas the pip package
+# carries the version that drives the submission.
+CERTORA_HOME_OVERRIDE_ENV = "AUTOPROVER_CERTORA_HOME"
+_FORCE_PIP = "pip"
 
-    Returns ``None`` when ``$CERTORA`` is unset (i.e. we run against the
-    pip-installed ``certora_cli`` / ``certora_jars`` packages).
+
+def certora_home() -> Path | None:
+    """The Certora source checkout to resolve against, or ``None`` to use the
+    pip-installed ``certora_cli`` / ``certora_jars`` packages.
+
+    ``$AUTOPROVER_CERTORA_HOME`` wins over ``$CERTORA`` when set: a filesystem
+    path selects that source checkout; the sentinel ``"pip"`` forces the pip
+    packages (returns ``None``). With the override unset, falls back to
+    ``$CERTORA`` (a checkout), else the pip packages.
     """
+    override = os.environ.get(CERTORA_HOME_OVERRIDE_ENV)
+    if override is not None:
+        if override.strip().lower() == _FORCE_PIP or not override.strip():
+            return None
+        return Path(override)
     path = os.environ.get("CERTORA")
     return Path(path) if path else None
 

--- a/composer/certora_env.py
+++ b/composer/certora_env.py
@@ -28,32 +28,12 @@ class CertoraEnvironmentError(Exception):
     """
 
 
-# Overrides ``$CERTORA`` for AutoProver's own Certora resolution, set by
-# console-autoprove's ``--certora-run-command``. The sentinel ``"pip"`` forces
-# the pip-installed CLI. This lets a session keep ``$CERTORA`` pointed at a local
-# build (for direct local-prover work) while AutoProver dispatches its cloud jobs
-# through the pip ``certora_cli``: a source checkout is not a pip distribution, so
-# ``get_package_and_version`` reports "not installed" and a cloud submission
-# aborts demanding ``prover_version``/``commit_sha1`` — whereas the pip package
-# carries the version that drives the submission.
-CERTORA_HOME_OVERRIDE_ENV = "AUTOPROVER_CERTORA_HOME"
-_FORCE_PIP = "pip"
-
-
 def certora_home() -> Path | None:
-    """The Certora source checkout to resolve against, or ``None`` to use the
-    pip-installed ``certora_cli`` / ``certora_jars`` packages.
+    """The Certora source checkout pointed to by ``$CERTORA``.
 
-    ``$AUTOPROVER_CERTORA_HOME`` wins over ``$CERTORA`` when set: a filesystem
-    path selects that source checkout; the sentinel ``"pip"`` forces the pip
-    packages (returns ``None``). With the override unset, falls back to
-    ``$CERTORA`` (a checkout), else the pip packages.
+    Returns ``None`` when ``$CERTORA`` is unset (i.e. we run against the
+    pip-installed ``certora_cli`` / ``certora_jars`` packages).
     """
-    override = os.environ.get(CERTORA_HOME_OVERRIDE_ENV)
-    if override is not None:
-        if override.strip().lower() == _FORCE_PIP or not override.strip():
-            return None
-        return Path(override)
     path = os.environ.get("CERTORA")
     return Path(path) if path else None
 

--- a/composer/prover/callbacks.py
+++ b/composer/prover/callbacks.py
@@ -1,5 +1,5 @@
 """Stream-event prover callbacks shared by the codegen prover tool and the
-source-pipeline ``verify_spec`` tool.
+source-pipeline buffer prover jobs.
 
 ``ProverEventCallbacks`` translates the ``ProverCallbacks`` lifecycle into the
 custom stream events the UI renders, keyed by tool_call_id. Both prover entry

--- a/composer/prover/cloud.py
+++ b/composer/prover/cloud.py
@@ -7,6 +7,7 @@ job URL (so waiting needs no credentials), then retrieves its results through
 
 import asyncio
 import logging
+import shutil
 import tempfile
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -159,6 +160,42 @@ def _results_api() -> ProverOutputAPI:
     return ProverOutputAPI(enable_cache=False)
 
 
+#: A fetch failure here is a *transport* fault, not a bad job: by the time we download documents
+#: the job has already polled ``SUCCEEDED``. Re-fetching the same completed job is cheap; re-running
+#: the whole proof (what the caller does if this context raises) throws away a finished — often
+#: hours-long — verification. So retry the fetch itself a few times with exponential backoff before
+#: giving up. POU retries at the individual-request level; this covers a whole-fetch failure that
+#: outlives those (e.g. a mid-transfer reset that exhausts the request-level retries on one file).
+_FETCH_MAX_ATTEMPTS = 3
+_FETCH_BACKOFF_BASE_S = 2.0
+
+
+async def _fetch_results(job_id: str, dest: Path) -> None:
+    """Download a completed job's sources + tree view into ``dest``, retrying a transient failure.
+
+    Each attempt starts from an empty ``dest`` so a partially-written archive from a failed attempt
+    cannot leave a truncated file behind. Never re-runs the job — only re-reads it.
+    """
+    for attempt in range(1, _FETCH_MAX_ATTEMPTS + 1):
+        try:
+            await asyncio.to_thread(
+                _results_api().fetch_sources_and_treeview_files, job_id, dest
+            )
+            return
+        except Exception as exc:
+            if attempt == _FETCH_MAX_ATTEMPTS:
+                raise
+            backoff = _FETCH_BACKOFF_BASE_S * 2 ** (attempt - 1)
+            logger.warning(
+                "Fetching results for completed job %s failed (attempt %d/%d): %s. "
+                "Re-fetching the finished job in %.0fs (not re-proving).",
+                job_id[:8], attempt, _FETCH_MAX_ATTEMPTS, exc, backoff,
+            )
+            for child in dest.iterdir():
+                shutil.rmtree(child) if child.is_dir() else child.unlink()
+            await asyncio.sleep(backoff)
+
+
 @asynccontextmanager
 async def cloud_results(
     run_result_link: str,
@@ -202,7 +239,5 @@ async def cloud_results(
         # tens of gigabytes on real jobs and used to exhaust the disk; across the
         # jobs measured here these two subtrees are ~3% of the archive. POU writes
         # them in the same layout the archive had, so the parse is unchanged.
-        await asyncio.to_thread(
-            _results_api().fetch_sources_and_treeview_files, cloud_job.job_id, dest
-        )
+        await _fetch_results(cloud_job.job_id, dest)
         yield (dest, runtime_ms)

--- a/composer/scripts/budget_math.py
+++ b/composer/scripts/budget_math.py
@@ -347,7 +347,7 @@ def build_matrix(
         "groups/`prover_links` exclude curtailed",
         "- rendered HTML (`autoprove-report-render`) shows the budget appendix",
         "- thread trail (`ap-trail export` + this script): the `<system-alert>` wrap-up "
-        "appears in the author transcript; no `verify_spec`/`feedback_tool` calls after it",
+        "appears in the author transcript; no `submit_buffer`/`feedback_tool` calls after it",
         "- `components_to_prover_runs.json` lacks curtailed entries",
         "",
         "## Caveats",

--- a/composer/spec/cvl_generation.py
+++ b/composer/spec/cvl_generation.py
@@ -269,16 +269,24 @@ class VanillaFeedbackTool(
     def _version_history(self) -> Sequence[str]:
         return ()
 
+def cvl_guidance_tools() -> list[BaseTool]:
+    """The dependency-free CVL *guidance* tools — no spec-writing tools. Used by the buffer-authoring
+    agent, which writes CVL through the buffer tools (put_buffer / edit_buffer) rather than put_cvl."""
+    return [
+        ERC20TokenGuidance.as_tool("erc20_guidance"),
+        UnresolvedCallGuidance.as_tool("unresolved_call_guidance"),
+    ]
+
+
 def static_tools() -> list[BaseTool]:
-    """The dependency-free CVL authoring tools. The property-management suite
-    (feedback / skip tools) is NOT here — it carries runtime deps; see
+    """The dependency-free CVL authoring tools — the single-``curr_spec`` writing tools plus guidance.
+    The property-management suite (feedback / skip tools) is NOT here — it carries runtime deps; see
     :func:`skip_tools` and :class:`FeedbackToolBase`."""
     return [
         put_cvl, put_cvl_raw,
         get_cvl(CVLGenerationState),
         edit_cvl(CVLGenerationState),
-        ERC20TokenGuidance.as_tool("erc20_guidance"),
-        UnresolvedCallGuidance.as_tool("unresolved_call_guidance"),
+        *cvl_guidance_tools(),
     ]
 
 

--- a/composer/spec/source/artifacts.py
+++ b/composer/spec/source/artifacts.py
@@ -100,7 +100,7 @@ class ProverArtifactStore(ArtifactStore[SpecIdentity, GeneratedCVL]):
         self, spec: SpecIdentity, base_config: dict | None, spec_path: Path,
     ) -> None:
         """The prover conf for the run: the generation's final ``state["config"]`` plus
-        the fixed run overlay (shared with the live ``verify_spec`` run). No-op if no
+        the fixed run overlay (shared with the live prover run). No-op if no
         base config."""
         if base_config is None:
             _log.warning("no base config for %s; skipping conf dump", spec.stem)

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -28,7 +28,9 @@ from composer.spec.cvl_generation import (
 from composer.prover.core import run_prover, CexHandler, ProverCallbacks, ProverReport
 from composer.spec.source.live_explorer import VersionedHistory, LiveEditTools, WIPE_HISTORY
 from composer.spec.source.prover import setup_prover_config_in
-from composer.spec.source.spec_buffers import SpecBuffersExtra, spec_buffers_enabled
+from composer.spec.source.spec_buffers import (
+    SpecBuffersExtra, combined_buffers_view, run_targets, spec_buffers_enabled,
+)
 from composer.spec.source.buffer_tools import (
     put_buffer, get_buffer, edit_buffer, list_buffers, delete_buffer,
 )
@@ -653,7 +655,10 @@ class EditorAwareFeedbackTool(
                 vfs=self.state["vfs"],
                 version_history=self.state["version_history"],
             )
-            return await judge(snap, spec, skipped, self.rebuttals, self.tool_call_id)
+            # In multi-buffer mode the single curr_spec is empty; review the buffers as one document.
+            buffers = self.state.get("buffers") or {}
+            review_spec = combined_buffers_view(buffers) if run_targets(buffers) else spec
+            return await judge(snap, review_spec, skipped, self.rebuttals, self.tool_call_id)
 
     @override
     def _version_history(self) -> Sequence[str]:
@@ -666,6 +671,35 @@ class PropertyGenSystemParams(TypedDict):
     source_editing: bool
 
 _PropertyGenSysTemplate = TypedTemplate[PropertyGenSystemParams]("property_generation_system_prompt.j2")
+
+#: Appended to the system prompt only when multi-buffer authoring is enabled (spec_buffers_enabled).
+_SPEC_BUFFERS_GUIDANCE = """
+## Splitting the spec into verification buffers
+
+Instead of one spec, you may author several named CVL **buffers**, each a self-contained spec that is
+verified and reviewed on its own. Use `put_buffer` / `edit_buffer` / `get_buffer` / `list_buffers` /
+`delete_buffer` instead of the single-spec put/get/edit tools when you split.
+
+When to split:
+- Properties have **conflicting precision needs** — one buffer can summarize a function that another
+  keeps exact (each buffer has its own `methods{}`), with no global-methods-block conflict.
+- To **isolate the hard/slow properties**: put the many easy properties in one buffer that verifies and
+  is approved once and never re-touched, while you iterate on a small hard buffer in isolation — its
+  re-verification and re-review cost only that buffer.
+
+How:
+- Put **shared** infrastructure (ghosts, common invariants, helper CVL functions, token/oracle models)
+  in a buffer with `is_run_target=false`, and have run-target buffers `import "<shared>.spec"` and list
+  it in their `imports`.
+- Each **run-target** buffer declares its `property_rules` (the properties it verifies + their rule
+  names). Across all run-target buffers, every non-skipped property must appear in **exactly one**
+  buffer, and each rule lives in exactly one buffer.
+- `verify_spec` then verifies every run-target buffer independently and in parallel; a buffer already
+  verified at its current content is skipped. Editing a shared buffer re-verifies every buffer that
+  imports it.
+
+A single run-target buffer is exactly the one-spec case, so only split when it helps.
+"""
 
 #: The prover's tool extension: contributions come from plugins deriving
 #: ``CertoraProverTools``, dispatched via their ``certora_prover_tools`` hook.
@@ -794,6 +828,8 @@ async def batch_cvl_generation(
     sys_prompt : list[RawPromptInput | type[CacheMarker]] = [
         _PropertyGenSysTemplate.bind({"source_editing": editing is not None}).render_to
     ]
+    if spec_buffers_enabled():
+        sys_prompt.append(_SPEC_BUFFERS_GUIDANCE)
 
     added_tools : list[BaseTool] = []
     if editing_tools is not None:
@@ -1012,8 +1048,13 @@ async def batch_cvl_generation(
             # unformalizable" judgment — it's the budget talking. Keep the agent's account.
             return Curtailed(None, detail=res_state["result"])
         return GaveUp(reason=res_state["result"])
-    d = res_state["curr_spec"]
-    assert d is not None
+    # In multi-buffer mode the artifact is the buffers combined into one document; else curr_spec.
+    _buffers = res_state.get("buffers") or {}
+    if run_targets(_buffers):
+        d = combined_buffers_view(_buffers)
+    else:
+        d = res_state["curr_spec"]
+        assert d is not None
     applied_edits: list[AppliedEdit] = []
     if editing is not None:
         for edit_id in res_state["version_history"]:

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -28,6 +28,10 @@ from composer.spec.cvl_generation import (
 from composer.prover.core import run_prover, CexHandler, ProverCallbacks, ProverReport
 from composer.spec.source.live_explorer import VersionedHistory, LiveEditTools, WIPE_HISTORY
 from composer.spec.source.prover import setup_prover_config_in
+from composer.spec.source.spec_buffers import SpecBuffersExtra, spec_buffers_enabled
+from composer.spec.source.buffer_tools import (
+    put_buffer, get_buffer, edit_buffer, list_buffers, delete_buffer,
+)
 from composer.spec.context import WorkflowContext, CVLGeneration, CacheKey, SourceCode
 from composer.spec.types import PropertyFormulation, PropertyTitle
 from composer.pipeline.core import GaveUp, ToolBinder, InjectingToolExtension, Curtailed
@@ -86,7 +90,7 @@ class SourceAuthorExtra(TypedDict):
 # ``vfs`` comes from ProverStateExtra (NotRequired, no merge op — replaced
 # wholesale by commit_edit / revert_to_edit); the generation input always
 # seeds it explicitly.
-class SourceCVLGenerationExtra(CVLGenerationExtra, ProverStateExtra, SourceAuthorExtra, VersionedHistory):
+class SourceCVLGenerationExtra(CVLGenerationExtra, ProverStateExtra, SourceAuthorExtra, VersionedHistory, SpecBuffersExtra):
     pass
 
 class SourceCVLGenerationInput(SourceCVLGenerationExtra, FlowInput):
@@ -893,8 +897,17 @@ async def batch_cvl_generation(
         )
     else:
         b = b.with_tools(env.source_tools)
+    # Multi-buffer authoring tools (opt-in): the agent partitions the spec into several named
+    # buffers verified independently. Off by default so the single-curr_spec flow is untouched.
+    buffer_authoring: list[BaseTool] = [
+        put_buffer(SourceCVLGenerationState), get_buffer(SourceCVLGenerationState),
+        edit_buffer(SourceCVLGenerationState), list_buffers(SourceCVLGenerationState),
+        delete_buffer(SourceCVLGenerationState),
+    ] if spec_buffers_enabled() else []
     task_graph = b.with_tools(
         static_tools()
+    ).with_tools(
+        buffer_authoring
     ).with_tools(
         feedback_suite
     ).with_tools(
@@ -972,7 +985,8 @@ async def batch_cvl_generation(
                 reminders_channel=[],
                 vfs=restored_vfs,
                 version_history=restored_history,
-                spec_stem=spec_stem
+                spec_stem=spec_stem,
+                buffers={},
             )
         )
     except BudgetExceeded as e:

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, NotRequired, override, Literal, Annotated, Sequence, Protocol, Callable
+from typing import AsyncIterator, NotRequired, override, Literal, Annotated, Sequence, Protocol, Callable, cast
 
 from typing_extensions import TypedDict
 from contextlib import asynccontextmanager
@@ -14,7 +14,7 @@ from graphcore.tools.schemas import (
     WithAsyncImplementation, WithImplementation, WithInjectedId, WithInjectedState,
     WithAsyncDependencies
 )
-from graphcore.graph import tool_state_update, RawPromptInput, CacheMarker, SummaryConfig
+from graphcore.graph import tool_state_update, tool_return, RawPromptInput, CacheMarker, SummaryConfig
 from graphcore.tools.vfs import VFSAccessor, VFSState
 
 from composer.authoring.judge import PropertyFeedbackProtocol
@@ -29,13 +29,15 @@ from composer.prover.core import run_prover, CexHandler, ProverCallbacks, Prover
 from composer.spec.source.live_explorer import VersionedHistory, LiveEditTools, WIPE_HISTORY
 from composer.spec.source.prover import setup_prover_config_in
 from composer.spec.source.spec_buffers import (
-    SpecBuffersExtra, combined_buffers_view, run_targets, spec_buffers_enabled,
+    SpecBuffersExtra, buffer_review_text, buffer_state_digest, check_buffer_completion,
+    combined_buffers_view, run_targets, spec_buffers_enabled, validate_coverage,
+    validate_disjoint_rules,
 )
 from composer.spec.source.buffer_tools import (
     put_buffer, get_buffer, edit_buffer, list_buffers, delete_buffer,
 )
 from composer.spec.context import WorkflowContext, CVLGeneration, CacheKey, SourceCode
-from composer.spec.types import PropertyFormulation, PropertyTitle
+from composer.spec.types import PropertyFormulation, PropertyTitle, RuleName
 from composer.pipeline.core import GaveUp, ToolBinder, InjectingToolExtension, Curtailed
 from composer.pipeline.plugin_api import ProvidedTools
 from composer.spec.source.plugin import CertoraProverTools, CVLAuthorState
@@ -162,16 +164,38 @@ class PublishResultTool(
 
     @override
     async def run(self) -> Command | str:
-        if (err := check_completion(self.state, self.state["version_history"])) is not None:
-            return err
-        with self.tool_deps() as titles:
-            if (err := validate_property_rules(self.property_rules, self.state["skipped"], titles)) is not None:
+        buffers = self.state.get("buffers") or {}
+        if run_targets(buffers):
+            # Multi-buffer completion: every run-target buffer verified AND reviewed at its current
+            # digest (per-buffer stamps), plus a clean property/rule partition across buffers.
+            skipped_pairs = [(str(s.property_title), str(s.reason)) for s in self.state["skipped"]]
+            if (err := check_buffer_completion(
+                buffers, self.state["validations"], self.state["required_validations"],
+                skipped=skipped_pairs, version_history=self.state["version_history"],
+            )) is not None:
                 return err
+            with self.tool_deps() as titles:
+                skip_titles = {str(s.property_title) for s in self.state["skipped"]}
+                if (err := validate_coverage(buffers, all_properties=set(titles), skipped=skip_titles)) is not None:
+                    return f"Completion REJECTED: {err}"
+            if (err := validate_disjoint_rules(buffers)) is not None:
+                return f"Completion REJECTED: {err}"
+            pr = [
+                PropertyRuleMapping(property_title=cast(PropertyTitle, p), rules=cast(list[RuleName], rs))
+                for b in run_targets(buffers) for p, rs in b.property_rules.items()
+            ]
+        else:
+            if (err := check_completion(self.state, self.state["version_history"])) is not None:
+                return err
+            with self.tool_deps() as titles:
+                if (err := validate_property_rules(self.property_rules, self.state["skipped"], titles)) is not None:
+                    return err
+            pr = self.property_rules
         return tool_state_update(
             self.tool_call_id,
             "Accepted",
             result=self.commentary,
-            property_rules=self.property_rules,
+            property_rules=pr,
             failed=False,
         )
 
@@ -655,14 +679,44 @@ class EditorAwareFeedbackTool(
                 vfs=self.state["vfs"],
                 version_history=self.state["version_history"],
             )
-            # In multi-buffer mode the single curr_spec is empty; review the buffers as one document.
-            buffers = self.state.get("buffers") or {}
-            review_spec = combined_buffers_view(buffers) if run_targets(buffers) else spec
-            return await judge(snap, review_spec, skipped, self.rebuttals, self.tool_call_id)
+            return await judge(snap, spec, skipped, self.rebuttals, self.tool_call_id)
 
     @override
     def _version_history(self) -> Sequence[str]:
         return self.state["version_history"]
+
+    @override
+    async def run(self) -> Command:
+        """Single-spec: the base flow. Multi-buffer: review each run-target buffer whose feedback
+        stamp is missing or stale (its text or an import changed) in isolation, and stamp
+        ``feedback:<buffer>`` per approved buffer — so an approved, unchanged buffer is never
+        re-reviewed and the hard buffer is reviewed alone."""
+        buffers = self.state.get("buffers") or {}
+        targets = run_targets(buffers)
+        if not targets:
+            return await super().run()
+
+        skipped = self.state["skipped"]
+        skipped_pairs = [(str(s.property_title), str(s.reason)) for s in skipped]
+        vh = self.state["version_history"]
+        validations = self.state["validations"]
+
+        def digest(name: str) -> str:
+            return buffer_state_digest(buffers, name, skipped=skipped_pairs, version_history=vh)
+
+        stale = [b for b in targets if validations.get(f"feedback:{b.name}") != digest(b.name)]
+        if not stale:
+            return tool_return(
+                self.tool_call_id, "All buffers already reviewed and approved at their current state."
+            )
+        new_stamps: dict[str, str] = {}
+        blocks: list[str] = []
+        for b in stale:
+            verdict = await self._get_feedback(buffer_review_text(buffers, b.name), skipped)
+            blocks.append(f"=== buffer {b.name} ===\nGood? {verdict.good}\nFeedback {verdict.feedback}")
+            if verdict.good:
+                new_stamps[f"feedback:{b.name}"] = digest(b.name)
+        return tool_state_update(self.tool_call_id, "\n\n".join(blocks), validations=new_stamps)
 
 
 _PropertyGenTemplate = TypedTemplate[PropertyGenParams]("property_generation_prompt.j2")

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -730,9 +730,9 @@ _PropertyGenSysTemplate = TypedTemplate[PropertyGenSystemParams]("property_gener
 _SPEC_BUFFERS_GUIDANCE = """
 ## Splitting the spec into verification buffers
 
-Instead of one spec, you may author several named CVL **buffers**, each a self-contained spec that is
-verified and reviewed on its own. Use `put_buffer` / `edit_buffer` / `get_buffer` / `list_buffers` /
-`delete_buffer` instead of the single-spec put/get/edit tools when you split.
+Instead of one spec, you author several named CVL **buffers**, each a self-contained spec verified and
+reviewed on its own. Use `put_buffer` / `edit_buffer` / `get_buffer` / `list_buffers` / `delete_buffer`
+to author them, and `submit_buffer` / `collect_results` (NOT `verify_spec`) to verify them.
 
 When to split:
 - Properties have **conflicting precision needs** — one buffer can summarize a function that another
@@ -741,16 +741,60 @@ When to split:
   is approved once and never re-touched, while you iterate on a small hard buffer in isolation — its
   re-verification and re-review cost only that buffer.
 
-How:
+Structuring buffers:
 - Put **shared** infrastructure (ghosts, common invariants, helper CVL functions, token/oracle models)
   in a buffer with `is_run_target=false`, and have run-target buffers `import "<shared>.spec"` and list
   it in their `imports`.
 - Each **run-target** buffer declares its `property_rules` (the properties it verifies + their rule
   names). Across all run-target buffers, every non-skipped property must appear in **exactly one**
   buffer, and each rule lives in exactly one buffer.
-- `verify_spec` then verifies every run-target buffer independently and in parallel; a buffer already
-  verified at its current content is skipped. Editing a shared buffer re-verifies every buffer that
-  imports it.
+
+Summaries — over-approximate up front (this is your main lever for tractability):
+- For each run-target buffer, look at the functions its properties exercise, and **summarize now**, in
+  that buffer's `methods{}`, every function the buffer's properties do not need exact — an
+  over-approximation (e.g. a `NONDET`/havoc return, or a weaker constraint than the real body).
+  **Do this preemptively, before the first `submit_buffer`** — do not wait for a timeout to force it.
+  Aggressive preemptive summarization is how the hard properties become tractable; a nonlinear-math,
+  hashing, or heavy-external function a property only reads through is the prime candidate.
+- **Soundness rule: an over-approximating summary is sound for `assert` rules but UNSOUND for `satisfy`
+  rules.** An over-approximation *adds* behaviors: an `assert` that holds over the larger behavior set
+  still holds over the real one (sound), whereas a `satisfy` may be witnessed only by an added, non-real
+  behavior (unsound — its witness need not correspond to a real execution). So over-approximate freely
+  in a buffer whose rules are **all `assert`**; in a buffer that contains any `satisfy` rule (or a
+  reachability check), keep the functions it exercises **exact**. This is a first-class reason to
+  partition: group `assert`-only properties (which share aggressive over-approximations) apart from
+  `satisfy` properties (which need those functions exact).
+- **Refine on a spurious counterexample.** A too-coarse over-approximation produces a *spurious* cex —
+  one reachable only because the summary admits behavior the real function cannot. When a buffer returns
+  VIOLATED, analyze the cex: if it hinges on behavior your summary allows but the real function forbids,
+  it is spurious → tighten that summary (add the missing constraint) or drop the over-approximation for
+  that function with `edit_buffer`, then re-`submit_buffer`. If the cex reproduces against the exact
+  function, it is a real bug. Start from the simplest sound over-approximation and tighten only as
+  spurious cexes force you to.
+
+Verifying — submit / collect (buffers prove in parallel; never wait on a slow buffer to work on a fast
+one):
+- **Settle the shared base before submitting anything that imports it.** Submit a run-target buffer only
+  once BOTH (i) that buffer is finished AND (ii) every shared buffer it imports is finished — you do not
+  expect to edit them again. Editing a shared buffer after submitting invalidates every buffer that
+  imports it (submitted or already verified): those prover jobs are wasted and must be re-run. So author
+  and stabilize the shared infrastructure first, then submit the run-target buffers that depend on it.
+- `submit_buffer(name)` starts a buffer's prover job in the **background** and returns immediately.
+  Submit each run-target buffer as soon as it and its shared imports are ready — they prove concurrently.
+- `collect_results()` returns the outcomes of jobs that have **finished so far** (without blocking) plus
+  a status board: which buffers are `complete`, `running`, or `needs (re)submission`. Process a finished
+  buffer immediately — fix its counterexample and `submit_buffer` it again — while the others keep
+  proving.
+- Work this priority order, and only ever block at the last step:
+  1. A finished result not yet processed → handle it. If the fix is in a **shared** buffer (e.g. an
+     under-approximation), edit the shared buffer; that invalidates every buffer importing it — the
+     board lists them under `needs (re)submission` (including ones already verified) — so re-submit
+     each of them.
+  2. Else a buffer still to author/submit → author it and `submit_buffer` it.
+  3. Else everything is submitted and running with nothing finished to process → call
+     `collect_results(wait=true)` to sleep until the next job finishes.
+- Editing a buffer (or a shared buffer it imports) makes its prior verification stale; re-submit it. A
+  buffer already verified at its current content is not re-run.
 
 A single run-target buffer is exactly the one-spec case, so only split when it helps.
 """
@@ -764,6 +808,9 @@ _PROVER_TOOLS = InjectingToolExtension(
 @dataclass
 class ProverTool:
     lg_tool: BaseTool
+    #: The async multi-buffer tools (submit_buffer / collect_results), bound in place of ``lg_tool``
+    #: when spec-buffer authoring is enabled.
+    buffer_tools: list[BaseTool]
     options: ProverOptions
 
 @dataclass
@@ -987,13 +1034,20 @@ async def batch_cvl_generation(
         )
     else:
         b = b.with_tools(env.source_tools)
-    # Multi-buffer authoring tools (opt-in): the agent partitions the spec into several named
-    # buffers verified independently. Off by default so the single-curr_spec flow is untouched.
-    buffer_authoring: list[BaseTool] = [
-        put_buffer(SourceCVLGenerationState), get_buffer(SourceCVLGenerationState),
-        edit_buffer(SourceCVLGenerationState), list_buffers(SourceCVLGenerationState),
-        delete_buffer(SourceCVLGenerationState),
-    ] if spec_buffers_enabled() else []
+    # Multi-buffer authoring (opt-in): the agent partitions the spec into several named buffers,
+    # each submitted and verified independently via the async submit_buffer / collect_results tools
+    # (bound in place of the single-spec verify_spec). Off by default so the single-curr_spec flow is
+    # untouched.
+    if spec_buffers_enabled():
+        buffer_authoring: list[BaseTool] = [
+            put_buffer(SourceCVLGenerationState), get_buffer(SourceCVLGenerationState),
+            edit_buffer(SourceCVLGenerationState), list_buffers(SourceCVLGenerationState),
+            delete_buffer(SourceCVLGenerationState),
+        ]
+        prover_binding: list[BaseTool] = list(prover_tool.buffer_tools)
+    else:
+        buffer_authoring = []
+        prover_binding = [prover_tool.lg_tool]
     task_graph = b.with_tools(
         static_tools()
     ).with_tools(
@@ -1001,7 +1055,7 @@ async def batch_cvl_generation(
     ).with_tools(
         feedback_suite
     ).with_tools(
-        [prover_tool.lg_tool,
+        [*prover_binding,
          ExpectRulePassage.as_tool("expect_rule_passage"),
          ExpectRuleFailure.as_tool("expect_rule_failure"),
          give_up_tool(name="give_up", description=_GIVE_UP_DESCRIPTION, label="CVL generation")

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -990,7 +990,7 @@ async def batch_cvl_generation(
         # Run-root strategy (see ProjectDirectory): an empty working copy is read
         # in-situ, a non-empty one against a temporary materialization whose lifetime
         # is the contributed tool's invocation.
-        project_directory = materializing_project(source.project_root, kit.live.mat)
+        project_directory = materializing_project(kit.live.mat)
 
         @asynccontextmanager
         async def yield_state(

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -18,11 +18,11 @@ from graphcore.graph import tool_state_update, tool_return, RawPromptInput, Cach
 from graphcore.tools.vfs import VFSAccessor, VFSState
 
 from composer.authoring.judge import PropertyFeedbackProtocol
-from composer.authoring.state import SkippedProperty, check_completion
+from composer.authoring.state import SkippedProperty
 from composer.authoring.tools import gated_give_up_tool, give_up_tool
 from composer.spec.cvl_generation import (
     cvl_guidance_tools, skip_tools, CVLGenerationExtra, FEEDBACK_VALIDATION_KEY,
-    validate_property_rules, CVL_JUDGE_KEY, run_cvl_generator,
+    CVL_JUDGE_KEY, run_cvl_generator,
     GeneratedCVL, PropertyRuleMapping, AppliedEdit, FeedbackToolBase, FeedbackServices,
 )
 from composer.prover.core import run_prover, CexHandler, ProverCallbacks, ProverReport
@@ -155,42 +155,32 @@ class PublishResultTool(
     Call to signal your completed cvl generation.
     """
     commentary: str = Field(description="Commentary on your generated spec")
-    property_rules: list[PropertyRuleMapping] = Field(
-        description="The property->rules mapping. For every property you did NOT skip "
-        "(referenced by its unique snake_case title from the batch listing), list the "
-        "name(s) of the rule(s)/invariant(s) in your spec that verify it. Every non-skipped "
-        "property must appear with at least one rule."
-    )
 
     @override
     async def run(self) -> Command | str:
+        # Completion requires every run-target buffer verified AND reviewed at its current digest
+        # (per-buffer stamps), with a clean property/rule partition across buffers. Each run-target
+        # declares its own property->rules on ``put_buffer``, so the published mapping is derived
+        # from the buffers. When every property is skipped there are no run-target buffers: the
+        # stamp check is then vacuous and ``validate_coverage`` alone decides whether publishing is
+        # allowed.
         buffers = self.state.get("buffers") or {}
-        if run_targets(buffers):
-            # Multi-buffer completion: every run-target buffer verified AND reviewed at its current
-            # digest (per-buffer stamps), plus a clean property/rule partition across buffers.
-            skipped_pairs = [(str(s.property_title), str(s.reason)) for s in self.state["skipped"]]
-            if (err := check_buffer_completion(
-                buffers, self.state["validations"], self.state["required_validations"],
-                skipped=skipped_pairs, version_history=self.state["version_history"],
-            )) is not None:
-                return err
-            with self.tool_deps() as titles:
-                skip_titles = {str(s.property_title) for s in self.state["skipped"]}
-                if (err := validate_coverage(buffers, all_properties=set(titles), skipped=skip_titles)) is not None:
-                    return f"Completion REJECTED: {err}"
-            if (err := validate_disjoint_rules(buffers)) is not None:
+        skipped_pairs = [(str(s.property_title), str(s.reason)) for s in self.state["skipped"]]
+        if (err := check_buffer_completion(
+            buffers, self.state["validations"], self.state["required_validations"],
+            skipped=skipped_pairs, version_history=self.state["version_history"],
+        )) is not None:
+            return err
+        with self.tool_deps() as titles:
+            skip_titles = {str(s.property_title) for s in self.state["skipped"]}
+            if (err := validate_coverage(buffers, all_properties=set(titles), skipped=skip_titles)) is not None:
                 return f"Completion REJECTED: {err}"
-            pr = [
-                PropertyRuleMapping(property_title=cast(PropertyTitle, p), rules=cast(list[RuleName], rs))
-                for b in run_targets(buffers) for p, rs in b.property_rules.items()
-            ]
-        else:
-            if (err := check_completion(self.state, self.state["version_history"])) is not None:
-                return err
-            with self.tool_deps() as titles:
-                if (err := validate_property_rules(self.property_rules, self.state["skipped"], titles)) is not None:
-                    return err
-            pr = self.property_rules
+        if (err := validate_disjoint_rules(buffers)) is not None:
+            return f"Completion REJECTED: {err}"
+        pr = [
+            PropertyRuleMapping(property_title=cast(PropertyTitle, p), rules=cast(list[RuleName], rs))
+            for b in run_targets(buffers) for p, rs in b.property_rules.items()
+        ]
         return tool_state_update(
             self.tool_call_id,
             "Accepted",
@@ -761,7 +751,7 @@ _SPEC_BUFFERS_GUIDANCE = """
 
 Instead of one spec, you author several named CVL **buffers**, each a self-contained spec verified and
 reviewed on its own. Use `put_buffer` / `edit_buffer` / `get_buffer` / `list_buffers` / `delete_buffer`
-to author them, and `submit_buffer` / `collect_results` (NOT `verify_spec`) to verify them.
+to author them, and `submit_buffer` / `collect_results` to verify them.
 
 **Strongly prefer splitting, and add over-approximating performance summaries preemptively.** A
 single spec has ONE global `methods{}` block, so every rule is verified under the *intersection* of
@@ -869,9 +859,7 @@ _PROVER_TOOLS = InjectingToolExtension(
 
 @dataclass
 class ProverTool:
-    lg_tool: BaseTool
-    #: The async multi-buffer tools (submit_buffer / collect_results), bound in place of ``lg_tool``
-    #: when spec-buffer authoring is enabled.
+    #: The async multi-buffer tools (submit_buffer / collect_results) the agent verifies with.
     buffer_tools: list[BaseTool]
     options: ProverOptions
 
@@ -999,9 +987,9 @@ async def batch_cvl_generation(
     if editing_tools is not None:
         task_host = TaskHost()
         kit = editing_tools.editing
-        # The same run-root strategy verify_spec uses (see ProjectDirectory): an
-        # empty working copy is read in-situ, a non-empty one against a temporary
-        # materialization whose lifetime is the contributed tool's invocation.
+        # Run-root strategy (see ProjectDirectory): an empty working copy is read
+        # in-situ, a non-empty one against a temporary materialization whose lifetime
+        # is the contributed tool's invocation.
         project_directory = materializing_project(source.project_root, kit.live.mat)
 
         @asynccontextmanager
@@ -1027,7 +1015,7 @@ async def batch_cvl_generation(
             async with project_directory(st.get("vfs") or {}) as run_root:
                 yield CVLAuthorState(
                     working_dir=pathlib.Path(run_root),
-                    curr_spec=st["curr_spec"],
+                    curr_spec=None,
                     prover_runner=WrappedProverRunner(
                         st["config"],
                         prover_tool.options,
@@ -1102,7 +1090,7 @@ async def batch_cvl_generation(
     # Multi-buffer authoring (opt-in): the agent partitions the spec into several named buffers,
     # Multi-buffer authoring is the only mode: the agent writes CVL through the buffer tools and
     # verifies each run-target buffer with the async submit_buffer / collect_results pair. Guidance-only
-    # CVL tools are bound (no put_cvl/edit_cvl/verify_spec).
+    # CVL tools are bound (no put_cvl/edit_cvl).
     buffer_authoring: list[BaseTool] = [
         put_buffer(SourceCVLGenerationState), get_buffer(SourceCVLGenerationState),
         edit_buffer(SourceCVLGenerationState), list_buffers(SourceCVLGenerationState),
@@ -1216,13 +1204,10 @@ async def batch_cvl_generation(
             # unformalizable" judgment — it's the budget talking. Keep the agent's account.
             return Curtailed(None, detail=res_state["result"])
         return GaveUp(reason=res_state["result"])
-    # In multi-buffer mode the artifact is the buffers combined into one document; else curr_spec.
+    # The published artifact is the buffers combined into one document (empty when every property
+    # was skipped, i.e. there are no buffers to combine).
     _buffers = res_state.get("buffers") or {}
-    if run_targets(_buffers):
-        d = combined_buffers_view(_buffers)
-    else:
-        d = res_state["curr_spec"]
-        assert d is not None
+    d = combined_buffers_view(_buffers)
     applied_edits: list[AppliedEdit] = []
     if editing is not None:
         for edit_id in res_state["version_history"]:

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -717,13 +717,13 @@ class EditorAwareFeedbackTool(
 
 
 @tool_display("Getting feedback", "Feedback")
+# Buffer-aware feedback for the non-editing author (structural invariants, immutable source): reviews
+# each buffer via the property judge (no source snapshot) and stamps ``feedback:<buffer>``. The
+# agent-facing description is the shared FeedbackToolBase one.
 class BufferPropertyFeedbackTool(
     _BufferReviewFeedback,
     WithAsyncDependencies[Command, FeedbackServices],
 ):
-    """Buffer-aware feedback for the non-editing author (structural invariants, immutable source):
-    reviews each buffer via the property judge (no source snapshot) and stamps ``feedback:<buffer>``."""
-
     __doc__ = FeedbackToolBase.__doc__
 
     @override
@@ -745,111 +745,6 @@ class PropertyGenSystemParams(TypedDict):
 
 _PropertyGenSysTemplate = TypedTemplate[PropertyGenSystemParams]("property_generation_system_prompt.j2")
 
-#: Appended to the CVL-generation system prompt: how to author and verify the spec as buffers.
-_SPEC_BUFFERS_GUIDANCE = """
-## Splitting the spec into verification buffers
-
-Instead of one spec, you author several named CVL **buffers**, each a self-contained spec verified and
-reviewed on its own. Use `put_buffer` / `edit_buffer` / `get_buffer` / `list_buffers` / `delete_buffer`
-to author them, and `submit_buffer` / `collect_results` to verify them.
-
-**Strongly prefer splitting, and add over-approximating performance summaries preemptively.** A
-single spec has ONE global `methods{}` block, so every rule is verified under the *intersection* of
-what all rules need precise — one property that needs an expensive function (nonlinear math, hashing,
-a heavy external) kept exact forces EVERY rule to pay that cost, which is the usual source of a
-timeout. Splitting breaks that coupling: each buffer keeps precise only what ITS properties need and
-over-approximates the rest, so a function one buffer must keep exact can be summarized in another.
-So decide the partition up front from the properties and **default to several buffers grouped by
-precision need** — do not start with one monolithic buffer and wait for a timeout to force the split.
-
-When to split:
-- Properties have **conflicting precision needs** — one buffer can summarize a function that another
-  keeps exact (each buffer has its own `methods{}`), with no global-methods-block conflict. This is
-  the primary axis: group the properties by the set of functions they genuinely need exact.
-- Separate **`assert`-only** properties (which can share aggressive over-approximations) from
-  **`satisfy`** properties (which need those functions exact) — see the soundness rule below.
-- To **isolate the hard/slow properties**: put the many easy properties in one buffer that verifies and
-  is approved once and never re-touched, while you iterate on a small hard buffer in isolation — its
-  re-verification and re-review cost only that buffer.
-
-Structuring buffers:
-- Put infrastructure shared by two or more run-target buffers (ghosts, common invariants, helper CVL
-  functions, token/oracle models, and summaries several groups need) in a buffer with
-  `is_run_target=false`, and `import "<shared>.spec"` it from **each run-target that uses it** (and list
-  it in that buffer's `imports`). A shared buffer is pulled in only by the buffers that import it, so
-  editing it re-verifies only those — you can make one shared buffer for a subset of groups and another
-  for a different subset. **Import the shared buffer where you need it; never restate its contents in a
-  run-target** (a duplicate `methods{}` entry or ghost is a compile error).
-- Each **run-target** buffer declares its `property_rules` (the properties it verifies + their rule
-  names). Across all run-target buffers, every non-skipped property must appear in **exactly one**
-  buffer, and each rule lives in exactly one buffer.
-
-Summaries — over-approximate up front (this is your main lever for tractability):
-- For each run-target buffer, look at the functions its properties exercise, and **summarize now**, in
-  that buffer's `methods{}`, every function the buffer's properties do not need exact — an
-  over-approximation (e.g. a `NONDET`/havoc return, or a weaker constraint than the real body).
-  **Do this preemptively, before the first `submit_buffer`** — do not wait for a timeout to force it.
-  Aggressive preemptive summarization is how the hard properties become tractable; a nonlinear-math,
-  hashing, or heavy-external function a property only reads through is the prime candidate.
-- **Soundness rule: an over-approximating summary is sound for `assert` rules but UNSOUND for `satisfy`
-  rules.** An over-approximation *adds* behaviors: an `assert` that holds over the larger behavior set
-  still holds over the real one (sound), whereas a `satisfy` may be witnessed only by an added, non-real
-  behavior (unsound — its witness need not correspond to a real execution). So over-approximate freely
-  in a buffer whose rules are **all `assert`**; in a buffer that contains any `satisfy` rule (or a
-  reachability check), keep the functions it exercises **exact**. This is a first-class reason to
-  partition: group `assert`-only properties (which share aggressive over-approximations) apart from
-  `satisfy` properties (which need those functions exact).
-- **Put each summary where it is USED.** A summary several run-target buffers need goes in a shared
-  buffer they each `import`; a summary only one buffer needs goes in *that* buffer's own `methods{}` (a
-  run-target buffer has its own `methods{}` too). A single-buffer summary parked in a shared buffer that
-  others import makes every later edit re-verify all of them — wasted work on buffers that never use it.
-  For example, if only the approvals buffer reasons about `setApprovalForAll`, summarize it there:
-
-      // buffer "approvals" (run-target)
-      methods {
-          function _.setApprovalForAll(address o, bool a) internal with (env e)
-              => recordErc1155Approval(e.msg.sender, o, a) expect void;
-      }
-      rule approvals_are_recorded { ... }
-
-  so editing this summary never invalidates the other buffers.
-- **Refine on a spurious counterexample.** A too-coarse over-approximation produces a *spurious* cex —
-  one reachable only because the summary admits behavior the real function cannot. When a buffer returns
-  VIOLATED, analyze the cex: if it hinges on behavior your summary allows but the real function forbids,
-  it is spurious → tighten that summary (add the missing constraint) or drop the over-approximation for
-  that function with `edit_buffer`, then re-`submit_buffer`. If the cex reproduces against the exact
-  function, it is a real bug. Start from the simplest sound over-approximation and tighten only as
-  spurious cexes force you to.
-
-Verifying — submit / collect (buffers prove in parallel; never wait on a slow buffer to work on a fast
-one):
-- **Settle the shared base before submitting anything that imports it.** Submit a run-target buffer only
-  once BOTH (i) that buffer is finished AND (ii) every shared buffer it imports is finished — you do not
-  expect to edit them again. Editing a shared buffer after submitting invalidates every buffer that
-  imports it (submitted or already verified): those prover jobs are wasted and must be re-run. So author
-  and stabilize the shared infrastructure first, then submit the run-target buffers that depend on it.
-- `submit_buffer(name)` starts a buffer's prover job in the **background** and returns immediately.
-  Submit each run-target buffer as soon as it and its shared imports are ready — they prove concurrently.
-- `collect_results()` returns the outcomes of jobs that have **finished so far** (without blocking) plus
-  a status board: which buffers are `complete`, `running`, or `needs (re)submission`. Process a finished
-  buffer immediately — fix its counterexample and `submit_buffer` it again — while the others keep
-  proving.
-- Work this priority order, and only ever block at the last step:
-  1. A finished result not yet processed → handle it. If the fix is in a **shared** buffer (e.g. an
-     under-approximation), edit the shared buffer; that invalidates every buffer importing it — the
-     board lists them under `needs (re)submission` (including ones already verified) — so re-submit
-     each of them.
-  2. Else a buffer still to author/submit → author it and `submit_buffer` it.
-  3. Else everything is submitted and running with nothing finished to process → call
-     `collect_results(wait=true)` to sleep until the next job finishes.
-- Editing a buffer (or a shared buffer it imports) makes its prior verification stale; re-submit it. A
-  buffer already verified at its current content is not re-run.
-
-A single run-target buffer is exactly the one-spec case; it is the exception, appropriate only when
-the properties genuinely share one precision profile and prove quickly together. When in doubt,
-split by precision need and summarize preemptively — a well-partitioned set of buffers is far more
-likely to prove than one monolith, and costs you little when the properties turn out to be easy.
-"""
 
 #: The prover's tool extension: contributions come from plugins deriving
 #: ``CertoraProverTools``, dispatched via their ``certora_prover_tools`` hook.
@@ -978,7 +873,6 @@ async def batch_cvl_generation(
 
     sys_prompt : list[RawPromptInput | type[CacheMarker]] = [
         _PropertyGenSysTemplate.bind({"source_editing": editing is not None}).render_to,
-        _SPEC_BUFFERS_GUIDANCE,
         f"\nCreate at most {max_spec_buffers()} run-target buffers; fold further properties into "
         f"existing ones. A single run-target buffer is the one-spec case.",
     ]

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -763,9 +763,21 @@ Instead of one spec, you author several named CVL **buffers**, each a self-conta
 reviewed on its own. Use `put_buffer` / `edit_buffer` / `get_buffer` / `list_buffers` / `delete_buffer`
 to author them, and `submit_buffer` / `collect_results` (NOT `verify_spec`) to verify them.
 
+**Strongly prefer splitting, and add over-approximating performance summaries preemptively.** A
+single spec has ONE global `methods{}` block, so every rule is verified under the *intersection* of
+what all rules need precise — one property that needs an expensive function (nonlinear math, hashing,
+a heavy external) kept exact forces EVERY rule to pay that cost, which is the usual source of a
+timeout. Splitting breaks that coupling: each buffer keeps precise only what ITS properties need and
+over-approximates the rest, so a function one buffer must keep exact can be summarized in another.
+So decide the partition up front from the properties and **default to several buffers grouped by
+precision need** — do not start with one monolithic buffer and wait for a timeout to force the split.
+
 When to split:
 - Properties have **conflicting precision needs** — one buffer can summarize a function that another
-  keeps exact (each buffer has its own `methods{}`), with no global-methods-block conflict.
+  keeps exact (each buffer has its own `methods{}`), with no global-methods-block conflict. This is
+  the primary axis: group the properties by the set of functions they genuinely need exact.
+- Separate **`assert`-only** properties (which can share aggressive over-approximations) from
+  **`satisfy`** properties (which need those functions exact) — see the soundness rule below.
 - To **isolate the hard/slow properties**: put the many easy properties in one buffer that verifies and
   is approved once and never re-touched, while you iterate on a small hard buffer in isolation — its
   re-verification and re-review cost only that buffer.
@@ -843,7 +855,10 @@ one):
 - Editing a buffer (or a shared buffer it imports) makes its prior verification stale; re-submit it. A
   buffer already verified at its current content is not re-run.
 
-A single run-target buffer is exactly the one-spec case, so only split when it helps.
+A single run-target buffer is exactly the one-spec case; it is the exception, appropriate only when
+the properties genuinely share one precision profile and prove quickly together. When in doubt,
+split by precision need and summarize preemptively — a well-partitioned set of buffers is far more
+likely to prove than one monolith, and costs you little when the properties turn out to be easy.
 """
 
 #: The prover's tool extension: contributions come from plugins deriving

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -5,7 +5,8 @@ from contextlib import asynccontextmanager
 import json
 import pathlib
 
-from dataclasses import dataclass
+from abc import abstractmethod
+from dataclasses import dataclass, field
 
 from langchain_core.tools import BaseTool
 from pydantic import Field, BaseModel, Discriminator
@@ -36,7 +37,7 @@ from composer.spec.source.spec_buffers import (
 from composer.spec.source.buffer_tools import (
     put_buffer, get_buffer, edit_buffer, list_buffers, delete_buffer,
 )
-from composer.spec.context import WorkflowContext, CVLGeneration, CacheKey, SourceCode
+from composer.spec.context import WorkflowContext, CVLGeneration, CacheKey, CVLJudge, SourceCode
 from composer.spec.types import PropertyFormulation, PropertyTitle, RuleName
 from composer.pipeline.core import GaveUp, ToolBinder, InjectingToolExtension, Curtailed
 from composer.pipeline.plugin_api import ProvidedTools
@@ -652,30 +653,83 @@ class _LiveJudgeHost:
         )
 
 
+@dataclass
+class _PerBufferJudge[J]:
+    """Lazily builds and caches one persistent judge per buffer, keyed by buffer name — each bound to
+    that buffer's claimed properties, on its own child context so its review memory stays scoped to the
+    buffer. Rebuilt only when the buffer's claimed properties change; because the child namespace is
+    derived from the name, the rebuilt judge keeps its memory. ``properties`` is the batch's full set,
+    for resolving each buffer's subset."""
+    build: Callable[[str, list[PropertyFormulation]], J]
+    properties: list[PropertyFormulation]
+    _cache: dict[str, tuple[tuple[str, ...], J]] = field(default_factory=dict)
+
+    def for_buffer(self, name: str, claimed: list[PropertyFormulation]) -> J:
+        sig = tuple(sorted(str(p.title) for p in claimed))
+        cached = self._cache.get(name)
+        if cached is None or cached[0] != sig:
+            self._cache[name] = (sig, self.build(name, claimed))
+        return self._cache[name][1]
+
+
 class _BufferReviewFeedback(FeedbackToolBase[SourceCVLGenerationState]):
-    """Feedback base that reviews each run-target buffer independently and stamps ``feedback:<buffer>``,
-    falling back to the single-spec base ``run`` when there are no buffers. Both source feedback tools —
-    editor-aware (source editing) and property-only (structural invariants / immutable source) — build
-    on it, so per-buffer review works whether or not source editing is enabled. Subclasses supply
-    ``_get_feedback`` (how the judge is reached)."""
+    """Feedback base that reviews each run-target buffer independently — against the properties that
+    buffer claims — with its own persistent per-buffer judge, and stamps ``feedback:<buffer>``. Both
+    source feedback tools — editor-aware (source editing) and property-only (structural invariants /
+    immutable source) — build on it. Subclasses supply ``_review`` (how the per-buffer judge is reached)
+    and ``_all_properties`` (the batch's property set). With no run-target buffers (nothing authored yet,
+    or every property skipped) there is nothing to review."""
+
+    @abstractmethod
+    async def _review(
+        self, name: str, spec: str, skipped: list[SkippedProperty],
+        properties: list[PropertyFormulation],
+    ) -> PropertyFeedbackProtocol:
+        """Review ``spec`` with the cached per-buffer judge for ``name``, scored against ``properties``
+        (that buffer's claimed subset)."""
+        ...
+
+    @abstractmethod
+    def _all_properties(self) -> list[PropertyFormulation]:
+        """The batch's full property set, for resolving a buffer's claimed subset."""
+        ...
+
+    @override
+    def _version_history(self) -> Sequence[str]:
+        return self.state["version_history"]
+
+    @override
+    async def _get_feedback(
+        self, spec: str, skipped: list[SkippedProperty]
+    ) -> PropertyFeedbackProtocol:
+        # Buffer feedback reviews per buffer through _review; this single-spec entry is unreachable
+        # (curr_spec is always None in buffer mode, and run() handles the no-buffers case directly).
+        # Present only to satisfy the abstract base.
+        raise AssertionError("buffer feedback uses per-buffer _review, not _get_feedback")
 
     @override
     async def run(self) -> Command:
         buffers = self.state.get("buffers") or {}
         targets = run_targets(buffers)
         if not targets:
-            return await super().run()
+            return tool_return(self.tool_call_id, "No run-target buffers to review yet.")
 
-        # Review each run-target buffer whose feedback stamp is missing or stale (its text or an import
-        # changed) in isolation, and stamp feedback:<buffer> per approved buffer — so an approved,
-        # unchanged buffer is never re-reviewed and the hard buffer is reviewed alone.
+        # Review each run-target buffer whose feedback stamp is missing or stale (its text, an import, a
+        # skip, or its claimed properties changed) in isolation, scored against the properties it claims,
+        # and stamp feedback:<buffer> per approved buffer — so an approved, unchanged buffer is never
+        # re-reviewed and the hard buffer is reviewed alone. The claimed properties are part of the
+        # feedback digest (include_claim), so re-assigning a property re-triggers review even with
+        # unchanged CVL.
         skipped = self.state["skipped"]
         skipped_pairs = [(str(s.property_title), str(s.reason)) for s in skipped]
         vh = self._version_history()
         validations = self.state["validations"]
+        all_props = self._all_properties()
 
         def digest(name: str) -> str:
-            return buffer_state_digest(buffers, name, skipped=skipped_pairs, version_history=vh)
+            return buffer_state_digest(
+                buffers, name, skipped=skipped_pairs, version_history=vh, include_claim=True
+            )
 
         stale = [b for b in targets if validations.get(f"feedback:{b.name}") != digest(b.name)]
         if not stale:
@@ -685,7 +739,10 @@ class _BufferReviewFeedback(FeedbackToolBase[SourceCVLGenerationState]):
         new_stamps: dict[str, str] = {}
         blocks: list[str] = []
         for b in stale:
-            verdict = await self._get_feedback(buffer_review_text(buffers, b.name), skipped)
+            claimed = [p for p in all_props if str(p.title) in b.property_rules]
+            verdict = await self._review(
+                b.name, buffer_review_text(buffers, b.name), skipped, claimed
+            )
             blocks.append(f"=== buffer {b.name} ===\nGood? {verdict.good}\nFeedback {verdict.feedback}")
             if verdict.good:
                 new_stamps[f"feedback:{b.name}"] = digest(b.name)
@@ -695,25 +752,29 @@ class _BufferReviewFeedback(FeedbackToolBase[SourceCVLGenerationState]):
 @tool_display("Getting feedback", "Feedback")
 class EditorAwareFeedbackTool(
     _BufferReviewFeedback,
-    WithAsyncDependencies[Command, ContextualFeedbackToolImpl[SourceSnapshot]],
+    WithAsyncDependencies[Command, _PerBufferJudge[ContextualFeedbackToolImpl[SourceSnapshot]]],
 ):
     __doc__ = FeedbackToolBase.__doc__
 
     @override
-    async def _get_feedback(
-        self, spec: str, skipped: list[SkippedProperty]
+    async def _review(
+        self, name: str, spec: str, skipped: list[SkippedProperty],
+        properties: list[PropertyFormulation],
     ) -> PropertyFeedbackProtocol:
-        with self.tool_deps() as judge:
+        with self.tool_deps() as judges:
             assert "vfs" in self.state
             snap = SourceSnapshot(
                 vfs=self.state["vfs"],
                 version_history=self.state["version_history"],
             )
-            return await judge(snap, spec, skipped, self.rebuttals, self.tool_call_id)
+            return await judges.for_buffer(name, properties)(
+                snap, spec, skipped, self.rebuttals, self.tool_call_id
+            )
 
     @override
-    def _version_history(self) -> Sequence[str]:
-        return self.state["version_history"]
+    def _all_properties(self) -> list[PropertyFormulation]:
+        with self.tool_deps() as judges:
+            return judges.properties
 
 
 @tool_display("Getting feedback", "Feedback")
@@ -722,20 +783,24 @@ class EditorAwareFeedbackTool(
 # agent-facing description is the shared FeedbackToolBase one.
 class BufferPropertyFeedbackTool(
     _BufferReviewFeedback,
-    WithAsyncDependencies[Command, FeedbackServices],
+    WithAsyncDependencies[Command, _PerBufferJudge[FeedbackServices]],
 ):
     __doc__ = FeedbackToolBase.__doc__
 
     @override
-    async def _get_feedback(
-        self, spec: str, skipped: list[SkippedProperty]
+    async def _review(
+        self, name: str, spec: str, skipped: list[SkippedProperty],
+        properties: list[PropertyFormulation],
     ) -> PropertyFeedbackProtocol:
-        with self.tool_deps() as svc:
-            return await svc.feedback_thunk(spec, skipped, self.rebuttals, self.tool_call_id)
+        with self.tool_deps() as judges:
+            return await judges.for_buffer(name, properties).feedback_thunk(
+                spec, skipped, self.rebuttals, self.tool_call_id
+            )
 
     @override
-    def _version_history(self) -> Sequence[str]:
-        return self.state["version_history"]
+    def _all_properties(self) -> list[PropertyFormulation]:
+        with self.tool_deps() as judges:
+            return judges.properties
 
 
 _PropertyGenTemplate = TypedTemplate[PropertyGenParams]("property_generation_prompt.j2")
@@ -949,18 +1014,28 @@ async def batch_cvl_generation(
     })
     protected = focus.protected if focus is not None else ()
     if editing is None:
+        # One persistent judge per buffer, bound to that buffer's claimed properties, on its own child
+        # context (memory scoped to the buffer, and kept across a rebuild when the claim changes).
+        property_judges = _PerBufferJudge(
+            build=lambda name, claimed: property_feedback_judge(
+                judge_ctx.child(CacheKey[CVLJudge, CVLJudge](name)), env, judge_prompt, claimed
+            ),
+            properties=props,
+        )
         feedback_suite = [
-            BufferPropertyFeedbackTool.bind(
-                property_feedback_judge(judge_ctx, env, judge_prompt, props)
-            ).as_tool("feedback_tool"),
+            BufferPropertyFeedbackTool.bind(property_judges).as_tool("feedback_tool"),
             *skip_tools(titles, protected=protected),
         ]
     else:
-        judge_impl = source_feedback_judge(
-            judge_ctx, _LiveJudgeHost(env, editing), judge_prompt, props
+        judge_host = _LiveJudgeHost(env, editing)
+        source_judges = _PerBufferJudge(
+            build=lambda name, claimed: source_feedback_judge(
+                judge_ctx.child(CacheKey[CVLJudge, CVLJudge](name)), judge_host, judge_prompt, claimed
+            ),
+            properties=props,
         )
         feedback_suite = [
-            EditorAwareFeedbackTool.bind(judge_impl).as_tool("feedback_tool"),
+            EditorAwareFeedbackTool.bind(source_judges).as_tool("feedback_tool"),
             *skip_tools(titles, protected=protected),
         ]
 

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -974,7 +974,7 @@ async def batch_cvl_generation(
             async with project_directory(st.get("vfs") or {}) as run_root:
                 yield CVLAuthorState(
                     working_dir=pathlib.Path(run_root),
-                    curr_spec=None,
+                    buffers=st.get("buffers") or {},
                     prover_runner=WrappedProverRunner(
                         st["config"],
                         prover_tool.options,

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -21,7 +21,7 @@ from composer.authoring.judge import PropertyFeedbackProtocol
 from composer.authoring.state import SkippedProperty, check_completion
 from composer.authoring.tools import gated_give_up_tool, give_up_tool
 from composer.spec.cvl_generation import (
-    static_tools, property_tools, skip_tools, CVLGenerationExtra, FEEDBACK_VALIDATION_KEY,
+    cvl_guidance_tools, property_tools, skip_tools, CVLGenerationExtra, FEEDBACK_VALIDATION_KEY,
     validate_property_rules, CVL_JUDGE_KEY, run_cvl_generator,
     GeneratedCVL, PropertyRuleMapping, AppliedEdit, FeedbackToolBase,
 )
@@ -30,7 +30,7 @@ from composer.spec.source.live_explorer import VersionedHistory, LiveEditTools, 
 from composer.spec.source.prover import setup_prover_config_in
 from composer.spec.source.spec_buffers import (
     SpecBuffersExtra, buffer_review_text, buffer_state_digest, check_buffer_completion,
-    combined_buffers_view, run_targets, spec_buffers_enabled, validate_coverage,
+    combined_buffers_view, max_spec_buffers, run_targets, validate_coverage,
     validate_disjoint_rules,
 )
 from composer.spec.source.buffer_tools import (
@@ -726,7 +726,7 @@ class PropertyGenSystemParams(TypedDict):
 
 _PropertyGenSysTemplate = TypedTemplate[PropertyGenSystemParams]("property_generation_system_prompt.j2")
 
-#: Appended to the system prompt only when multi-buffer authoring is enabled (spec_buffers_enabled).
+#: Appended to the CVL-generation system prompt: how to author and verify the spec as buffers.
 _SPEC_BUFFERS_GUIDANCE = """
 ## Splitting the spec into verification buffers
 
@@ -764,6 +764,23 @@ Summaries — over-approximate up front (this is your main lever for tractabilit
   reachability check), keep the functions it exercises **exact**. This is a first-class reason to
   partition: group `assert`-only properties (which share aggressive over-approximations) apart from
   `satisfy` properties (which need those functions exact).
+- **Put each summary where it is USED — do NOT default everything into the shared buffer.** A summary
+  that is sound and useful for *every* run-target buffer belongs in the shared buffer; a summary only
+  *some* buffers need belongs in *those* buffers' own `methods{}` (a run-target buffer has its own
+  `methods{}` too). A property-specific summary parked in the shared buffer makes every later edit to it
+  re-verify *every* importer — wasted work on buffers that never use it. For example, if only the
+  approvals buffer reasons about `setApprovalForAll`, summarize it there and leave the shared base free
+  of it:
+
+      // buffer "approvals" (run-target) — imports the shared base
+      import "base.spec";
+      methods {
+          function _.setApprovalForAll(address o, bool a) internal with (env e)
+              => recordErc1155Approval(e.msg.sender, o, a) expect void;
+      }
+      rule approvals_are_recorded { ... }
+
+  so editing this summary never invalidates the other buffers.
 - **Refine on a spurious counterexample.** A too-coarse over-approximation produces a *spurious* cex —
   one reachable only because the summary admits behavior the real function cannot. When a buffer returns
   VIOLATED, analyze the cex: if it hinges on behavior your summary allows but the real function forbids,
@@ -927,10 +944,11 @@ async def batch_cvl_generation(
     })
 
     sys_prompt : list[RawPromptInput | type[CacheMarker]] = [
-        _PropertyGenSysTemplate.bind({"source_editing": editing is not None}).render_to
+        _PropertyGenSysTemplate.bind({"source_editing": editing is not None}).render_to,
+        _SPEC_BUFFERS_GUIDANCE,
+        f"\nCreate at most {max_spec_buffers()} run-target buffers; fold further properties into "
+        f"existing ones. A single run-target buffer is the one-spec case.",
     ]
-    if spec_buffers_enabled():
-        sys_prompt.append(_SPEC_BUFFERS_GUIDANCE)
 
     added_tools : list[BaseTool] = []
     if editing_tools is not None:
@@ -1035,27 +1053,22 @@ async def batch_cvl_generation(
     else:
         b = b.with_tools(env.source_tools)
     # Multi-buffer authoring (opt-in): the agent partitions the spec into several named buffers,
-    # each submitted and verified independently via the async submit_buffer / collect_results tools
-    # (bound in place of the single-spec verify_spec). Off by default so the single-curr_spec flow is
-    # untouched.
-    if spec_buffers_enabled():
-        buffer_authoring: list[BaseTool] = [
-            put_buffer(SourceCVLGenerationState), get_buffer(SourceCVLGenerationState),
-            edit_buffer(SourceCVLGenerationState), list_buffers(SourceCVLGenerationState),
-            delete_buffer(SourceCVLGenerationState),
-        ]
-        prover_binding: list[BaseTool] = list(prover_tool.buffer_tools)
-    else:
-        buffer_authoring = []
-        prover_binding = [prover_tool.lg_tool]
+    # Multi-buffer authoring is the only mode: the agent writes CVL through the buffer tools and
+    # verifies each run-target buffer with the async submit_buffer / collect_results pair. Guidance-only
+    # CVL tools are bound (no put_cvl/edit_cvl/verify_spec).
+    buffer_authoring: list[BaseTool] = [
+        put_buffer(SourceCVLGenerationState), get_buffer(SourceCVLGenerationState),
+        edit_buffer(SourceCVLGenerationState), list_buffers(SourceCVLGenerationState),
+        delete_buffer(SourceCVLGenerationState),
+    ]
     task_graph = b.with_tools(
-        static_tools()
+        cvl_guidance_tools()
     ).with_tools(
         buffer_authoring
     ).with_tools(
         feedback_suite
     ).with_tools(
-        [*prover_binding,
+        [*prover_tool.buffer_tools,
          ExpectRulePassage.as_tool("expect_rule_passage"),
          ExpectRuleFailure.as_tool("expect_rule_failure"),
          give_up_tool(name="give_up", description=_GIVE_UP_DESCRIPTION, label="CVL generation")

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -21,9 +21,9 @@ from composer.authoring.judge import PropertyFeedbackProtocol
 from composer.authoring.state import SkippedProperty, check_completion
 from composer.authoring.tools import gated_give_up_tool, give_up_tool
 from composer.spec.cvl_generation import (
-    cvl_guidance_tools, property_tools, skip_tools, CVLGenerationExtra, FEEDBACK_VALIDATION_KEY,
+    cvl_guidance_tools, skip_tools, CVLGenerationExtra, FEEDBACK_VALIDATION_KEY,
     validate_property_rules, CVL_JUDGE_KEY, run_cvl_generator,
-    GeneratedCVL, PropertyRuleMapping, AppliedEdit, FeedbackToolBase,
+    GeneratedCVL, PropertyRuleMapping, AppliedEdit, FeedbackToolBase, FeedbackServices,
 )
 from composer.prover.core import run_prover, CexHandler, ProverCallbacks, ProverReport
 from composer.spec.source.live_explorer import VersionedHistory, LiveEditTools, WIPE_HISTORY
@@ -662,9 +662,49 @@ class _LiveJudgeHost:
         )
 
 
+class _BufferReviewFeedback(FeedbackToolBase[SourceCVLGenerationState]):
+    """Feedback base that reviews each run-target buffer independently and stamps ``feedback:<buffer>``,
+    falling back to the single-spec base ``run`` when there are no buffers. Both source feedback tools —
+    editor-aware (source editing) and property-only (structural invariants / immutable source) — build
+    on it, so per-buffer review works whether or not source editing is enabled. Subclasses supply
+    ``_get_feedback`` (how the judge is reached)."""
+
+    @override
+    async def run(self) -> Command:
+        buffers = self.state.get("buffers") or {}
+        targets = run_targets(buffers)
+        if not targets:
+            return await super().run()
+
+        # Review each run-target buffer whose feedback stamp is missing or stale (its text or an import
+        # changed) in isolation, and stamp feedback:<buffer> per approved buffer — so an approved,
+        # unchanged buffer is never re-reviewed and the hard buffer is reviewed alone.
+        skipped = self.state["skipped"]
+        skipped_pairs = [(str(s.property_title), str(s.reason)) for s in skipped]
+        vh = self._version_history()
+        validations = self.state["validations"]
+
+        def digest(name: str) -> str:
+            return buffer_state_digest(buffers, name, skipped=skipped_pairs, version_history=vh)
+
+        stale = [b for b in targets if validations.get(f"feedback:{b.name}") != digest(b.name)]
+        if not stale:
+            return tool_return(
+                self.tool_call_id, "All buffers already reviewed and approved at their current state."
+            )
+        new_stamps: dict[str, str] = {}
+        blocks: list[str] = []
+        for b in stale:
+            verdict = await self._get_feedback(buffer_review_text(buffers, b.name), skipped)
+            blocks.append(f"=== buffer {b.name} ===\nGood? {verdict.good}\nFeedback {verdict.feedback}")
+            if verdict.good:
+                new_stamps[f"feedback:{b.name}"] = digest(b.name)
+        return tool_state_update(self.tool_call_id, "\n\n".join(blocks), validations=new_stamps)
+
+
 @tool_display("Getting feedback", "Feedback")
 class EditorAwareFeedbackTool(
-    FeedbackToolBase[SourceCVLGenerationState],
+    _BufferReviewFeedback,
     WithAsyncDependencies[Command, ContextualFeedbackToolImpl[SourceSnapshot]],
 ):
     __doc__ = FeedbackToolBase.__doc__
@@ -685,38 +725,27 @@ class EditorAwareFeedbackTool(
     def _version_history(self) -> Sequence[str]:
         return self.state["version_history"]
 
+
+@tool_display("Getting feedback", "Feedback")
+class BufferPropertyFeedbackTool(
+    _BufferReviewFeedback,
+    WithAsyncDependencies[Command, FeedbackServices],
+):
+    """Buffer-aware feedback for the non-editing author (structural invariants, immutable source):
+    reviews each buffer via the property judge (no source snapshot) and stamps ``feedback:<buffer>``."""
+
+    __doc__ = FeedbackToolBase.__doc__
+
     @override
-    async def run(self) -> Command:
-        """Single-spec: the base flow. Multi-buffer: review each run-target buffer whose feedback
-        stamp is missing or stale (its text or an import changed) in isolation, and stamp
-        ``feedback:<buffer>`` per approved buffer — so an approved, unchanged buffer is never
-        re-reviewed and the hard buffer is reviewed alone."""
-        buffers = self.state.get("buffers") or {}
-        targets = run_targets(buffers)
-        if not targets:
-            return await super().run()
+    async def _get_feedback(
+        self, spec: str, skipped: list[SkippedProperty]
+    ) -> PropertyFeedbackProtocol:
+        with self.tool_deps() as svc:
+            return await svc.feedback_thunk(spec, skipped, self.rebuttals, self.tool_call_id)
 
-        skipped = self.state["skipped"]
-        skipped_pairs = [(str(s.property_title), str(s.reason)) for s in skipped]
-        vh = self.state["version_history"]
-        validations = self.state["validations"]
-
-        def digest(name: str) -> str:
-            return buffer_state_digest(buffers, name, skipped=skipped_pairs, version_history=vh)
-
-        stale = [b for b in targets if validations.get(f"feedback:{b.name}") != digest(b.name)]
-        if not stale:
-            return tool_return(
-                self.tool_call_id, "All buffers already reviewed and approved at their current state."
-            )
-        new_stamps: dict[str, str] = {}
-        blocks: list[str] = []
-        for b in stale:
-            verdict = await self._get_feedback(buffer_review_text(buffers, b.name), skipped)
-            blocks.append(f"=== buffer {b.name} ===\nGood? {verdict.good}\nFeedback {verdict.feedback}")
-            if verdict.good:
-                new_stamps[f"feedback:{b.name}"] = digest(b.name)
-        return tool_state_update(self.tool_call_id, "\n\n".join(blocks), validations=new_stamps)
+    @override
+    def _version_history(self) -> Sequence[str]:
+        return self.state["version_history"]
 
 
 _PropertyGenTemplate = TypedTemplate[PropertyGenParams]("property_generation_prompt.j2")
@@ -742,9 +771,13 @@ When to split:
   re-verification and re-review cost only that buffer.
 
 Structuring buffers:
-- Put **shared** infrastructure (ghosts, common invariants, helper CVL functions, token/oracle models)
-  in a buffer with `is_run_target=false`, and have run-target buffers `import "<shared>.spec"` and list
-  it in their `imports`.
+- Put infrastructure shared by two or more run-target buffers (ghosts, common invariants, helper CVL
+  functions, token/oracle models, and summaries several groups need) in a buffer with
+  `is_run_target=false`, and `import "<shared>.spec"` it from **each run-target that uses it** (and list
+  it in that buffer's `imports`). A shared buffer is pulled in only by the buffers that import it, so
+  editing it re-verifies only those — you can make one shared buffer for a subset of groups and another
+  for a different subset. **Import the shared buffer where you need it; never restate its contents in a
+  run-target** (a duplicate `methods{}` entry or ghost is a compile error).
 - Each **run-target** buffer declares its `property_rules` (the properties it verifies + their rule
   names). Across all run-target buffers, every non-skipped property must appear in **exactly one**
   buffer, and each rule lives in exactly one buffer.
@@ -764,16 +797,13 @@ Summaries — over-approximate up front (this is your main lever for tractabilit
   reachability check), keep the functions it exercises **exact**. This is a first-class reason to
   partition: group `assert`-only properties (which share aggressive over-approximations) apart from
   `satisfy` properties (which need those functions exact).
-- **Put each summary where it is USED — do NOT default everything into the shared buffer.** A summary
-  that is sound and useful for *every* run-target buffer belongs in the shared buffer; a summary only
-  *some* buffers need belongs in *those* buffers' own `methods{}` (a run-target buffer has its own
-  `methods{}` too). A property-specific summary parked in the shared buffer makes every later edit to it
-  re-verify *every* importer — wasted work on buffers that never use it. For example, if only the
-  approvals buffer reasons about `setApprovalForAll`, summarize it there and leave the shared base free
-  of it:
+- **Put each summary where it is USED.** A summary several run-target buffers need goes in a shared
+  buffer they each `import`; a summary only one buffer needs goes in *that* buffer's own `methods{}` (a
+  run-target buffer has its own `methods{}` too). A single-buffer summary parked in a shared buffer that
+  others import makes every later edit re-verify all of them — wasted work on buffers that never use it.
+  For example, if only the approvals buffer reasons about `setApprovalForAll`, summarize it there:
 
-      // buffer "approvals" (run-target) — imports the shared base
-      import "base.spec";
+      // buffer "approvals" (run-target)
       methods {
           function _.setApprovalForAll(address o, bool a) internal with (env e)
               => recordErc1155Approval(e.msg.sender, o, a) expect void;
@@ -1022,10 +1052,12 @@ async def batch_cvl_generation(
     })
     protected = focus.protected if focus is not None else ()
     if editing is None:
-        feedback_suite = property_tools(
-            property_feedback_judge(judge_ctx, env, judge_prompt, props),
-            protected=protected,
-        )
+        feedback_suite = [
+            BufferPropertyFeedbackTool.bind(
+                property_feedback_judge(judge_ctx, env, judge_prompt, props)
+            ).as_tool("feedback_tool"),
+            *skip_tools(titles, protected=protected),
+        ]
     else:
         judge_impl = source_feedback_judge(
             judge_ctx, _LiveJudgeHost(env, editing), judge_prompt, props

--- a/composer/spec/source/author.py
+++ b/composer/spec/source/author.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, NotRequired, override, Literal, Annotated, Sequence, Protocol, Callable, cast
+from typing import AsyncIterator, NotRequired, override, Literal, Annotated, Sequence, Protocol, Callable
 
 from typing_extensions import TypedDict
 from contextlib import asynccontextmanager
@@ -178,7 +178,7 @@ class PublishResultTool(
         if (err := validate_disjoint_rules(buffers)) is not None:
             return f"Completion REJECTED: {err}"
         pr = [
-            PropertyRuleMapping(property_title=cast(PropertyTitle, p), rules=cast(list[RuleName], rs))
+            PropertyRuleMapping(property_title=PropertyTitle(p), rules=[RuleName(rn) for rn in rs])
             for b in run_targets(buffers) for p, rs in b.property_rules.items()
         ]
         return tool_state_update(

--- a/composer/spec/source/autoprove_common.py
+++ b/composer/spec/source/autoprove_common.py
@@ -3,7 +3,6 @@
 import argparse
 import hashlib
 import logging
-import os
 import pathlib
 import uuid
 from contextlib import asynccontextmanager
@@ -25,7 +24,6 @@ from composer.pipeline.ecosystem import EVM
 from composer.spec.source.pipeline import ProverBackend, GeneratedCVL
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.prover.core import make_prover_options
-from composer.certora_env import CERTORA_HOME_OVERRIDE_ENV
 from composer.spec.source.source_env import build_source_env
 from composer.spec.source.author import SourceEditing
 from composer.spec.source.live_explorer import setup_live_edits
@@ -64,7 +62,6 @@ class AutoProveArgs(ExtendedModelOptions, RAGDBOptions, Protocol):
     budget: str | None
     time_budget: float | None
     run_mode: str | None
-    certora_run_command: str | None
 
 
 # ---------------------------------------------------------------------------
@@ -102,30 +99,8 @@ async def _entry_point(summary: RunSummary) -> AsyncIterator[Executor]:
              "spends the run on the highest-contribution property and the properties it rests "
              "on. Also settable as AUTOPROVER_RUN_MODE; this flag wins.",
     )
-    parser.add_argument(
-        "--certora-run-command",
-        default=None,
-        help="Which Certora install AutoProver resolves certoraRun / Typechecker.jar from, "
-        "overriding $CERTORA for this run. Pass 'certoraRun' (or 'pip') to use the pip-installed "
-        "certora_cli — required to dispatch cloud jobs while $CERTORA points at a local source "
-        "build (a checkout is not a pip distribution, so a cloud submission cannot infer its "
-        "version). Or pass a path to a source checkout. Omit to honor $CERTORA.",
-    )
 
     args = cast(AutoProveArgs, parser.parse_args())
-    # Translate the flag into the env override certora_env reads. The wrapper
-    # subprocesses (certoraRunWrapper / certoraTypeCheck) inherit this env, so
-    # setting it here covers every certoraRun/jar resolution for the run.
-    if args.certora_run_command is not None:
-        cmd = args.certora_run_command.strip()
-        # A bare command that names the pip CLI selects the pip package; anything
-        # else is treated as a path to a source checkout (its directory).
-        if pathlib.Path(cmd).name in ("certoraRun", "certoraRun.py", "pip"):
-            os.environ[CERTORA_HOME_OVERRIDE_ENV] = "pip"
-        else:
-            p = pathlib.Path(cmd)
-            os.environ[CERTORA_HOME_OVERRIDE_ENV] = str(p.parent if p.name == "certoraRun.py" else p)
-
     async with autoprove_executor(args, summary) as runner:
         yield runner
 

--- a/composer/spec/source/autoprove_common.py
+++ b/composer/spec/source/autoprove_common.py
@@ -3,6 +3,7 @@
 import argparse
 import hashlib
 import logging
+import os
 import pathlib
 import uuid
 from contextlib import asynccontextmanager
@@ -24,6 +25,7 @@ from composer.pipeline.ecosystem import EVM
 from composer.spec.source.pipeline import ProverBackend, GeneratedCVL
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.prover.core import make_prover_options
+from composer.certora_env import CERTORA_HOME_OVERRIDE_ENV
 from composer.spec.source.source_env import build_source_env
 from composer.spec.source.author import SourceEditing
 from composer.spec.source.live_explorer import setup_live_edits
@@ -62,6 +64,7 @@ class AutoProveArgs(ExtendedModelOptions, RAGDBOptions, Protocol):
     budget: str | None
     time_budget: float | None
     run_mode: str | None
+    certora_run_command: str | None
 
 
 # ---------------------------------------------------------------------------
@@ -99,8 +102,30 @@ async def _entry_point(summary: RunSummary) -> AsyncIterator[Executor]:
              "spends the run on the highest-contribution property and the properties it rests "
              "on. Also settable as AUTOPROVER_RUN_MODE; this flag wins.",
     )
+    parser.add_argument(
+        "--certora-run-command",
+        default=None,
+        help="Which Certora install AutoProver resolves certoraRun / Typechecker.jar from, "
+        "overriding $CERTORA for this run. Pass 'certoraRun' (or 'pip') to use the pip-installed "
+        "certora_cli — required to dispatch cloud jobs while $CERTORA points at a local source "
+        "build (a checkout is not a pip distribution, so a cloud submission cannot infer its "
+        "version). Or pass a path to a source checkout. Omit to honor $CERTORA.",
+    )
 
     args = cast(AutoProveArgs, parser.parse_args())
+    # Translate the flag into the env override certora_env reads. The wrapper
+    # subprocesses (certoraRunWrapper / certoraTypeCheck) inherit this env, so
+    # setting it here covers every certoraRun/jar resolution for the run.
+    if args.certora_run_command is not None:
+        cmd = args.certora_run_command.strip()
+        # A bare command that names the pip CLI selects the pip package; anything
+        # else is treated as a path to a source checkout (its directory).
+        if pathlib.Path(cmd).name in ("certoraRun", "certoraRun.py", "pip"):
+            os.environ[CERTORA_HOME_OVERRIDE_ENV] = "pip"
+        else:
+            p = pathlib.Path(cmd)
+            os.environ[CERTORA_HOME_OVERRIDE_ENV] = str(p.parent if p.name == "certoraRun.py" else p)
+
     async with autoprove_executor(args, summary) as runner:
         yield runner
 

--- a/composer/spec/source/buffer_tools.py
+++ b/composer/spec/source/buffer_tools.py
@@ -1,0 +1,179 @@
+"""Agent-facing tools for authoring several named CVL spec buffers — the multi-buffer generalization
+of the single ``curr_spec`` tools in :mod:`composer.authoring.buffer`.
+
+Each tool reads and writes ``state["buffers"][name]`` (a :class:`NamedBuffer`) instead of the single
+``curr_spec`` string, reusing the shared CVL validator (:func:`cvl_syntax_error`) and the
+surgical-edit primitive (:func:`replace_unique`). Writes go through the buffers-map reducer, so an
+edit to one buffer leaves the others untouched. Each factory takes the concrete state type so the
+tool can inject it.
+"""
+
+from typing import Annotated
+
+from langchain_core.tools import BaseTool, InjectedToolCallId, tool
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from pydantic import BaseModel, Field, create_model
+from typing_extensions import TypedDict
+
+from graphcore.graph import tool_state_update
+
+from composer.core.edit import EditErr, EditOk, replace_unique
+from composer.cvl.tools import cvl_syntax_error
+from composer.spec.source.spec_buffers import NamedBuffer
+from composer.ui.tool_display import ToolDisplay, suppress_ack, tool_display_of
+
+
+class WithBuffers(TypedDict):
+    buffers: dict[str, NamedBuffer]
+
+
+_put_display = ToolDisplay("Writing spec buffer", suppress_ack("Buffer write result"))
+_get_display = ToolDisplay("Reading spec buffer", None)
+_edit_display = ToolDisplay("Editing spec buffer", suppress_ack("Buffer edit result"))
+_list_display = ToolDisplay("Listing spec buffers", None)
+_delete_display = ToolDisplay("Deleting spec buffer", suppress_ack("Buffer delete result"))
+
+
+put_buffer_description = """
+Create or replace a whole CVL spec buffer, identified by `name`. A buffer is a self-contained spec:
+its own rules, its `methods{}` block, and `import` statements pulling in shared buffers. The text is
+run through the CVL parser; if it fails to parse the update is rejected and the buffer is unchanged.
+
+Set `is_run_target` false for a shared buffer that only supplies imports (ghosts/invariants/models)
+and runs no rules of its own. List the names it imports in `imports` so shared-buffer edits correctly
+invalidate this one. Re-putting an existing buffer keeps its property->rule mapping.
+"""
+
+
+class _PutBufferTemplate(BaseModel):
+    name: str = Field(description="Unique buffer name (also its on-disk spec stem).")
+    cvl: str = Field(description="The buffer's full CVL text (rules, methods{}, imports).")
+    imports: list[str] = Field(
+        default_factory=list, description="Names of the buffers this one imports."
+    )
+    is_run_target: bool = Field(
+        default=True, description="False for a shared, imported-only buffer that runs no rules."
+    )
+
+
+def put_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
+    schema = create_model(
+        "PutBuffer", __base__=_PutBufferTemplate, __doc__=put_buffer_description,
+        state=(Annotated[ty, InjectedState], ...),
+        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
+    )
+
+    @tool_display_of(_put_display)
+    @tool(args_schema=schema)
+    def put_buffer(**args) -> str | Command:
+        if (err := cvl_syntax_error(args["cvl"])) is not None:
+            return err
+        existing = args["state"]["buffers"].get(args["name"])
+        buf = NamedBuffer(
+            name=args["name"], cvl=args["cvl"], imports=tuple(args["imports"]),
+            is_run_target=args["is_run_target"],
+            property_rules=dict(existing.property_rules) if existing else {},
+        )
+        return tool_state_update(
+            tool_call_id=args["tool_call_id"], content="Accepted", buffers={args["name"]: buf}
+        )
+    return put_buffer
+
+
+edit_buffer_description = """
+Make a surgical edit to one spec buffer instead of re-emitting it. Provide `name`, an exact
+`old_string` span copied from that buffer (must occur exactly once — include context to disambiguate),
+and `new_string`. The edited buffer is re-parsed; if it fails to parse the edit is rejected and the
+buffer is unchanged. Dramatically cheaper than `put_buffer` for a small change.
+"""
+
+
+class _EditBufferTemplate(BaseModel):
+    name: str = Field(description="The buffer to edit.")
+    old_string: str = Field(description="Exact span to replace; must occur exactly once.")
+    new_string: str = Field(description="Replacement text.")
+
+
+def edit_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
+    schema = create_model(
+        "EditBuffer", __base__=_EditBufferTemplate, __doc__=edit_buffer_description,
+        state=(Annotated[ty, InjectedState], ...),
+        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
+    )
+
+    @tool_display_of(_edit_display)
+    @tool(args_schema=schema)
+    def edit_buffer(**args) -> str | Command:
+        existing = args["state"]["buffers"].get(args["name"])
+        if existing is None:
+            return f"No buffer named {args['name']!r}. Create it with put_buffer first."
+        match replace_unique(existing.cvl, args["old_string"], args["new_string"]):
+            case EditErr(message=msg):
+                return msg
+            case EditOk(text=new_text):
+                if (err := cvl_syntax_error(new_text)) is not None:
+                    return err
+                buf = existing.model_copy(update={"cvl": new_text})
+                return tool_state_update(
+                    tool_call_id=args["tool_call_id"], content="Accepted",
+                    buffers={args["name"]: buf},
+                )
+    return edit_buffer
+
+
+def get_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
+    schema = create_model(
+        "GetBuffer", __doc__="Read one spec buffer's current CVL text.",
+        name=(str, Field(description="The buffer to read.")),
+        state=(Annotated[ty, InjectedState], ...),
+    )
+
+    @tool_display_of(_get_display)
+    @tool(args_schema=schema)
+    def get_buffer(**args) -> str:
+        buf = args["state"]["buffers"].get(args["name"])
+        return buf.cvl if buf is not None else f"No buffer named {args['name']!r}."
+    return get_buffer
+
+
+def list_buffers[S: WithBuffers](ty: type[S]) -> BaseTool:
+    schema = create_model(
+        "ListBuffers", __doc__="List the spec buffers: name, kind, imports, and rule count.",
+        state=(Annotated[ty, InjectedState], ...),
+    )
+
+    @tool_display_of(_list_display)
+    @tool(args_schema=schema)
+    def list_buffers(**args) -> str:
+        buffers: dict[str, NamedBuffer] = args["state"]["buffers"]
+        if not buffers:
+            return "No spec buffers yet."
+        lines = []
+        for name in sorted(buffers):
+            b = buffers[name]
+            kind = "run-target" if b.is_run_target else "shared"
+            imp = f", imports {sorted(b.imports)}" if b.imports else ""
+            lines.append(f"- {name} ({kind}, {len(b.owned_rules)} rules{imp})")
+        return "\n".join(lines)
+    return list_buffers
+
+
+def delete_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
+    schema = create_model(
+        "DeleteBuffer",
+        __doc__="Delete a spec buffer (e.g. after merging its rules into another).",
+        name=(str, Field(description="The buffer to delete.")),
+        state=(Annotated[ty, InjectedState], ...),
+        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
+    )
+
+    @tool_display_of(_delete_display)
+    @tool(args_schema=schema)
+    def delete_buffer(**args) -> str | Command:
+        if args["name"] not in args["state"]["buffers"]:
+            return f"No buffer named {args['name']!r}."
+        return tool_state_update(
+            tool_call_id=args["tool_call_id"], content="Deleted", buffers={args["name"]: None}
+        )
+    return delete_buffer

--- a/composer/spec/source/buffer_tools.py
+++ b/composer/spec/source/buffer_tools.py
@@ -49,6 +49,12 @@ invalidate this one. Re-putting an existing buffer keeps its property->rule mapp
 class _PutBufferTemplate(BaseModel):
     name: str = Field(description="Unique buffer name (also its on-disk spec stem).")
     cvl: str = Field(description="The buffer's full CVL text (rules, methods{}, imports).")
+    property_rules: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="The properties this buffer verifies and, for each (by its snake_case title), the "
+        "rule/invariant names in this buffer's CVL that verify it. Across all run-target buffers every "
+        "non-skipped property must appear in exactly one buffer. Omit for a shared buffer.",
+    )
     imports: list[str] = Field(
         default_factory=list, description="Names of the buffers this one imports."
     )
@@ -70,10 +76,11 @@ def put_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
         if (err := cvl_syntax_error(args["cvl"])) is not None:
             return err
         existing = (args["state"].get("buffers") or {}).get(args["name"])
+        # Keep the prior property->rule mapping when the agent re-puts text without restating it.
+        prop_rules = args["property_rules"] or (dict(existing.property_rules) if existing else {})
         buf = NamedBuffer(
             name=args["name"], cvl=args["cvl"], imports=tuple(args["imports"]),
-            is_run_target=args["is_run_target"],
-            property_rules=dict(existing.property_rules) if existing else {},
+            is_run_target=args["is_run_target"], property_rules=prop_rules,
         )
         return tool_state_update(
             tool_call_id=args["tool_call_id"], content="Accepted", buffers={args["name"]: buf}

--- a/composer/spec/source/buffer_tools.py
+++ b/composer/spec/source/buffer_tools.py
@@ -69,7 +69,7 @@ def put_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
     def put_buffer(**args) -> str | Command:
         if (err := cvl_syntax_error(args["cvl"])) is not None:
             return err
-        existing = args["state"]["buffers"].get(args["name"])
+        existing = (args["state"].get("buffers") or {}).get(args["name"])
         buf = NamedBuffer(
             name=args["name"], cvl=args["cvl"], imports=tuple(args["imports"]),
             is_run_target=args["is_run_target"],
@@ -105,7 +105,7 @@ def edit_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
     @tool_display_of(_edit_display)
     @tool(args_schema=schema)
     def edit_buffer(**args) -> str | Command:
-        existing = args["state"]["buffers"].get(args["name"])
+        existing = (args["state"].get("buffers") or {}).get(args["name"])
         if existing is None:
             return f"No buffer named {args['name']!r}. Create it with put_buffer first."
         match replace_unique(existing.cvl, args["old_string"], args["new_string"]):
@@ -132,7 +132,7 @@ def get_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
     @tool_display_of(_get_display)
     @tool(args_schema=schema)
     def get_buffer(**args) -> str:
-        buf = args["state"]["buffers"].get(args["name"])
+        buf = (args["state"].get("buffers") or {}).get(args["name"])
         return buf.cvl if buf is not None else f"No buffer named {args['name']!r}."
     return get_buffer
 
@@ -146,7 +146,7 @@ def list_buffers[S: WithBuffers](ty: type[S]) -> BaseTool:
     @tool_display_of(_list_display)
     @tool(args_schema=schema)
     def list_buffers(**args) -> str:
-        buffers: dict[str, NamedBuffer] = args["state"]["buffers"]
+        buffers: dict[str, NamedBuffer] = (args["state"].get("buffers") or {})
         if not buffers:
             return "No spec buffers yet."
         lines = []
@@ -171,7 +171,7 @@ def delete_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
     @tool_display_of(_delete_display)
     @tool(args_schema=schema)
     def delete_buffer(**args) -> str | Command:
-        if args["name"] not in args["state"]["buffers"]:
+        if args["name"] not in (args["state"].get("buffers") or {}):
             return f"No buffer named {args['name']!r}."
         return tool_state_update(
             tool_call_id=args["tool_call_id"], content="Deleted", buffers={args["name"]: None}

--- a/composer/spec/source/buffer_tools.py
+++ b/composer/spec/source/buffer_tools.py
@@ -20,7 +20,7 @@ from graphcore.graph import tool_state_update
 
 from composer.core.edit import EditErr, EditOk, replace_unique
 from composer.cvl.tools import cvl_syntax_error
-from composer.spec.source.spec_buffers import NamedBuffer
+from composer.spec.source.spec_buffers import NamedBuffer, max_spec_buffers
 from composer.ui.tool_display import ToolDisplay, suppress_ack, tool_display_of
 
 
@@ -75,7 +75,17 @@ def put_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
     def put_buffer(**args) -> str | Command:
         if (err := cvl_syntax_error(args["cvl"])) is not None:
             return err
-        existing = (args["state"].get("buffers") or {}).get(args["name"])
+        buffers_now = args["state"].get("buffers") or {}
+        # Cap how far the agent partitions: a new run-target buffer beyond the cap is refused.
+        if args["is_run_target"] and args["name"] not in buffers_now:
+            cap = max_spec_buffers()
+            if sum(1 for b in buffers_now.values() if b.is_run_target) >= cap:
+                return (
+                    f"Refusing to create run-target buffer {args['name']!r}: the run-target buffer cap "
+                    f"({cap}) is already reached. Fold these properties into an existing run-target "
+                    f"buffer instead."
+                )
+        existing = buffers_now.get(args["name"])
         # Keep the prior property->rule mapping when the agent re-puts text without restating it.
         prop_rules = args["property_rules"] or (dict(existing.property_rules) if existing else {})
         buf = NamedBuffer(

--- a/composer/spec/source/buffer_tools.py
+++ b/composer/spec/source/buffer_tools.py
@@ -20,7 +20,7 @@ from graphcore.graph import tool_state_update
 
 from composer.core.edit import EditErr, EditOk, replace_unique
 from composer.cvl.tools import cvl_syntax_error
-from composer.spec.source.spec_buffers import NamedBuffer, max_spec_buffers
+from composer.spec.source.spec_buffers import NamedBuffer, buffer_imports, max_spec_buffers
 from composer.ui.tool_display import ToolDisplay, suppress_ack, tool_display_of
 
 
@@ -169,7 +169,8 @@ def list_buffers[S: WithBuffers](ty: type[S]) -> BaseTool:
         for name in sorted(buffers):
             b = buffers[name]
             kind = "run-target" if b.is_run_target else "shared"
-            imp = f", imports {sorted(b.imports)}" if b.imports else ""
+            imps = buffer_imports(buffers, name)
+            imp = f", imports {sorted(imps)}" if imps else ""
             lines.append(f"- {name} ({kind}, {len(b.owned_rules)} rules{imp})")
         return "\n".join(lines)
     return list_buffers

--- a/composer/spec/source/buffer_tools.py
+++ b/composer/spec/source/buffer_tools.py
@@ -4,19 +4,17 @@ of the single ``curr_spec`` tools in :mod:`composer.authoring.buffer`.
 Each tool reads and writes ``state["buffers"][name]`` (a :class:`NamedBuffer`) instead of the single
 ``curr_spec`` string, reusing the shared CVL validator (:func:`cvl_syntax_error`) and the
 surgical-edit primitive (:func:`replace_unique`). Writes go through the buffers-map reducer, so an
-edit to one buffer leaves the others untouched. Each factory takes the concrete state type so the
-tool can inject it.
+edit to one buffer leaves the others untouched. Each tool is a pydantic model generic over the
+concrete graph state; the factory subscribes it to that state and mints the tool.
 """
 
-from typing import Annotated
-
-from langchain_core.tools import BaseTool, InjectedToolCallId, tool
-from langgraph.prebuilt import InjectedState
+from langchain_core.tools import BaseTool
 from langgraph.types import Command
-from pydantic import BaseModel, Field, create_model
+from pydantic import Field
 from typing_extensions import TypedDict
 
 from graphcore.graph import tool_state_update
+from graphcore.tools.schemas import WithImplementation, WithInjectedId, WithInjectedState
 
 from composer.core.edit import EditErr, EditOk, replace_unique
 from composer.cvl.tools import cvl_syntax_error
@@ -35,20 +33,18 @@ _list_display = ToolDisplay("Listing spec buffers", None)
 _delete_display = ToolDisplay("Deleting spec buffer", suppress_ack("Buffer delete result"))
 
 
-put_buffer_description = """
-Create or replace a whole CVL spec buffer, identified by `name`. A buffer is a self-contained spec:
-its own rules, its `methods{}` block, and `import` statements pulling in shared buffers. The text is
-run through the CVL parser; if it fails to parse the update is rejected and the buffer is unchanged.
+class PutBuffer[S: WithBuffers](WithImplementation[str | Command], WithInjectedState[S], WithInjectedId):
+    """Create or replace a whole CVL spec buffer, identified by `name`. A buffer is a self-contained
+    spec: its own rules, its `methods{}` block, and `import` statements pulling in shared buffers. The
+    text is run through the CVL parser; if it fails to parse the update is rejected and the buffer is
+    unchanged.
 
-Set `is_run_target` false for a shared buffer that only supplies imports (ghosts/invariants/models)
-and runs no rules of its own. To depend on a shared buffer, just `import "<name>.spec";` in this
-buffer's CVL — the dependency is read from those import statements, so editing a shared buffer
-correctly re-verifies exactly the buffers that import it. Re-putting an existing buffer keeps its
-property->rule mapping.
-"""
+    Set `is_run_target` false for a shared buffer that only supplies imports (ghosts/invariants/models)
+    and runs no rules of its own. To depend on a shared buffer, just `import "<name>.spec";` in this
+    buffer's CVL — the dependency is read from those import statements, so editing a shared buffer
+    correctly re-verifies exactly the buffers that import it. Re-putting an existing buffer keeps its
+    property->rule mapping."""
 
-
-class _PutBufferTemplate(BaseModel):
     name: str = Field(description="Unique buffer name (also its on-disk spec stem).")
     cvl: str = Field(description="The buffer's full CVL text (rules, methods{}, imports).")
     property_rules: dict[str, list[str]] = Field(
@@ -61,70 +57,50 @@ class _PutBufferTemplate(BaseModel):
         default=True, description="False for a shared, imported-only buffer that runs no rules."
     )
 
-
-def put_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
-    schema = create_model(
-        "PutBuffer", __base__=_PutBufferTemplate, __doc__=put_buffer_description,
-        state=(Annotated[ty, InjectedState], ...),
-        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
-    )
-
-    @tool_display_of(_put_display)
-    @tool(args_schema=schema)
-    def put_buffer(**args) -> str | Command:
-        if (err := cvl_syntax_error(args["cvl"])) is not None:
+    def run(self) -> str | Command:
+        if (err := cvl_syntax_error(self.cvl)) is not None:
             return err
-        buffers_now = args["state"].get("buffers") or {}
+        buffers_now = self.state.get("buffers") or {}
         # Cap how far the agent partitions: a new run-target buffer beyond the cap is refused.
-        if args["is_run_target"] and args["name"] not in buffers_now:
+        if self.is_run_target and self.name not in buffers_now:
             cap = max_spec_buffers()
             if sum(1 for b in buffers_now.values() if b.is_run_target) >= cap:
                 return (
-                    f"Refusing to create run-target buffer {args['name']!r}: the run-target buffer cap "
+                    f"Refusing to create run-target buffer {self.name!r}: the run-target buffer cap "
                     f"({cap}) is already reached. Fold these properties into an existing run-target "
                     f"buffer instead."
                 )
-        existing = buffers_now.get(args["name"])
+        existing = buffers_now.get(self.name)
         # Keep the prior property->rule mapping when the agent re-puts text without restating it.
-        prop_rules = args["property_rules"] or (dict(existing.property_rules) if existing else {})
+        prop_rules = self.property_rules or (dict(existing.property_rules) if existing else {})
         buf = NamedBuffer(
-            name=args["name"], cvl=args["cvl"],
-            is_run_target=args["is_run_target"], property_rules=prop_rules,
+            name=self.name, cvl=self.cvl,
+            is_run_target=self.is_run_target, property_rules=prop_rules,
         )
         return tool_state_update(
-            tool_call_id=args["tool_call_id"], content="Accepted", buffers={args["name"]: buf}
+            tool_call_id=self.tool_call_id, content="Accepted", buffers={self.name: buf}
         )
-    return put_buffer
 
 
-edit_buffer_description = """
-Make a surgical edit to one spec buffer instead of re-emitting it. Provide `name`, an exact
-`old_string` span copied from that buffer (must occur exactly once — include context to disambiguate),
-and `new_string`. The edited buffer is re-parsed; if it fails to parse the edit is rejected and the
-buffer is unchanged. Dramatically cheaper than `put_buffer` for a small change.
-"""
+def put_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
+    return tool_display_of(_put_display)(PutBuffer[ty].as_tool("put_buffer"))
 
 
-class _EditBufferTemplate(BaseModel):
+class EditBuffer[S: WithBuffers](WithImplementation[str | Command], WithInjectedState[S], WithInjectedId):
+    """Make a surgical edit to one spec buffer instead of re-emitting it. Provide `name`, an exact
+    `old_string` span copied from that buffer (must occur exactly once — include context to
+    disambiguate), and `new_string`. The edited buffer is re-parsed; if it fails to parse the edit is
+    rejected and the buffer is unchanged. Dramatically cheaper than `put_buffer` for a small change."""
+
     name: str = Field(description="The buffer to edit.")
     old_string: str = Field(description="Exact span to replace; must occur exactly once.")
     new_string: str = Field(description="Replacement text.")
 
-
-def edit_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
-    schema = create_model(
-        "EditBuffer", __base__=_EditBufferTemplate, __doc__=edit_buffer_description,
-        state=(Annotated[ty, InjectedState], ...),
-        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
-    )
-
-    @tool_display_of(_edit_display)
-    @tool(args_schema=schema)
-    def edit_buffer(**args) -> str | Command:
-        existing = (args["state"].get("buffers") or {}).get(args["name"])
+    def run(self) -> str | Command:
+        existing = (self.state.get("buffers") or {}).get(self.name)
         if existing is None:
-            return f"No buffer named {args['name']!r}. Create it with put_buffer first."
-        match replace_unique(existing.cvl, args["old_string"], args["new_string"]):
+            return f"No buffer named {self.name!r}. Create it with put_buffer first."
+        match replace_unique(existing.cvl, self.old_string, self.new_string):
             case EditErr(message=msg):
                 return msg
             case EditOk(text=new_text):
@@ -132,37 +108,33 @@ def edit_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
                     return err
                 buf = existing.model_copy(update={"cvl": new_text})
                 return tool_state_update(
-                    tool_call_id=args["tool_call_id"], content="Accepted",
-                    buffers={args["name"]: buf},
+                    tool_call_id=self.tool_call_id, content="Accepted", buffers={self.name: buf},
                 )
-    return edit_buffer
+
+
+def edit_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
+    return tool_display_of(_edit_display)(EditBuffer[ty].as_tool("edit_buffer"))
+
+
+class GetBuffer[S: WithBuffers](WithImplementation[str], WithInjectedState[S]):
+    """Read one spec buffer's current CVL text."""
+
+    name: str = Field(description="The buffer to read.")
+
+    def run(self) -> str:
+        buf = (self.state.get("buffers") or {}).get(self.name)
+        return buf.cvl if buf is not None else f"No buffer named {self.name!r}."
 
 
 def get_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
-    schema = create_model(
-        "GetBuffer", __doc__="Read one spec buffer's current CVL text.",
-        name=(str, Field(description="The buffer to read.")),
-        state=(Annotated[ty, InjectedState], ...),
-    )
-
-    @tool_display_of(_get_display)
-    @tool(args_schema=schema)
-    def get_buffer(**args) -> str:
-        buf = (args["state"].get("buffers") or {}).get(args["name"])
-        return buf.cvl if buf is not None else f"No buffer named {args['name']!r}."
-    return get_buffer
+    return tool_display_of(_get_display)(GetBuffer[ty].as_tool("get_buffer"))
 
 
-def list_buffers[S: WithBuffers](ty: type[S]) -> BaseTool:
-    schema = create_model(
-        "ListBuffers", __doc__="List the spec buffers: name, kind, imports, and rule count.",
-        state=(Annotated[ty, InjectedState], ...),
-    )
+class ListBuffers[S: WithBuffers](WithImplementation[str], WithInjectedState[S]):
+    """List the spec buffers: name, kind, imports, and rule count."""
 
-    @tool_display_of(_list_display)
-    @tool(args_schema=schema)
-    def list_buffers(**args) -> str:
-        buffers: dict[str, NamedBuffer] = (args["state"].get("buffers") or {})
+    def run(self) -> str:
+        buffers: dict[str, NamedBuffer] = (self.state.get("buffers") or {})
         if not buffers:
             return "No spec buffers yet."
         lines = []
@@ -173,24 +145,24 @@ def list_buffers[S: WithBuffers](ty: type[S]) -> BaseTool:
             imp = f", imports {sorted(imps)}" if imps else ""
             lines.append(f"- {name} ({kind}, {len(b.owned_rules)} rules{imp})")
         return "\n".join(lines)
-    return list_buffers
+
+
+def list_buffers[S: WithBuffers](ty: type[S]) -> BaseTool:
+    return tool_display_of(_list_display)(ListBuffers[ty].as_tool("list_buffers"))
+
+
+class DeleteBuffer[S: WithBuffers](WithImplementation[str | Command], WithInjectedState[S], WithInjectedId):
+    """Delete a spec buffer (e.g. after merging its rules into another)."""
+
+    name: str = Field(description="The buffer to delete.")
+
+    def run(self) -> str | Command:
+        if self.name not in (self.state.get("buffers") or {}):
+            return f"No buffer named {self.name!r}."
+        return tool_state_update(
+            tool_call_id=self.tool_call_id, content="Deleted", buffers={self.name: None}
+        )
 
 
 def delete_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
-    schema = create_model(
-        "DeleteBuffer",
-        __doc__="Delete a spec buffer (e.g. after merging its rules into another).",
-        name=(str, Field(description="The buffer to delete.")),
-        state=(Annotated[ty, InjectedState], ...),
-        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
-    )
-
-    @tool_display_of(_delete_display)
-    @tool(args_schema=schema)
-    def delete_buffer(**args) -> str | Command:
-        if args["name"] not in (args["state"].get("buffers") or {}):
-            return f"No buffer named {args['name']!r}."
-        return tool_state_update(
-            tool_call_id=args["tool_call_id"], content="Deleted", buffers={args["name"]: None}
-        )
-    return delete_buffer
+    return tool_display_of(_delete_display)(DeleteBuffer[ty].as_tool("delete_buffer"))

--- a/composer/spec/source/buffer_tools.py
+++ b/composer/spec/source/buffer_tools.py
@@ -18,12 +18,27 @@ from graphcore.tools.schemas import WithImplementation, WithInjectedId, WithInje
 
 from composer.core.edit import EditErr, EditOk, replace_unique
 from composer.cvl.tools import cvl_syntax_error
-from composer.spec.source.spec_buffers import NamedBuffer, buffer_imports, max_spec_buffers
+from composer.spec.source.spec_buffers import (
+    NamedBuffer, buffer_imports, duplicated_declarations, max_spec_buffers,
+)
 from composer.ui.tool_display import ToolDisplay, suppress_ack, tool_display_of
 
 
 class WithBuffers(TypedDict):
     buffers: dict[str, NamedBuffer]
+
+
+def _dup_note(buffers: dict[str, NamedBuffer], name: str) -> str:
+    """A warning listing declarations in buffer ``name`` that also appear verbatim in another run-target
+    buffer, or "" if there are none. Restricted to ``name``: dups among other buffers were flagged when
+    those buffers were written."""
+    dups = {d: [n for n in ns if n != name]
+            for d, ns in duplicated_declarations(buffers).items() if name in ns}
+    if not dups:
+        return ""
+    lines = "\n".join(f"  {d}  (also in {ns})" for d, ns in dups.items())
+    return ("\n\nNOTE: these declarations are duplicated in other run-target buffers — consider moving "
+            "each to a shared buffer the duplicating buffers import, before proving:\n" + lines)
 
 
 _put_display = ToolDisplay("Writing spec buffer", suppress_ack("Buffer write result"))
@@ -78,7 +93,9 @@ class PutBuffer[S: WithBuffers](WithImplementation[str | Command], WithInjectedS
             is_run_target=self.is_run_target, property_rules=prop_rules,
         )
         return tool_state_update(
-            tool_call_id=self.tool_call_id, content="Accepted", buffers={self.name: buf}
+            tool_call_id=self.tool_call_id,
+            content="Accepted" + _dup_note({**buffers_now, self.name: buf}, self.name),
+            buffers={self.name: buf},
         )
 
 
@@ -107,8 +124,11 @@ class EditBuffer[S: WithBuffers](WithImplementation[str | Command], WithInjected
                 if (err := cvl_syntax_error(new_text)) is not None:
                     return err
                 buf = existing.model_copy(update={"cvl": new_text})
+                buffers_now = self.state.get("buffers") or {}
                 return tool_state_update(
-                    tool_call_id=self.tool_call_id, content="Accepted", buffers={self.name: buf},
+                    tool_call_id=self.tool_call_id,
+                    content="Accepted" + _dup_note({**buffers_now, self.name: buf}, self.name),
+                    buffers={self.name: buf},
                 )
 
 

--- a/composer/spec/source/buffer_tools.py
+++ b/composer/spec/source/buffer_tools.py
@@ -41,8 +41,10 @@ its own rules, its `methods{}` block, and `import` statements pulling in shared 
 run through the CVL parser; if it fails to parse the update is rejected and the buffer is unchanged.
 
 Set `is_run_target` false for a shared buffer that only supplies imports (ghosts/invariants/models)
-and runs no rules of its own. List the names it imports in `imports` so shared-buffer edits correctly
-invalidate this one. Re-putting an existing buffer keeps its property->rule mapping.
+and runs no rules of its own. To depend on a shared buffer, just `import "<name>.spec";` in this
+buffer's CVL — the dependency is read from those import statements, so editing a shared buffer
+correctly re-verifies exactly the buffers that import it. Re-putting an existing buffer keeps its
+property->rule mapping.
 """
 
 
@@ -54,9 +56,6 @@ class _PutBufferTemplate(BaseModel):
         description="The properties this buffer verifies and, for each (by its snake_case title), the "
         "rule/invariant names in this buffer's CVL that verify it. Across all run-target buffers every "
         "non-skipped property must appear in exactly one buffer. Omit for a shared buffer.",
-    )
-    imports: list[str] = Field(
-        default_factory=list, description="Names of the buffers this one imports."
     )
     is_run_target: bool = Field(
         default=True, description="False for a shared, imported-only buffer that runs no rules."
@@ -89,7 +88,7 @@ def put_buffer[S: WithBuffers](ty: type[S]) -> BaseTool:
         # Keep the prior property->rule mapping when the agent re-puts text without restating it.
         prop_rules = args["property_rules"] or (dict(existing.property_rules) if existing else {})
         buf = NamedBuffer(
-            name=args["name"], cvl=args["cvl"], imports=tuple(args["imports"]),
+            name=args["name"], cvl=args["cvl"],
             is_run_target=args["is_run_target"], property_rules=prop_rules,
         )
         return tool_state_update(

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -84,9 +84,7 @@ class _ProverPipelineDeps:
     editing: SourceEditing
 
     def to_prover_tool(self, tools: ProverToolset) -> ProverTool:
-        return ProverTool(
-            lg_tool=tools.verify_spec, buffer_tools=tools.buffer_tools, options=self.prover_options
-        )
+        return ProverTool(buffer_tools=tools.buffer_tools, options=self.prover_options)
 
 #: The invariant CVL's slot in the report: a real delivery (imported by every component spec)
 #: or the quarantined leftovers of a budget-curtailed generation (appendix only).

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -44,7 +44,7 @@ from composer.spec.source.harness import (
 from composer.spec.source.summarizer import setup_summaries
 from composer.spec.source.struct_invariant import get_invariant_formulation
 from composer.spec.source.autosetup import SetupSuccess
-from composer.spec.source.prover import get_prover_tool, materializing_project
+from composer.spec.source.prover import get_prover_tool, materializing_project, ProverToolset
 from composer.spec.source.plugin import CertoraProverTools
 from composer.spec.source.author import (
     batch_cvl_generation, EditingTools, FocusPolicy, SourceEditing, ProverTool,
@@ -83,8 +83,10 @@ class _ProverPipelineDeps:
     analysis_store: CexAnalysisStore
     editing: SourceEditing
 
-    def to_prover_tool(self, tool: BaseTool) -> ProverTool:
-        return ProverTool(lg_tool=tool, options=self.prover_options)
+    def to_prover_tool(self, tools: ProverToolset) -> ProverTool:
+        return ProverTool(
+            lg_tool=tools.verify_spec, buffer_tools=tools.buffer_tools, options=self.prover_options
+        )
 
 #: The invariant CVL's slot in the report: a real delivery (imported by every component spec)
 #: or the quarantined leftovers of a budget-curtailed generation (appendix only).
@@ -96,7 +98,7 @@ class ProverRunner(Formalizer[GeneratedCVL, ContractComponentInstance]):
     """Immutable formalizer: per-batch CVL generation against a fixed prover
     config + resource set (already including ``invariants.spec`` when there are
     structural invariants), plus the in-memory invariant result for the report."""
-    _prover_tool: BaseTool
+    _prover_tool: ProverToolset
     _prover_config: dict
     _resources: list[CVLResource]
     _invariant: tuple[list[PropertyFormulation], InvariantResult] | None
@@ -210,7 +212,7 @@ class ProverPrepared(PreparedSystem[GeneratedCVL, ContractComponentInstance, Con
     prover-only pre-formalization fan-out in ``prepare_formalization``."""
     _sys_desc: SystemDescriptionHarnessed
     _harnessed: HarnessedApplication
-    _prover_tool: BaseTool
+    _prover_tool: ProverToolset
     _analyzed: SourceApplication
 
     _deps: _ProverPipelineDeps

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -84,7 +84,7 @@ class _ProverPipelineDeps:
     editing: SourceEditing
 
     def to_prover_tool(self, tools: ProverToolset) -> ProverTool:
-        return ProverTool(buffer_tools=tools.buffer_tools, options=self.prover_options)
+        return ProverTool(buffer_tools=tools.make_buffer_tools(), options=self.prover_options)
 
 #: The invariant CVL's slot in the report: a real delivery (imported by every component spec)
 #: or the quarantined leftovers of a budget-curtailed generation (appendix only).

--- a/composer/spec/source/pipeline.py
+++ b/composer/spec/source/pipeline.py
@@ -371,7 +371,7 @@ class ProverBackend:
         # VFS (invariants, or an author that never edited) runs in-situ; a
         # non-empty one runs in a temp materialization of the working copy.
         prover_tool = get_prover_tool(
-            run.env.llm_heavy(), run.source.contract_name, materializing_project(run.source.project_root, self.editing.live.mat),
+            run.env.llm_heavy(), run.source.contract_name, materializing_project(self.editing.live.mat),
             prover_opts=self._prover_opts, analysis_store=self.analysis_store,
         )
         return ProverPrepared(

--- a/composer/spec/source/plugin.py
+++ b/composer/spec/source/plugin.py
@@ -11,7 +11,7 @@ the driver's binder as a ``ToolExtension`` (``composer.pipeline.core``).
 import pathlib
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import AsyncContextManager, Callable, Sequence, Protocol
+from typing import AsyncContextManager, Callable, Mapping, Sequence, Protocol
 
 from composer.pipeline.plugin_api import (
     FormalizationTool, PipelinePlugin, PluginToolContext, ProvidedTools,
@@ -20,6 +20,7 @@ from composer.spec.system_model import FeatureUnit
 from composer.spec.types import PropertyFormulation
 from composer.prover.core import ProverReport, ProverCallbacks, CexHandler
 from composer.io.task_host import TaskHost
+from composer.spec.source.spec_buffers import NamedBuffer, buffer_review_text
 
 class ProverRunner(Protocol):
     """One ad-hoc prover run: stages the spec/conf into ``working_dir`` for the
@@ -63,12 +64,21 @@ class CVLAuthorState:
     # The run root the prover would execute in: the project itself, or a temporary
     # materialization of the author's working copy (lifetime = the read).
     working_dir: pathlib.Path
-    curr_spec: str | None
+    # The spec under authoring, as its named buffers — each a self-contained CVL unit (its own rules,
+    # methods{}, and imports). Every rule lives in exactly one buffer; ``spec_for_rule`` returns the CVL
+    # for a given rule.
+    buffers: Mapping[str, NamedBuffer]
     prover_runner: ProverRunner
     host: TaskHost
     # Propose source edits for the author to apply; records carry the
     # proposing plugin's attribution.
     edit_store: EditProposer
+
+    def spec_for_rule(self, rule: str) -> str | None:
+        """The CVL the author has written for ``rule``: the buffer that declares it, together with its
+        transitive import closure, as one document — or None if no buffer declares ``rule``."""
+        name = next((nm for nm, b in self.buffers.items() if rule in b.owned_rules), None)
+        return buffer_review_text(self.buffers, name) if name is not None else None
 
 type ProverStateReader[T] = Callable[[T], AsyncContextManager[CVLAuthorState]]
 

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -53,6 +53,9 @@ from composer.spec.util import temp_certora_file
 from composer.spec.gen_types import CERTORA_DIR, SPECS_DIR
 from composer.spec.util import string_hash
 from composer.spec.source.cex_capture import CexAnalysisStore
+from composer.spec.source.spec_buffers import (
+    BufferRun, NamedBuffer, SpecBuffersExtra, buffer_digest, plan_buffer_runs, run_targets,
+)
 
 
 _logger = logging.getLogger("composer.prover")
@@ -306,7 +309,7 @@ type ProverEvents = CEXAnalysisStart | CloudPollingEvent | ProverOutputEvent | R
 # (structural invariants, never-edited authors), in which case it contributes
 # nothing to the digest. The prover's validation stamp is bound to it so a
 # post-run edit invalidates the stamp.
-class StateWithSkips(CVLGenerationState, ProverStateExtra, VersionedHistory):
+class StateWithSkips(CVLGenerationState, ProverStateExtra, VersionedHistory, SpecBuffersExtra):
     pass
 
 class _SpecCallbacks(ProverEventCallbacks):
@@ -526,6 +529,51 @@ def setup_prover_config_in(
         ) as conf_path:
             yield (conf_path, config)
 
+@contextmanager
+def materialize_buffers(
+    working_dir: str, buffers: Mapping[str, NamedBuffer]
+) -> Iterator[dict[str, str]]:
+    """Write every buffer as ``{name}.spec`` into the specs dir (all at once), so any buffer's
+    ``import "X.spec"`` resolves to its sibling. Yields ``name -> on-disk spec path``; every file is
+    removed on exit. Buffer names are unique, so there is no same-name write race across the set."""
+    with ExitStack() as stack:
+        yield {
+            name: stack.enter_context(tmp_spec(root=working_dir, content=buf.cvl, name=name))
+            for name, buf in buffers.items()
+        }
+
+
+@contextmanager
+def buffer_conf(
+    *,
+    working_dir: str,
+    config: dict,
+    main_contract: str,
+    spec_path: str,
+    buffer_name: str,
+    conf_dir: Path,
+    rule: list[str] | None,
+    msg: str,
+) -> Iterator[tuple[str, dict]]:
+    """Build a conf verifying an already-materialized buffer spec at ``spec_path`` (its imports resolve
+    to the sibling ``.spec`` files written by :func:`materialize_buffers`). Yields (conf_path, config)."""
+    cfg = prover_config_overlay(
+        config, main_contract=main_contract, verify_target=f"{main_contract}:{spec_path}"
+    )
+    if rule is not None:
+        cfg["rule"] = rule
+    cfg["msg"] = msg
+    with temp_certora_file(
+        root=working_dir,
+        content=json.dumps(cfg, indent=2),
+        ext="conf",
+        name=f"verify_{buffer_name}",
+        prefix="verify",
+        dest_dir=conf_dir,
+    ) as conf_path:
+        yield (conf_path, cfg)
+
+
 def get_prover_tool(
     llm: LLM,
     main_contract: str,
@@ -561,15 +609,18 @@ def get_prover_tool(
         if rules is not None and exclude_rules is not None:
             return "Cannot invoke the prover with both `rules` and `exclude_rules` set to non-none"
 
+        # Multi-buffer mode when the agent has declared run-target buffers; otherwise the single
+        # curr_spec path below (unchanged).
+        buffers = state.get("buffers") or {}
+        targets = run_targets(buffers)
+
         spec = state["curr_spec"]
-        if spec is None:
+        if not targets and spec is None:
             return "Specification not yet put on VFS"
 
-        spec_hash = string_hash(
-            spec
-        )
+        spec_hash = string_hash(spec) if spec is not None else ""
 
-        if (last_run := last_prover_run(state["prover_history"])) is not None:
+        if not targets and (last_run := last_prover_run(state["prover_history"])) is not None:
             if any(i == "TIMEOUT" for (_,i) in last_run["prover_results"]) and last_run["spec_digest"] == spec_hash:
                 return "Refusing to re-run prover on identical spec with a known TIMEOUT result; timeouts are not transient " \
                     "errors and will not go away by re-running the tool."
@@ -594,6 +645,7 @@ def get_prover_tool(
 
 
         async def run_in(run_root: str) -> str | Command:
+            assert spec is not None  # single-spec path; buffers mode dispatches to run_buffers
             with setup_prover_config_in(
                 working_dir=run_root,
                 main_contract=main_contract,
@@ -716,6 +768,120 @@ def get_prover_tool(
         # The author's working copy decides where this run executes (in-situ for
         # an empty VFS, a temp materialization otherwise); the same-stem lock
         # guards the deterministic spec/conf names within it.
+        async def run_buffers(run_root: str, targets: list[NamedBuffer]) -> str | Command:
+            """Verify each run-target buffer as its own spec, concurrently; overall completion is the
+            AND of per-buffer completion. A buffer already complete at its current digest is skipped."""
+            conf = state["config"]
+            summary = get_run_summary()
+            conf_dir = CERTORA_DIR / "confs"
+            expected = set(state["rule_skips"].keys())
+            skipped = state["skipped"]
+            vh = state["version_history"]
+
+            def digest_of(b: NamedBuffer) -> str:
+                # The buffer's content + import closure, plus this authoring state (skips / edit history),
+                # so any of them changing forces a re-verify.
+                return buffer_digest(
+                    buffers, b.name,
+                    extra_parts=[f"skip:{s}" for s in sorted(str(x) for x in skipped)] + [f"vh:{len(vh)}"],
+                )
+
+            plan = plan_buffer_runs(
+                buffers,
+                digest_of=digest_of,
+                is_complete=lambda b, d: buffer_is_complete(
+                    state["prover_history"], buffer=b.name, curr_digest=d,
+                    expected_to_fail=expected, curr_status=[], all_rules=list(b.owned_rules),
+                ),
+            )
+            pending = [r for r in plan if r.needs_run]
+            if not pending:
+                return tool_state_update(
+                    tool_call_id=tool_call_id,
+                    content="All buffers already verified at their current state; nothing to re-run.",
+                )
+
+            with materialize_buffers(run_root, buffers) as paths:
+                async def run_one(r: BufferRun):
+                    b = r.buffer
+                    spec_path = paths[b.name]
+                    with buffer_conf(
+                        working_dir=run_root, config=conf, main_contract=main_contract,
+                        spec_path=spec_path, buffer_name=b.name, conf_dir=conf_dir, rule=None, msg="",
+                    ) as (cpath, _cfg):
+                        try:
+                            all_rules = await declared_rules_list(folder=Path(run_root), args=[cpath])
+                        except SpecCompilationError as exc:
+                            return (r, f"[buffer {b.name}] failed to compile:\n{exc.output}", [])
+                    with buffer_conf(
+                        working_dir=run_root, config=conf, main_contract=main_contract,
+                        spec_path=spec_path, buffer_name=b.name, conf_dir=conf_dir, rule=None,
+                        msg=f"{b.name} iteration {len(state['prover_history']) + 1}",
+                    ) as (cpath, cfg):
+                        async with sem:
+                            res = await run_prover(
+                                Path(run_root), [cpath], tool_call_id, prover_opts,
+                                _SpecCallbacks(get_stream_writer(), tool_call_id, summary, cfg,
+                                               analysis_store=analysis_store),
+                                DefaultCexHandler(llm, state, summarization_threshold=10),
+                            )
+                    return (r, res, all_rules)
+
+                outcomes = await asyncio.gather(*(run_one(r) for r in pending))
+
+            for (_r, res, _rules) in outcomes:
+                if isinstance(res, str):  # a hard compile/toolchain error in any buffer aborts the pass
+                    return res
+
+            prover_update: list[ProverHistoryItem] = []
+            fresh: dict[str, list[tuple[RulePath, StatusCodes]]] = {}
+            link: str | None = None
+            parts: list[str] = []
+            for (r, res, all_rules) in outcomes:
+                assert not isinstance(res, str)
+                results: list[tuple[RulePath, StatusCodes]] = [(k, v) for (k, v) in res.raw_rule_status.items()]
+                fresh[r.buffer.name] = results
+                link = res.link or link
+                parts.append(f"=== buffer {r.buffer.name} ===\n{res.result_str}")
+                prover_update.append(ProverRunLog(
+                    tool_call_id=tool_call_id,
+                    prover_results=results,
+                    rules=None,
+                    spec_digest=string_hash(r.buffer.cvl),
+                    sort="run",
+                    declared_rules=all_rules,
+                    state_digest=r.digest,
+                    buffer=r.buffer.name,
+                ))
+
+            # Overall completion is the AND across every run target: fresh results for the ones we ran,
+            # history for those skipped as already complete.
+            history_after = state["prover_history"] + prover_update
+            all_verified = all(
+                buffer_is_complete(
+                    history_after, buffer=b.name, curr_digest=digest_of(b),
+                    expected_to_fail=expected, curr_status=fresh.get(b.name, []),
+                    all_rules=list(b.owned_rules),
+                )
+                for b in targets
+            )
+
+            content = "\n\n".join(parts)
+            if all_verified:
+                return tool_state_update(
+                    tool_call_id=tool_call_id, content=content, prover_link=link,
+                    validations=stamper(state, state["version_history"]),
+                    prover_history=prover_update,
+                )
+            return tool_state_update(
+                tool_call_id=tool_call_id, content=content, prover_link=link,
+                prover_history=prover_update,
+            )
+
+        if targets:
+            async with spec_locks.setdefault("__buffers__", asyncio.Lock()), \
+                    project_directory(state.get("vfs") or {}) as run_root:
+                return await run_buffers(run_root, targets)
         async with lock, project_directory(state.get("vfs") or {}) as run_root:
             return await run_in(run_root)
 

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -113,6 +113,9 @@ class ProverRunLog(TypedDict):
     sort: Literal["run"]
     declared_rules: list[str]
     state_digest: str
+    # The spec buffer this run belongs to; absent for a single-curr_spec run. Each buffer has its own
+    # spec/digest, so completion is evaluated per buffer over its own runs (see _history_for_buffer).
+    buffer: NotRequired[str]
 
 class NagMarker(TypedDict):
     nagged_rules: list[RulePath]
@@ -245,6 +248,33 @@ def _is_completion_history(
         if not remaining_rules:
             return True
     return False
+
+def _history_for_buffer(l: list[ProverHistoryItem], buffer: str) -> list[ProverHistoryItem]:
+    """The prover history restricted to one buffer's runs (nag markers pass through). Each buffer has
+    its own spec, hence its own ``state_digest``; filtering first keeps :func:`_iterate_history`'s
+    digest streak from being truncated by an interleaved run of a different buffer."""
+    return [it for it in l if it["sort"] != "run" or it.get("buffer") == buffer]
+
+
+def buffer_is_complete(
+    l: list[ProverHistoryItem],
+    *,
+    buffer: str,
+    curr_digest: str,
+    expected_to_fail: set[str],
+    curr_status: list[tuple[RulePath, StatusCodes]],
+    all_rules: list[str],
+) -> bool:
+    """Whether one buffer's rules are all verified against its current digest, evaluated over that
+    buffer's own runs. Overall completion is the AND of this across every run-target buffer."""
+    return _is_completion_history(
+        l=_history_for_buffer(l, buffer),
+        curr_digest=curr_digest,
+        expected_to_fail=expected_to_fail,
+        curr_status=curr_status,
+        all_rules=all_rules,
+    )
+
 
 def _merge_prover_history(left: list[ProverHistoryItem], right: list[ProverHistoryItem]) -> list[ProverHistoryItem]:
     to_ret = left.copy()

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -54,7 +54,7 @@ from composer.spec.gen_types import CERTORA_DIR, SPECS_DIR
 from composer.spec.util import string_hash
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.spec.source.spec_buffers import (
-    BufferRun, NamedBuffer, SpecBuffersExtra, buffer_digest, plan_buffer_runs, run_targets,
+    BufferRun, NamedBuffer, SpecBuffersExtra, buffer_state_digest, plan_buffer_runs, run_targets,
 )
 
 
@@ -775,16 +775,11 @@ def get_prover_tool(
             summary = get_run_summary()
             conf_dir = CERTORA_DIR / "confs"
             expected = set(state["rule_skips"].keys())
-            skipped = state["skipped"]
             vh = state["version_history"]
+            skipped_pairs = [(str(s.property_title), str(s.reason)) for s in state["skipped"]]
 
             def digest_of(b: NamedBuffer) -> str:
-                # The buffer's content + import closure, plus this authoring state (skips / edit history),
-                # so any of them changing forces a re-verify.
-                return buffer_digest(
-                    buffers, b.name,
-                    extra_parts=[f"skip:{s}" for s in sorted(str(x) for x in skipped)] + [f"vh:{len(vh)}"],
-                )
+                return buffer_state_digest(buffers, b.name, skipped=skipped_pairs, version_history=vh)
 
             plan = plan_buffer_runs(
                 buffers,
@@ -854,28 +849,22 @@ def get_prover_tool(
                     buffer=r.buffer.name,
                 ))
 
-            # Overall completion is the AND across every run target: fresh results for the ones we ran,
-            # history for those skipped as already complete.
+            # Stamp the prover validation per buffer that is complete at its current digest (fresh
+            # results for the ones we ran, history for those skipped as already complete). Overall
+            # completion is checked per buffer at publish (check_buffer_completion).
             history_after = state["prover_history"] + prover_update
-            all_verified = all(
-                buffer_is_complete(
+            prover_stamps: dict[str, str] = {}
+            for b in targets:
+                if buffer_is_complete(
                     history_after, buffer=b.name, curr_digest=digest_of(b),
                     expected_to_fail=expected, curr_status=fresh.get(b.name, []),
                     all_rules=list(b.owned_rules),
-                )
-                for b in targets
-            )
+                ):
+                    prover_stamps[f"prover:{b.name}"] = digest_of(b)
 
-            content = "\n\n".join(parts)
-            if all_verified:
-                return tool_state_update(
-                    tool_call_id=tool_call_id, content=content, prover_link=link,
-                    validations=stamper(state, state["version_history"]),
-                    prover_history=prover_update,
-                )
             return tool_state_update(
-                tool_call_id=tool_call_id, content=content, prover_link=link,
-                prover_history=prover_update,
+                tool_call_id=tool_call_id, content="\n\n".join(parts), prover_link=link,
+                validations=prover_stamps, prover_history=prover_update,
             )
 
         if targets:

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -529,6 +529,41 @@ def setup_prover_config_in(
         ) as conf_path:
             yield (conf_path, config)
 
+def stuck_rule_nag(
+    status_pairs: list[tuple[RulePath, StatusCodes]],
+    prover_update: list[ProverHistoryItem],
+    state: StateWithSkips,
+) -> list[str]:
+    """Warn when a rule has repeated the identical failure across recent runs: append a NagMarker to
+    ``prover_update`` and return the reminder lines (empty when nothing is stuck). Shared by the
+    single-spec and per-buffer verify paths."""
+    stuck_rules = {
+        k: v for (k, v) in status_pairs
+        if v in ("TIMEOUT", "ERROR", "SANITY_FAILED") and k.rule not in state["rule_skips"]
+    }
+    known_tc_ids = {
+        l["id"] for msg in state["messages"] if isinstance(msg, AIMessage)
+        for l in msg.tool_calls if l["name"] == "verify_spec"
+    }
+    to_warn, seen_post_compaction_history = stuck_rule_warnings(
+        stuck_rules, state["prover_history"], known_tc_ids
+    )
+    if not to_warn:
+        return []
+    prover_update.append(NagMarker(sort="nag", nagged_rules=list(to_warn)))
+    reminders = [
+        "The following rule(s) have had identical failures on the last 3 runs of the prover:",
+        *(f"- {it.pprint()}" for it in to_warn),
+        "You may need to significantly change your approach, or skip the property if this is a persistent issue (you may need to use rebuttals to communicate"
+        " these failures to the feedback judge).",
+    ]
+    if seen_post_compaction_history:
+        reminders.append(
+            "(NB: Some of these prover calls happened before your most recent task history summarization)"
+        )
+    return reminders
+
+
 @contextmanager
 def materialize_buffers(
     working_dir: str, buffers: Mapping[str, NamedBuffer]
@@ -689,20 +724,6 @@ def get_prover_tool(
             if isinstance(result, str):
                 return result
 
-            stuck_rules = {
-                k: v for (k,v) in result.raw_rule_status.items() if v in ("TIMEOUT", "ERROR", "SANITY_FAILED") and k.rule not in state["rule_skips"]
-            }
-
-            known_tc_ids = {
-                l["id"]
-                for msg in state["messages"] if isinstance(msg, AIMessage)
-                for l in msg.tool_calls if l["name"] == "verify_spec"
-            }
-
-            to_warn, seen_post_compaction_history = stuck_rule_warnings(
-                stuck_rules, state["prover_history"], known_tc_ids
-            )
-
             curr_state_digest = spec_digest(
                 spec, state["skipped"], state["version_history"]
             )
@@ -729,24 +750,9 @@ def get_prover_tool(
                     state_digest=curr_state_digest
                 )
             ]
-            nag_channel = {
-
-            }
-            if len(to_warn) > 0:
-                prover_update.append(NagMarker(
-                    sort="nag",
-                    nagged_rules=list(to_warn)
-                ))
-                nag_channel["reminders_channel"] = [
-                    "The following rule(s) have had identical failures on the last 3 runs of the prover:",
-                    *(f"- {it.pprint()}" for it in to_warn),
-                    "You may need to significantly change your approach, or skip the property if this is a persistent issue (you may need to use rebuttals to communicate"
-                    " these failures to the feedback judge)."
-                ]
-                if seen_post_compaction_history:
-                    nag_channel["reminders_channel"].append(
-                        "(NB: Some of these prover calls happened before your most recent task history summarization)"
-                    )
+            nag_channel: dict = {}
+            if reminders := stuck_rule_nag(prover_results, prover_update, state):
+                nag_channel["reminders_channel"] = reminders
             if all_verified:
                 nag_channel.setdefault("reminders_channel", []).append(
                     "You have successfully verified over your prior prover run(s) that all rules verify. This task is completed."
@@ -862,9 +868,15 @@ def get_prover_tool(
                 ):
                     prover_stamps[f"prover:{b.name}"] = digest_of(b)
 
+            # Nag on rules stuck on repeated failures across all buffers' runs (shared with run_in).
+            all_status = [pair for results in fresh.values() for pair in results]
+            nag_channel: dict = {}
+            if reminders := stuck_rule_nag(all_status, prover_update, state):
+                nag_channel["reminders_channel"] = reminders
+
             return tool_state_update(
                 tool_call_id=tool_call_id, content="\n\n".join(parts), prover_link=link,
-                validations=prover_stamps, prover_history=prover_update,
+                validations=prover_stamps, prover_history=prover_update, **nag_channel,
             )
 
         if targets:

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -111,6 +111,28 @@ class RuleSelection(TypedDict):
     sort: Literal["exclude", "include"]
     selector: list[str]
 
+def _selection_of(rule: list[str] | None, exclude_rules: list[str] | None) -> RuleSelection | None:
+    """The ``RuleSelection`` a submit_buffer call asks for, or None to run the whole buffer."""
+    if rule is not None:
+        return RuleSelection(sort="include", selector=rule)
+    if exclude_rules is not None:
+        return RuleSelection(sort="exclude", selector=exclude_rules)
+    return None
+
+def _selection_key(sel: RuleSelection | None) -> str:
+    """A stable key distinguishing one buffer's rule selections, so striped runs (different subsets of
+    the same buffer at the same content) coexist as separate jobs instead of deduping each other. The
+    whole-buffer run keys to the empty string."""
+    if sel is None:
+        return ""
+    return f"{sel['sort']}:{','.join(sorted(sel['selector']))}"
+
+def _apply_selection(config: dict, selection: RuleSelection | None) -> None:
+    """Write a rule subset onto a prover conf: ``rule`` for an include selection, ``exclude_rule`` for
+    an exclude one; a None selection leaves the conf running every rule."""
+    if selection is not None:
+        config["rule" if selection["sort"] == "include" else "exclude_rule"] = list(selection["selector"])
+
 class ProverRunLog(TypedDict):
     tool_call_id: str
     prover_results: list[tuple[RulePath, StatusCodes]]
@@ -499,10 +521,7 @@ def setup_prover_config_in(
             config, main_contract=main_contract, verify_target=f"{main_contract}:{generated_path}"
         )
         config.update(config_extra)
-        if rule is not None:
-            config["rule"] = rule
-        if exclude_rule is not None:
-            config["exclude_rule"] = exclude_rule
+        _apply_selection(config, _selection_of(rule, exclude_rule))
         with temp_certora_file(
             root=working_dir,
             content=json.dumps(config, indent=2),
@@ -573,13 +592,16 @@ def buffer_conf(
     buffer_name: str,
     conf_dir: Path,
     msg: str,
+    selection: RuleSelection | None = None,
 ) -> Iterator[tuple[str, dict]]:
     """Build a conf verifying an already-materialized buffer spec at ``spec_path`` (its imports resolve
-    to the sibling ``.spec`` files written by :func:`materialize_buffers`). Yields (conf_path, config)."""
+    to the sibling ``.spec`` files written by :func:`materialize_buffers`). ``selection`` restricts the
+    run to a subset of the buffer's rules. Yields (conf_path, config)."""
     cfg = prover_config_overlay(
         config, main_contract=main_contract, verify_target=f"{main_contract}:{spec_path}"
     )
     cfg["msg"] = msg
+    _apply_selection(cfg, selection)
     with temp_certora_file(
         root=working_dir,
         content=json.dumps(cfg, indent=2),
@@ -599,8 +621,24 @@ class _SubmitBufferArgs(WithInjectedState[StateWithSkips], WithInjectedId):
     it), which is how you re-verify a buffer after editing it, or after editing a shared buffer it
     imports. A buffer already verified at its current content, or already running, is not re-launched.
     Retrieve outcomes with collect_results.
+
+    By default the job runs every rule of the buffer. To keep one expensive rule from holding up the
+    cheap ones, submit a subset with `rule` (or run the rest with `exclude_rules`): the subsets share
+    the buffer's one compiled spec, prove as separate parallel jobs, and their results combine — the
+    buffer is verified once every rule has been covered by some run at the current content. Use this to
+    isolate a rule by *cost*; use separate buffers to isolate rules by *precision* (differing summary
+    needs).
     """
     name: str = Field(description="The run-target buffer to submit for verification.")
+    rule: list[str] | None = Field(
+        default=None,
+        description="Run only these rules of the buffer (a subset of its own rules). Mutually exclusive "
+        "with `exclude_rules`; omit both to run the whole buffer.",
+    )
+    exclude_rules: list[str] | None = Field(
+        default=None,
+        description="Run every rule of the buffer except these. Mutually exclusive with `rule`.",
+    )
 
 
 class _CollectResultsArgs(WithInjectedState[StateWithSkips], WithInjectedId):
@@ -641,6 +679,9 @@ class _BufJob:
     #: so a job whose digest is now stale (its buffer or a shared import changed) can't mark it done.
     digest: str
     task: "asyncio.Task[None]"
+    #: The rule subset this job runs, or None for the whole buffer. Jobs of one buffer are keyed by
+    #: ``(name, _selection_key(selection))``, so striped runs at the same content coexist.
+    selection: RuleSelection | None = None
 
 
 @dataclass
@@ -652,6 +693,8 @@ class _BufDone:
     #: The prover report, or a compile/toolchain error message (str) that aborts only this buffer.
     result: ProverReport | str
     all_rules: list[str]
+    #: The rule subset this run covered, recorded onto the run's ``ProverRunLog.rules``.
+    selection: RuleSelection | None = None
 
 
 def get_prover_tool(
@@ -683,7 +726,9 @@ def get_prover_tool(
         # submit_buffer launches a background task per buffer and returns immediately; collect_results
         # drains finished jobs off the queue. At most one live job per buffer name — a re-submit supersedes
         # a stale predecessor. See submit_buffer / collect_results below.
-        buffer_jobs: dict[str, _BufJob] = {}
+        # Keyed by (buffer name, selection key): one buffer can have several concurrent jobs, one per
+        # rule subset it was striped into. A content edit supersedes every one of them (digest changes).
+        buffer_jobs: dict[tuple[str, str], _BufJob] = {}
         done_queue: asyncio.Queue[_BufDone] = asyncio.Queue()
         submit_counts: dict[str, int] = {}
         # Declarations already flagged as duplicated-across-buffers, so collect_results nags about each at
@@ -694,6 +739,7 @@ def get_prover_tool(
             *, name: str, digest: str, label: str, buffers: Mapping[str, NamedBuffer],
             vfs: dict[str, str], conf: dict, cex_state: StateWithSkips, tool_call_id: str,
             writer: Callable[[ProverEvents], None], summary: RunSummary,
+            selection: RuleSelection | None = None,
         ) -> None:
             """Verify one buffer end-to-end against a frozen snapshot (taken at submit time) of the source
             and all buffers, then push the outcome onto the completion queue. The job runs in its own
@@ -719,18 +765,19 @@ def get_prover_tool(
                         with buffer_conf(
                             working_dir=run_root, config=conf, main_contract=main_contract,
                             spec_path=spec_path, buffer_name=name, conf_dir=conf_dir, msg=label,
+                            selection=selection,
                         ) as (cpath, cfg):
                             res = await run_prover(
                                 Path(run_root), [cpath], tool_call_id, prover_opts,
                                 _SpecCallbacks(writer, tool_call_id, summary, cfg, analysis_store=analysis_store),
                                 DefaultCexHandler(llm, cex_state, summarization_threshold=10),
                             )
-                await done_queue.put(_BufDone(name, digest, res, all_rules))
+                await done_queue.put(_BufDone(name, digest, res, all_rules, selection))
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # a job crash must not sink silently — surface it on the queue
                 _logger.exception("buffer job %s crashed", name)
-                await done_queue.put(_BufDone(name, digest, f"[buffer {name}] job error: {exc}", []))
+                await done_queue.put(_BufDone(name, digest, f"[buffer {name}] job error: {exc}", [], selection))
 
         def _cur_digest(state: StateWithSkips, buffers: Mapping[str, NamedBuffer], name: str) -> str:
             skipped_pairs = [(str(s.property_title), str(s.reason)) for s in state["skipped"]]
@@ -761,29 +808,49 @@ def get_prover_tool(
             if not b.is_run_target:
                 return f"Buffer {name!r} is a shared (imports-only) buffer; it runs no rules of its own."
 
+            rule: list[str] | None = args.get("rule")
+            exclude_rules: list[str] | None = args.get("exclude_rules")
+            if rule is not None and exclude_rules is not None:
+                return "Pass at most one of `rule` / `exclude_rules`; omit both to run the whole buffer."
+            selection = _selection_of(rule, exclude_rules)
+            if selection is not None:
+                owned = b.owned_rules
+                unknown = [r for r in selection["selector"] if r not in owned]
+                if unknown:
+                    return f"Buffer {name!r} declares no rule(s) {unknown}; its rules are {sorted(owned)}."
+                would_run = selection["selector"] if selection["sort"] == "include" \
+                    else [r for r in owned if r not in set(selection["selector"])]
+                if not would_run:
+                    return f"That selection would run no rule of buffer {name!r}; its rules are {sorted(owned)}."
+
             digest = _cur_digest(state, buffers, name)
             if _buffer_complete_at(state, buffers, name, digest):
                 return f"Buffer {name!r} is already verified at its current content; nothing to submit."
 
-            existing = buffer_jobs.get(name)
+            sel_key = _selection_key(selection)
+            existing = buffer_jobs.get((name, sel_key))
             if existing is not None and existing.digest == digest:
-                # A job for this exact content is already in flight, or has just finished with its result
-                # not yet collected. Either way, do not launch a duplicate — the answer is (coming) on the
-                # queue; the agent should collect it, not re-run identical work.
+                # This exact subset at this exact content is already in flight, or has just finished with
+                # its result not yet collected. Either way, do not launch a duplicate — the answer is
+                # (coming) on the queue; the agent should collect it, not re-run identical work.
                 proving = "is still proving" if not existing.task.done() else "has already finished"
                 return (
                     f"Buffer {name!r} was already submitted at its current content and {proving}; do not "
                     f"re-submit it. Call collect_results to take its result — if this is your only "
                     f"remaining buffer/task and you are just waiting on it, use collect_results(wait=true)."
                 )
-            if existing is not None and not existing.task.done():
-                existing.task.cancel()  # buffer (or a shared import) changed: supersede the stale job
+            # A content edit supersedes every subset job of this buffer (all now at a stale digest); the
+            # sibling subsets at the *current* digest are the parallel stripes and stay running.
+            for (nm, sk), j in list(buffer_jobs.items()):
+                if nm == name and j.digest != digest and not j.task.done():
+                    j.task.cancel()
+                    buffer_jobs.pop((nm, sk), None)
 
             n = submit_counts.get(name, 0) + 1
             submit_counts[name] = n
             component = component_of(state)
             task = asyncio.create_task(_run_buffer_job(
-                name=name, digest=digest,
+                name=name, digest=digest, selection=selection,
                 label=f"{component}/{name} submission {n}",
                 buffers=dict(buffers), vfs=dict(state.get("vfs") or {}), conf=state["config"],
                 cex_state=state, tool_call_id=tool_call_id,
@@ -792,11 +859,14 @@ def get_prover_tool(
                 # progress can render loosely in the UI (functional results are unaffected).
                 writer=get_stream_writer(), summary=get_run_summary(),
             ))
-            buffer_jobs[name] = _BufJob(name=name, digest=digest, task=task)
-            running = sorted(nm for nm, j in buffer_jobs.items() if not j.task.done())
+            buffer_jobs[(name, sel_key)] = _BufJob(name=name, digest=digest, task=task, selection=selection)
+            running = sorted({nm for (nm, _sk), j in buffer_jobs.items() if not j.task.done()})
+            sel_desc = "" if selection is None else (
+                f" (rules {selection['selector']})" if selection["sort"] == "include"
+                else f" (excluding {selection['selector']})")
             return (
-                f"Submitted buffer {name!r} (submission {n}); it is now proving in the background. "
-                f"Running: {running}. Call collect_results to retrieve results as jobs finish."
+                f"Submitted buffer {name!r}{sel_desc} (submission {n}); it is now proving in the "
+                f"background. Running: {running}. Call collect_results to retrieve results as jobs finish."
             )
 
         @tool_display("Collecting prover results", None)
@@ -832,15 +902,15 @@ def get_prover_tool(
             # Cancel jobs left running against a now-stale digest: a shared buffer they import was edited, so
             # their result would be discarded anyway — and on local runs a doomed job needlessly holds the
             # single prover slot. The agent re-submits them (they show under needs-(re)submission below).
-            for nm, j in list(buffer_jobs.items()):
-                if not j.task.done() and nm in buffers and j.digest != cur_digest(nm):
+            for key, j in list(buffer_jobs.items()):
+                if not j.task.done() and j.name in buffers and j.digest != cur_digest(j.name):
                     j.task.cancel()
-                    buffer_jobs.pop(nm, None)
+                    buffer_jobs.pop(key, None)
 
             # Retire finished jobs from the registry. A result that lands between the drain and here stays on
             # the queue, so its buffer is picked up on the next collect even though its job is already gone.
-            for nm in [nm for nm, j in buffer_jobs.items() if j.task.done()]:
-                buffer_jobs.pop(nm, None)
+            for key in [key for key, j in buffer_jobs.items() if j.task.done()]:
+                buffer_jobs.pop(key, None)
 
             prover_update: list[ProverHistoryItem] = []
             fresh: dict[str, list[tuple[RulePath, StatusCodes]]] = {}
@@ -851,14 +921,14 @@ def get_prover_tool(
                     parts.append(f"=== buffer {d.name} ===\n{d.result}")
                     continue
                 results: list[tuple[RulePath, StatusCodes]] = list(d.result.raw_rule_status.items())
-                fresh[d.name] = results
+                fresh.setdefault(d.name, []).extend(results)  # striped subsets of one buffer accumulate
                 link = d.result.link or link
                 stale = d.name in buffers and d.digest != cur_digest(d.name)
                 note = (" (NOTE: the spec changed since this was submitted — this result is STALE; re-submit "
                         "this buffer.)") if stale else ""
                 parts.append(f"=== buffer {d.name} ==={note}\n{d.result.result_str}")
                 prover_update.append(ProverRunLog(
-                    tool_call_id=tool_call_id, prover_results=results, rules=None,
+                    tool_call_id=tool_call_id, prover_results=results, rules=d.selection,
                     spec_digest=string_hash(buffers[d.name].cvl) if d.name in buffers else "",
                     sort="run", declared_rules=d.all_rules, state_digest=d.digest, buffer=d.name,
                 ))
@@ -877,8 +947,8 @@ def get_prover_tool(
             # under needs-(re)submission until the agent relaunches it.
             complete = {b.name for b in targets if f"prover:{b.name}" in prover_stamps}
             running = {
-                nm for nm, j in buffer_jobs.items()
-                if not j.task.done() and nm in buffers and j.digest == cur_digest(nm)
+                j.name for j in buffer_jobs.values()
+                if not j.task.done() and j.name in buffers and j.digest == cur_digest(j.name)
             }
             needs_submit = [b.name for b in targets if b.name not in complete and b.name not in running]
             board = [

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -620,10 +620,12 @@ sleeps until the next job finishes.
 
 @dataclass
 class ProverToolset:
-    """The prover-side agent tools: ``buffer_tools`` (``submit_buffer`` / ``collect_results``), which
-    submit per-buffer jobs asynchronously and consume results as they finish."""
+    """The prover-side agent tools. ``make_buffer_tools`` mints a fresh ``[submit_buffer,
+    collect_results]`` pair that submit per-buffer jobs asynchronously and consume results as they
+    finish; each pair owns its in-flight job state (queue, job table, submit counts, reported
+    dupes)."""
 
-    buffer_tools: list[BaseTool]
+    make_buffer_tools: Callable[[], list[BaseTool]]
 
 
 @dataclass
@@ -660,17 +662,6 @@ def get_prover_tool(
     sem = _prover_sem(prover_opts.cloud)
     stamper = make_validation_stamper(VALIDATION_KEY)
 
-    # Multi-buffer async job state, held in the closure (not graph state) so it spans agent turns:
-    # submit_buffer launches a background task per buffer and returns immediately; collect_results
-    # drains finished jobs off the queue. At most one live job per buffer name — a re-submit supersedes
-    # a stale predecessor. See submit_buffer / collect_results below.
-    buffer_jobs: dict[str, _BufJob] = {}
-    done_queue: asyncio.Queue[_BufDone] = asyncio.Queue()
-    submit_counts: dict[str, int] = {}
-    # Declarations already flagged as duplicated-across-buffers, so collect_results nags about each at
-    # most once per run (advisory only — the agent may hoist them to a shared buffer or ignore).
-    reported_dupes: set[str] = set()
-
     def component_of(state: StateWithSkips) -> str:
         """The label prefix for this generation's prover runs: its seeded spec stem, or the main
         contract, with the ``autospec_`` prefix stripped."""
@@ -681,239 +672,257 @@ def get_prover_tool(
     # as they finish, so a fast group is reviewed while a slow group is still proving. A shared-buffer
     # edit re-verifying every importer rides the content digest.
 
-    async def _run_buffer_job(
-        *, name: str, digest: str, tag: str, label: str, buffers: Mapping[str, NamedBuffer],
-        vfs: dict[str, str], conf: dict, cex_state: StateWithSkips, tool_call_id: str,
-        writer: Callable[[ProverEvents], None], summary: RunSummary,
-    ) -> None:
-        """Verify one buffer end-to-end against a frozen snapshot (taken at submit time) of the source
-        and all buffers, then push the outcome onto the completion queue. The per-submission ``tag``
-        isolates this job's spec/conf files, so editing + re-submitting a shared buffer (or a concurrent
-        sibling job) can never mutate the files this job is reading. Cancellation (a supersede) propagates
-        as CancelledError and pushes nothing — the superseded result is simply dropped."""
-        conf_dir = CERTORA_DIR / "confs"
-        stem = f"{name}__{tag}"
-        try:
-            async with sem, project_directory(vfs) as run_root:
-                with materialize_buffers(run_root, buffers, tag) as paths:
-                    spec_path = paths[name]
-                    with buffer_conf(
-                        working_dir=run_root, config=conf, main_contract=main_contract,
-                        spec_path=spec_path, buffer_name=stem, conf_dir=conf_dir, msg="",
-                    ) as (cpath, _cfg):
-                        try:
-                            all_rules = await declared_rules_list(folder=Path(run_root), args=[cpath])
-                        except SpecCompilationError as exc:
-                            await done_queue.put(_BufDone(
-                                name, digest, f"[buffer {name}] failed to compile:\n{exc.output}", [],
-                            ))
-                            return
-                    with buffer_conf(
-                        working_dir=run_root, config=conf, main_contract=main_contract,
-                        spec_path=spec_path, buffer_name=stem, conf_dir=conf_dir, msg=label,
-                    ) as (cpath, cfg):
-                        res = await run_prover(
-                            Path(run_root), [cpath], tool_call_id, prover_opts,
-                            _SpecCallbacks(writer, tool_call_id, summary, cfg, analysis_store=analysis_store),
-                            DefaultCexHandler(llm, cex_state, summarization_threshold=10),
-                        )
-            await done_queue.put(_BufDone(name, digest, res, all_rules))
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:  # a job crash must not sink silently — surface it on the queue
-            _logger.exception("buffer job %s crashed", name)
-            await done_queue.put(_BufDone(name, digest, f"[buffer {name}] job error: {exc}", []))
+    def make_buffer_tools() -> list[BaseTool]:
+        """Mint a fresh ``[submit_buffer, collect_results]`` pair with its own in-flight job state:
+        a new queue, job table, submit counts, and reported-dupe set per call, so separate pairs
+        never drain or suppress each other's jobs. The prover semaphore and the other deps stay
+        shared from the enclosing scope."""
+        # Multi-buffer async job state, held in the closure (not graph state) so it spans agent turns:
+        # submit_buffer launches a background task per buffer and returns immediately; collect_results
+        # drains finished jobs off the queue. At most one live job per buffer name — a re-submit supersedes
+        # a stale predecessor. See submit_buffer / collect_results below.
+        buffer_jobs: dict[str, _BufJob] = {}
+        done_queue: asyncio.Queue[_BufDone] = asyncio.Queue()
+        submit_counts: dict[str, int] = {}
+        # Declarations already flagged as duplicated-across-buffers, so collect_results nags about each at
+        # most once per run (advisory only — the agent may hoist them to a shared buffer or ignore).
+        reported_dupes: set[str] = set()
 
-    def _cur_digest(state: StateWithSkips, buffers: Mapping[str, NamedBuffer], name: str) -> str:
-        skipped_pairs = [(str(s.property_title), str(s.reason)) for s in state["skipped"]]
-        return buffer_state_digest(
-            buffers, name, skipped=skipped_pairs, version_history=state["version_history"],
-        )
+        async def _run_buffer_job(
+            *, name: str, digest: str, tag: str, label: str, buffers: Mapping[str, NamedBuffer],
+            vfs: dict[str, str], conf: dict, cex_state: StateWithSkips, tool_call_id: str,
+            writer: Callable[[ProverEvents], None], summary: RunSummary,
+        ) -> None:
+            """Verify one buffer end-to-end against a frozen snapshot (taken at submit time) of the source
+            and all buffers, then push the outcome onto the completion queue. The per-submission ``tag``
+            isolates this job's spec/conf files, so editing + re-submitting a shared buffer (or a concurrent
+            sibling job) can never mutate the files this job is reading. Cancellation (a supersede) propagates
+            as CancelledError and pushes nothing — the superseded result is simply dropped."""
+            conf_dir = CERTORA_DIR / "confs"
+            stem = f"{name}__{tag}"
+            try:
+                async with sem, project_directory(vfs) as run_root:
+                    with materialize_buffers(run_root, buffers, tag) as paths:
+                        spec_path = paths[name]
+                        with buffer_conf(
+                            working_dir=run_root, config=conf, main_contract=main_contract,
+                            spec_path=spec_path, buffer_name=stem, conf_dir=conf_dir, msg="",
+                        ) as (cpath, _cfg):
+                            try:
+                                all_rules = await declared_rules_list(folder=Path(run_root), args=[cpath])
+                            except SpecCompilationError as exc:
+                                await done_queue.put(_BufDone(
+                                    name, digest, f"[buffer {name}] failed to compile:\n{exc.output}", [],
+                                ))
+                                return
+                        with buffer_conf(
+                            working_dir=run_root, config=conf, main_contract=main_contract,
+                            spec_path=spec_path, buffer_name=stem, conf_dir=conf_dir, msg=label,
+                        ) as (cpath, cfg):
+                            res = await run_prover(
+                                Path(run_root), [cpath], tool_call_id, prover_opts,
+                                _SpecCallbacks(writer, tool_call_id, summary, cfg, analysis_store=analysis_store),
+                                DefaultCexHandler(llm, cex_state, summarization_threshold=10),
+                            )
+                await done_queue.put(_BufDone(name, digest, res, all_rules))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # a job crash must not sink silently — surface it on the queue
+                _logger.exception("buffer job %s crashed", name)
+                await done_queue.put(_BufDone(name, digest, f"[buffer {name}] job error: {exc}", []))
 
-    def _buffer_complete_at(
-        state: StateWithSkips, buffers: Mapping[str, NamedBuffer], name: str, digest: str,
-        *, extra_history: Sequence[ProverHistoryItem] = (),
-    ) -> bool:
-        return buffer_is_complete(
-            list(state["prover_history"]) + list(extra_history), buffer=name, curr_digest=digest,
-            expected_to_fail=set(state["rule_skips"].keys()), curr_status=[],
-            all_rules=list(buffers[name].owned_rules),
-        )
-
-    submit_schema = create_model(
-        "SubmitBuffer", __doc__=_SUBMIT_BUFFER_DESCRIPTION,
-        name=(str, Field(description="The run-target buffer to submit for verification.")),
-        state=(Annotated[StateWithSkips, InjectedState], ...),
-        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
-    )
-
-    @tool_display("Submitting buffer", None)
-    @tool(args_schema=submit_schema)
-    async def submit_buffer(**args) -> str | Command:
-        state: StateWithSkips = args["state"]
-        name: str = args["name"]
-        tool_call_id: str = args["tool_call_id"]
-        buffers = state.get("buffers") or {}
-        b = buffers.get(name)
-        if b is None:
-            return f"No buffer named {name!r}. Create it with put_buffer first."
-        if not b.is_run_target:
-            return f"Buffer {name!r} is a shared (imports-only) buffer; it runs no rules of its own."
-
-        digest = _cur_digest(state, buffers, name)
-        if _buffer_complete_at(state, buffers, name, digest):
-            return f"Buffer {name!r} is already verified at its current content; nothing to submit."
-
-        existing = buffer_jobs.get(name)
-        if existing is not None and not existing.task.done():
-            if existing.digest == digest:
-                return f"Buffer {name!r} is already running. Use collect_results to retrieve its result."
-            existing.task.cancel()  # buffer (or a shared import) changed: supersede the stale job
-
-        n = submit_counts.get(name, 0) + 1
-        submit_counts[name] = n
-        component = component_of(state)
-        task = asyncio.create_task(_run_buffer_job(
-            name=name, digest=digest, tag=f"{digest[:8]}_{n}",
-            label=f"{component}/{name} submission {n}",
-            buffers=dict(buffers), vfs=dict(state.get("vfs") or {}), conf=state["config"],
-            cex_state=state, tool_call_id=tool_call_id,
-            # The stream writer is captured here and used by the detached task: its prover-progress
-            # events carry this submit call's tool_call_id, which has already returned, so background-job
-            # progress can render loosely in the UI (functional results are unaffected).
-            writer=get_stream_writer(), summary=get_run_summary(),
-        ))
-        buffer_jobs[name] = _BufJob(name=name, digest=digest, task=task)
-        running = sorted(nm for nm, j in buffer_jobs.items() if not j.task.done())
-        return (
-            f"Submitted buffer {name!r} (submission {n}); it is now proving in the background. "
-            f"Running: {running}. Call collect_results to retrieve results as jobs finish."
-        )
-
-    collect_schema = create_model(
-        "CollectResults", __doc__=_COLLECT_RESULTS_DESCRIPTION,
-        wait=(bool, Field(
-            default=False,
-            description="Block until the next job finishes. Set true ONLY when you have no other work: "
-            "every buffer is submitted and running and you have no finished result left to process. "
-            "Leave false to take whatever has finished so far without waiting.",
-        )),
-        state=(Annotated[StateWithSkips, InjectedState], ...),
-        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
-    )
-
-    @tool_display("Collecting prover results", None)
-    @tool(args_schema=collect_schema)
-    async def collect_results(**args) -> str | Command:
-        state: StateWithSkips = args["state"]
-        tool_call_id: str = args["tool_call_id"]
-        wait: bool = args["wait"]
-        buffers = state.get("buffers") or {}
-        targets = run_targets(buffers)
-        if not targets:
-            return "No run-target buffers to collect. Author buffers and submit_buffer them first."
-
-        # Current digest per buffer is stable within this call (buffers/skips/edit-history are fixed);
-        # memoize it — each is a content hash over the import closure, read at several points below.
-        _digests: dict[str, str] = {}
-        def cur_digest(nm: str) -> str:
-            if nm not in _digests:
-                _digests[nm] = _cur_digest(state, buffers, nm)
-            return _digests[nm]
-
-        drained: list[_BufDone] = []
-        while not done_queue.empty():
-            drained.append(done_queue.get_nowait())
-        if not drained and wait and any(not j.task.done() for j in buffer_jobs.values()):
-            # Idle wait: nothing else to do, sleep until one job finishes. Unbounded, but every job is
-            # guaranteed to land on the queue — run_prover self-bounds its subprocess, and a crash is
-            # caught and enqueued as an error — so this can't hang on a wedged job.
-            drained.append(await done_queue.get())
-            while not done_queue.empty():
-                drained.append(done_queue.get_nowait())
-
-        # Cancel jobs left running against a now-stale digest: a shared buffer they import was edited, so
-        # their result would be discarded anyway — and on local runs a doomed job needlessly holds the
-        # single prover slot. The agent re-submits them (they show under needs-(re)submission below).
-        for nm, j in list(buffer_jobs.items()):
-            if not j.task.done() and nm in buffers and j.digest != cur_digest(nm):
-                j.task.cancel()
-                buffer_jobs.pop(nm, None)
-
-        # Retire finished jobs from the registry. A result that lands between the drain and here stays on
-        # the queue, so its buffer is picked up on the next collect even though its job is already gone.
-        for nm in [nm for nm, j in buffer_jobs.items() if j.task.done()]:
-            buffer_jobs.pop(nm, None)
-
-        prover_update: list[ProverHistoryItem] = []
-        fresh: dict[str, list[tuple[RulePath, StatusCodes]]] = {}
-        link: str | None = None
-        parts: list[str] = []
-        for d in drained:
-            if isinstance(d.result, str):  # compile/toolchain error: surface it, record no run
-                parts.append(f"=== buffer {d.name} ===\n{d.result}")
-                continue
-            results: list[tuple[RulePath, StatusCodes]] = list(d.result.raw_rule_status.items())
-            fresh[d.name] = results
-            link = d.result.link or link
-            stale = d.name in buffers and d.digest != cur_digest(d.name)
-            note = (" (NOTE: the spec changed since this was submitted — this result is STALE; re-submit "
-                    "this buffer.)") if stale else ""
-            parts.append(f"=== buffer {d.name} ==={note}\n{d.result.result_str}")
-            prover_update.append(ProverRunLog(
-                tool_call_id=tool_call_id, prover_results=results, rules=None,
-                spec_digest=string_hash(buffers[d.name].cvl) if d.name in buffers else "",
-                sort="run", declared_rules=d.all_rules, state_digest=d.digest, buffer=d.name,
-            ))
-
-        # Per-buffer completion is re-evaluated over history + this drain against the CURRENT digest, so
-        # a stale run (state_digest mismatch) never credits completion. Overall completion is the AND of
-        # these, checked at publish (check_buffer_completion).
-        prover_stamps: dict[str, str] = {}
-        for b in targets:
-            d = cur_digest(b.name)
-            if _buffer_complete_at(state, buffers, b.name, d, extra_history=prover_update):
-                prover_stamps[f"prover:{b.name}"] = d
-
-        # Status board — the agent's work-list. `running` counts only a live job at the CURRENT digest;
-        # a job left running at a stale digest (its shared import changed) is doomed, so its buffer falls
-        # under needs-(re)submission until the agent relaunches it.
-        complete = {b.name for b in targets if f"prover:{b.name}" in prover_stamps}
-        running = {
-            nm for nm, j in buffer_jobs.items()
-            if not j.task.done() and nm in buffers and j.digest == cur_digest(nm)
-        }
-        needs_submit = [b.name for b in targets if b.name not in complete and b.name not in running]
-        board = [
-            "",
-            f"[buffers] complete: {sorted(complete)}",
-            f"[buffers] running: {sorted(running)}",
-            f"[buffers] needs (re)submission: {sorted(needs_submit)}",
-        ]
-        # Advisory: flag declarations duplicated verbatim across run-target buffers (once each) — likely
-        # belong in a shared buffer the duplicating buffers import.
-        fresh_dupes = {d: ns for d, ns in duplicated_declarations(buffers).items() if d not in reported_dupes}
-        if fresh_dupes:
-            reported_dupes.update(fresh_dupes)
-            board.append("[buffers] NOTE: these declarations are duplicated across run-target buffers — "
-                         "consider moving each to a shared buffer the duplicating buffers import:")
-            board.extend(f"  {d}  (in {ns})" for d, ns in fresh_dupes.items())
-        if not drained:
-            parts.append("No finished jobs yet." if running else "No finished jobs and nothing running.")
-
-        nag_channel: dict = {}
-        all_status = [pair for results in fresh.values() for pair in results]
-        if reminders := stuck_rule_nag(all_status, prover_update, state):
-            nag_channel["reminders_channel"] = reminders
-        if not needs_submit and not running:
-            nag_channel.setdefault("reminders_channel", []).append(
-                "Every run-target buffer is verified at its current content. Once each also has "
-                "feedback, you can publish."
+        def _cur_digest(state: StateWithSkips, buffers: Mapping[str, NamedBuffer], name: str) -> str:
+            skipped_pairs = [(str(s.property_title), str(s.reason)) for s in state["skipped"]]
+            return buffer_state_digest(
+                buffers, name, skipped=skipped_pairs, version_history=state["version_history"],
             )
 
-        return tool_state_update(
-            tool_call_id=tool_call_id, content="\n".join(parts + board), prover_link=link,
-            validations=prover_stamps, prover_history=prover_update, **nag_channel,
+        def _buffer_complete_at(
+            state: StateWithSkips, buffers: Mapping[str, NamedBuffer], name: str, digest: str,
+            *, extra_history: Sequence[ProverHistoryItem] = (),
+        ) -> bool:
+            return buffer_is_complete(
+                list(state["prover_history"]) + list(extra_history), buffer=name, curr_digest=digest,
+                expected_to_fail=set(state["rule_skips"].keys()), curr_status=[],
+                all_rules=list(buffers[name].owned_rules),
+            )
+
+        submit_schema = create_model(
+            "SubmitBuffer", __doc__=_SUBMIT_BUFFER_DESCRIPTION,
+            name=(str, Field(description="The run-target buffer to submit for verification.")),
+            state=(Annotated[StateWithSkips, InjectedState], ...),
+            tool_call_id=(Annotated[str, InjectedToolCallId], ...),
         )
 
-    return ProverToolset(buffer_tools=[submit_buffer, collect_results])
+        @tool_display("Submitting buffer", None)
+        @tool(args_schema=submit_schema)
+        async def submit_buffer(**args) -> str | Command:
+            state: StateWithSkips = args["state"]
+            name: str = args["name"]
+            tool_call_id: str = args["tool_call_id"]
+            buffers = state.get("buffers") or {}
+            b = buffers.get(name)
+            if b is None:
+                return f"No buffer named {name!r}. Create it with put_buffer first."
+            if not b.is_run_target:
+                return f"Buffer {name!r} is a shared (imports-only) buffer; it runs no rules of its own."
+
+            digest = _cur_digest(state, buffers, name)
+            if _buffer_complete_at(state, buffers, name, digest):
+                return f"Buffer {name!r} is already verified at its current content; nothing to submit."
+
+            existing = buffer_jobs.get(name)
+            if existing is not None and not existing.task.done():
+                if existing.digest == digest:
+                    return f"Buffer {name!r} is already running. Use collect_results to retrieve its result."
+                existing.task.cancel()  # buffer (or a shared import) changed: supersede the stale job
+
+            n = submit_counts.get(name, 0) + 1
+            submit_counts[name] = n
+            component = component_of(state)
+            task = asyncio.create_task(_run_buffer_job(
+                name=name, digest=digest, tag=f"{digest[:8]}_{n}",
+                label=f"{component}/{name} submission {n}",
+                buffers=dict(buffers), vfs=dict(state.get("vfs") or {}), conf=state["config"],
+                cex_state=state, tool_call_id=tool_call_id,
+                # The stream writer is captured here and used by the detached task: its prover-progress
+                # events carry this submit call's tool_call_id, which has already returned, so background-job
+                # progress can render loosely in the UI (functional results are unaffected).
+                writer=get_stream_writer(), summary=get_run_summary(),
+            ))
+            buffer_jobs[name] = _BufJob(name=name, digest=digest, task=task)
+            running = sorted(nm for nm, j in buffer_jobs.items() if not j.task.done())
+            return (
+                f"Submitted buffer {name!r} (submission {n}); it is now proving in the background. "
+                f"Running: {running}. Call collect_results to retrieve results as jobs finish."
+            )
+
+        collect_schema = create_model(
+            "CollectResults", __doc__=_COLLECT_RESULTS_DESCRIPTION,
+            wait=(bool, Field(
+                default=False,
+                description="Block until the next job finishes. Set true ONLY when you have no other work: "
+                "every buffer is submitted and running and you have no finished result left to process. "
+                "Leave false to take whatever has finished so far without waiting.",
+            )),
+            state=(Annotated[StateWithSkips, InjectedState], ...),
+            tool_call_id=(Annotated[str, InjectedToolCallId], ...),
+        )
+
+        @tool_display("Collecting prover results", None)
+        @tool(args_schema=collect_schema)
+        async def collect_results(**args) -> str | Command:
+            state: StateWithSkips = args["state"]
+            tool_call_id: str = args["tool_call_id"]
+            wait: bool = args["wait"]
+            buffers = state.get("buffers") or {}
+            targets = run_targets(buffers)
+            if not targets:
+                return "No run-target buffers to collect. Author buffers and submit_buffer them first."
+
+            # Current digest per buffer is stable within this call (buffers/skips/edit-history are fixed);
+            # memoize it — each is a content hash over the import closure, read at several points below.
+            _digests: dict[str, str] = {}
+            def cur_digest(nm: str) -> str:
+                if nm not in _digests:
+                    _digests[nm] = _cur_digest(state, buffers, nm)
+                return _digests[nm]
+
+            drained: list[_BufDone] = []
+            while not done_queue.empty():
+                drained.append(done_queue.get_nowait())
+            if not drained and wait and any(not j.task.done() for j in buffer_jobs.values()):
+                # Idle wait: nothing else to do, sleep until one job finishes. Unbounded, but every job is
+                # guaranteed to land on the queue — run_prover self-bounds its subprocess, and a crash is
+                # caught and enqueued as an error — so this can't hang on a wedged job.
+                drained.append(await done_queue.get())
+                while not done_queue.empty():
+                    drained.append(done_queue.get_nowait())
+
+            # Cancel jobs left running against a now-stale digest: a shared buffer they import was edited, so
+            # their result would be discarded anyway — and on local runs a doomed job needlessly holds the
+            # single prover slot. The agent re-submits them (they show under needs-(re)submission below).
+            for nm, j in list(buffer_jobs.items()):
+                if not j.task.done() and nm in buffers and j.digest != cur_digest(nm):
+                    j.task.cancel()
+                    buffer_jobs.pop(nm, None)
+
+            # Retire finished jobs from the registry. A result that lands between the drain and here stays on
+            # the queue, so its buffer is picked up on the next collect even though its job is already gone.
+            for nm in [nm for nm, j in buffer_jobs.items() if j.task.done()]:
+                buffer_jobs.pop(nm, None)
+
+            prover_update: list[ProverHistoryItem] = []
+            fresh: dict[str, list[tuple[RulePath, StatusCodes]]] = {}
+            link: str | None = None
+            parts: list[str] = []
+            for d in drained:
+                if isinstance(d.result, str):  # compile/toolchain error: surface it, record no run
+                    parts.append(f"=== buffer {d.name} ===\n{d.result}")
+                    continue
+                results: list[tuple[RulePath, StatusCodes]] = list(d.result.raw_rule_status.items())
+                fresh[d.name] = results
+                link = d.result.link or link
+                stale = d.name in buffers and d.digest != cur_digest(d.name)
+                note = (" (NOTE: the spec changed since this was submitted — this result is STALE; re-submit "
+                        "this buffer.)") if stale else ""
+                parts.append(f"=== buffer {d.name} ==={note}\n{d.result.result_str}")
+                prover_update.append(ProverRunLog(
+                    tool_call_id=tool_call_id, prover_results=results, rules=None,
+                    spec_digest=string_hash(buffers[d.name].cvl) if d.name in buffers else "",
+                    sort="run", declared_rules=d.all_rules, state_digest=d.digest, buffer=d.name,
+                ))
+
+            # Per-buffer completion is re-evaluated over history + this drain against the CURRENT digest, so
+            # a stale run (state_digest mismatch) never credits completion. Overall completion is the AND of
+            # these, checked at publish (check_buffer_completion).
+            prover_stamps: dict[str, str] = {}
+            for b in targets:
+                d = cur_digest(b.name)
+                if _buffer_complete_at(state, buffers, b.name, d, extra_history=prover_update):
+                    prover_stamps[f"prover:{b.name}"] = d
+
+            # Status board — the agent's work-list. `running` counts only a live job at the CURRENT digest;
+            # a job left running at a stale digest (its shared import changed) is doomed, so its buffer falls
+            # under needs-(re)submission until the agent relaunches it.
+            complete = {b.name for b in targets if f"prover:{b.name}" in prover_stamps}
+            running = {
+                nm for nm, j in buffer_jobs.items()
+                if not j.task.done() and nm in buffers and j.digest == cur_digest(nm)
+            }
+            needs_submit = [b.name for b in targets if b.name not in complete and b.name not in running]
+            board = [
+                "",
+                f"[buffers] complete: {sorted(complete)}",
+                f"[buffers] running: {sorted(running)}",
+                f"[buffers] needs (re)submission: {sorted(needs_submit)}",
+            ]
+            # Advisory: flag declarations duplicated verbatim across run-target buffers (once each) — likely
+            # belong in a shared buffer the duplicating buffers import.
+            fresh_dupes = {d: ns for d, ns in duplicated_declarations(buffers).items() if d not in reported_dupes}
+            if fresh_dupes:
+                reported_dupes.update(fresh_dupes)
+                board.append("[buffers] NOTE: these declarations are duplicated across run-target buffers — "
+                             "consider moving each to a shared buffer the duplicating buffers import:")
+                board.extend(f"  {d}  (in {ns})" for d, ns in fresh_dupes.items())
+            if not drained:
+                parts.append("No finished jobs yet." if running else "No finished jobs and nothing running.")
+
+            nag_channel: dict = {}
+            all_status = [pair for results in fresh.values() for pair in results]
+            if reminders := stuck_rule_nag(all_status, prover_update, state):
+                nag_channel["reminders_channel"] = reminders
+            if not needs_submit and not running:
+                nag_channel.setdefault("reminders_channel", []).append(
+                    "Every run-target buffer is verified at its current content. Once each also has "
+                    "feedback, you can publish."
+                )
+
+            return tool_state_update(
+                tool_call_id=tool_call_id, content="\n".join(parts + board), prover_link=link,
+                validations=prover_stamps, prover_history=prover_update, **nag_channel,
+            )
+
+        return [submit_buffer, collect_results]
+
+    return ProverToolset(make_buffer_tools=make_buffer_tools)

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -446,19 +446,14 @@ def in_situ_project(project_root: str) -> ProjectDirectory:
     return provide
 
 
-def materializing_project(
-    project_root: str, accessor: VFSAccessor[VFSState]
-) -> ProjectDirectory:
-    """The editing strategy: an empty VFS runs in-situ; a non-empty VFS is
-    materialized over the project into a temporary directory that lives for
-    the duration of the run. The copy (and the teardown) run in a worker
-    thread — materializing a whole project is blocking IO that would
-    otherwise stall every concurrently-streaming batch."""
+def materializing_project(accessor: VFSAccessor[VFSState]) -> ProjectDirectory:
+    """Materialize the project — the author's VFS overlay unioned over the base source tree — into a
+    fresh temporary directory that lives for the duration of the run, so every run is the sole tenant
+    of its own folder and concurrent runs never share on-disk scratch. The copy (and the teardown) run
+    in a worker thread — materializing a whole project is blocking IO that would otherwise stall every
+    concurrently-streaming batch."""
     @asynccontextmanager
     async def provide(vfs: dict[str, str]) -> AsyncIterator[str]:
-        if not vfs:
-            yield project_root
-            return
         stack = ExitStack()
         tmp = await asyncio.to_thread(
             stack.enter_context, accessor.materialize({"vfs": vfs})
@@ -540,33 +535,17 @@ def stuck_rule_nag(
     return reminders
 
 
-def _retarget_buffer_imports(cvl: str, names: Iterable[str], tag: str) -> str:
-    """Rewrite each sibling-buffer import ``"<name>.spec"`` to its tagged filename ``"<name>__<tag>.spec"``
-    so a tagged materialization stays self-consistent. Resource imports (e.g. ``"summaries/foo.spec"``)
-    are different quoted strings and are left untouched, so they still resolve within the specs dir."""
-    out = cvl
-    for n in names:
-        out = out.replace(f'"{n}.spec"', f'"{n}__{tag}.spec"')
-    return out
-
-
 @contextmanager
 def materialize_buffers(
-    working_dir: str, buffers: Mapping[str, NamedBuffer], tag: str
+    working_dir: str, buffers: Mapping[str, NamedBuffer]
 ) -> Iterator[dict[str, str]]:
-    """Write every buffer as ``{name}__{tag}.spec`` into the specs dir (all at once, so any buffer's
-    ``import "<sibling>.spec"`` — retargeted to the tagged name — resolves), and yield ``name -> on-disk
-    spec path``; every file is removed on exit. The ``tag`` (unique per submission) isolates concurrent
-    jobs that share one run-root: on the in-situ path the run-root is the shared project directory, so
-    two jobs writing the deterministic ``{name}.spec`` would clobber each other and race on cleanup."""
-    names = list(buffers)
+    """Write every buffer as ``{name}.spec`` into the specs dir (all at once, so any buffer's
+    ``import "<sibling>.spec"`` resolves to its sibling), and yield ``name -> on-disk spec path``;
+    every file is removed on exit. The run owns its materialized project folder, so the deterministic
+    filenames never collide with a concurrent job's."""
     with ExitStack() as stack:
         yield {
-            name: stack.enter_context(tmp_spec(
-                root=working_dir,
-                content=_retarget_buffer_imports(buf.cvl, names, tag),
-                name=f"{name}__{tag}",
-            ))
+            name: stack.enter_context(tmp_spec(root=working_dir, content=buf.cvl, name=name))
             for name, buf in buffers.items()
         }
 
@@ -689,24 +668,23 @@ def get_prover_tool(
         reported_dupes: set[str] = set()
 
         async def _run_buffer_job(
-            *, name: str, digest: str, tag: str, label: str, buffers: Mapping[str, NamedBuffer],
+            *, name: str, digest: str, label: str, buffers: Mapping[str, NamedBuffer],
             vfs: dict[str, str], conf: dict, cex_state: StateWithSkips, tool_call_id: str,
             writer: Callable[[ProverEvents], None], summary: RunSummary,
         ) -> None:
             """Verify one buffer end-to-end against a frozen snapshot (taken at submit time) of the source
-            and all buffers, then push the outcome onto the completion queue. The per-submission ``tag``
-            isolates this job's spec/conf files, so editing + re-submitting a shared buffer (or a concurrent
+            and all buffers, then push the outcome onto the completion queue. The job runs in its own
+            materialized project folder, so editing + re-submitting a shared buffer (or a concurrent
             sibling job) can never mutate the files this job is reading. Cancellation (a supersede) propagates
             as CancelledError and pushes nothing — the superseded result is simply dropped."""
             conf_dir = CERTORA_DIR / "confs"
-            stem = f"{name}__{tag}"
             try:
                 async with sem, project_directory(vfs) as run_root:
-                    with materialize_buffers(run_root, buffers, tag) as paths:
+                    with materialize_buffers(run_root, buffers) as paths:
                         spec_path = paths[name]
                         with buffer_conf(
                             working_dir=run_root, config=conf, main_contract=main_contract,
-                            spec_path=spec_path, buffer_name=stem, conf_dir=conf_dir, msg="",
+                            spec_path=spec_path, buffer_name=name, conf_dir=conf_dir, msg="",
                         ) as (cpath, _cfg):
                             try:
                                 all_rules = await declared_rules_list(folder=Path(run_root), args=[cpath])
@@ -717,7 +695,7 @@ def get_prover_tool(
                                 return
                         with buffer_conf(
                             working_dir=run_root, config=conf, main_contract=main_contract,
-                            spec_path=spec_path, buffer_name=stem, conf_dir=conf_dir, msg=label,
+                            spec_path=spec_path, buffer_name=name, conf_dir=conf_dir, msg=label,
                         ) as (cpath, cfg):
                             res = await run_prover(
                                 Path(run_root), [cpath], tool_call_id, prover_opts,
@@ -781,7 +759,7 @@ def get_prover_tool(
             submit_counts[name] = n
             component = component_of(state)
             task = asyncio.create_task(_run_buffer_job(
-                name=name, digest=digest, tag=f"{digest[:8]}_{n}",
+                name=name, digest=digest,
                 label=f"{component}/{name} submission {n}",
                 buffers=dict(buffers), vfs=dict(state.get("vfs") or {}), conf=state["config"],
                 cex_state=state, tool_call_id=tool_call_id,

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -766,9 +766,17 @@ def get_prover_tool(
                 return f"Buffer {name!r} is already verified at its current content; nothing to submit."
 
             existing = buffer_jobs.get(name)
+            if existing is not None and existing.digest == digest:
+                # A job for this exact content is already in flight, or has just finished with its result
+                # not yet collected. Either way, do not launch a duplicate — the answer is (coming) on the
+                # queue; the agent should collect it, not re-run identical work.
+                proving = "is still proving" if not existing.task.done() else "has already finished"
+                return (
+                    f"Buffer {name!r} was already submitted at its current content and {proving}; do not "
+                    f"re-submit it. Call collect_results to take its result — if this is your only "
+                    f"remaining buffer/task and you are just waiting on it, use collect_results(wait=true)."
+                )
             if existing is not None and not existing.task.done():
-                if existing.digest == digest:
-                    return f"Buffer {name!r} is already running. Use collect_results to retrieve its result."
                 existing.task.cancel()  # buffer (or a shared import) changed: supersede the stale job
 
             n = submit_counts.get(name, 0) + 1

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -11,7 +11,9 @@ Provides get_prover_tool() which creates a verify_spec tool that:
 import asyncio
 import json
 import logging
+import os
 import time
+from dataclasses import dataclass
 from contextlib import contextmanager, asynccontextmanager, ExitStack, nullcontext
 from pathlib import Path
 from typing import (
@@ -27,7 +29,7 @@ from composer.spec.source.live_explorer import VersionedHistory
 from langchain_core.tools import InjectedToolCallId, tool, BaseTool
 from langchain_core.messages import AIMessage
 from langgraph.prebuilt import InjectedState
-from pydantic import BaseModel, Field, Discriminator
+from pydantic import BaseModel, Field, Discriminator, create_model
 
 from langgraph.config import get_stream_writer
 from langgraph.types import Command
@@ -36,7 +38,7 @@ from graphcore.graph import LLM
 
 from composer.prover.core import (
     ProverOptions, SpecCompilationError, declared_rules_list, run_prover,
-    DefaultCexHandler
+    DefaultCexHandler, ProverReport
 )
 from composer.prover.callbacks import ProverEventCallbacks
 from composer.prover.ptypes import StatusCodes
@@ -54,7 +56,7 @@ from composer.spec.gen_types import CERTORA_DIR, SPECS_DIR
 from composer.spec.util import string_hash
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.spec.source.spec_buffers import (
-    BufferRun, NamedBuffer, SpecBuffersExtra, buffer_state_digest, plan_buffer_runs, run_targets,
+    NamedBuffer, SpecBuffersExtra, buffer_state_digest, run_targets,
 )
 
 
@@ -564,16 +566,33 @@ def stuck_rule_nag(
     return reminders
 
 
+def _retarget_buffer_imports(cvl: str, names: Iterable[str], tag: str) -> str:
+    """Rewrite each sibling-buffer import ``"<name>.spec"`` to its tagged filename ``"<name>__<tag>.spec"``
+    so a tagged materialization stays self-consistent. Resource imports (e.g. ``"summaries/foo.spec"``)
+    are different quoted strings and are left untouched, so they still resolve within the specs dir."""
+    out = cvl
+    for n in names:
+        out = out.replace(f'"{n}.spec"', f'"{n}__{tag}.spec"')
+    return out
+
+
 @contextmanager
 def materialize_buffers(
-    working_dir: str, buffers: Mapping[str, NamedBuffer]
+    working_dir: str, buffers: Mapping[str, NamedBuffer], tag: str
 ) -> Iterator[dict[str, str]]:
-    """Write every buffer as ``{name}.spec`` into the specs dir (all at once), so any buffer's
-    ``import "X.spec"`` resolves to its sibling. Yields ``name -> on-disk spec path``; every file is
-    removed on exit. Buffer names are unique, so there is no same-name write race across the set."""
+    """Write every buffer as ``{name}__{tag}.spec`` into the specs dir (all at once, so any buffer's
+    ``import "<sibling>.spec"`` — retargeted to the tagged name — resolves), and yield ``name -> on-disk
+    spec path``; every file is removed on exit. The ``tag`` (unique per submission) isolates concurrent
+    jobs that share one run-root: on the in-situ path the run-root is the shared project directory, so
+    two jobs writing the deterministic ``{name}.spec`` would clobber each other and race on cleanup."""
+    names = list(buffers)
     with ExitStack() as stack:
         yield {
-            name: stack.enter_context(tmp_spec(root=working_dir, content=buf.cvl, name=name))
+            name: stack.enter_context(tmp_spec(
+                root=working_dir,
+                content=_retarget_buffer_imports(buf.cvl, names, tag),
+                name=f"{name}__{tag}",
+            ))
             for name, buf in buffers.items()
         }
 
@@ -587,7 +606,6 @@ def buffer_conf(
     spec_path: str,
     buffer_name: str,
     conf_dir: Path,
-    rule: list[str] | None,
     msg: str,
 ) -> Iterator[tuple[str, dict]]:
     """Build a conf verifying an already-materialized buffer spec at ``spec_path`` (its imports resolve
@@ -595,8 +613,6 @@ def buffer_conf(
     cfg = prover_config_overlay(
         config, main_contract=main_contract, verify_target=f"{main_contract}:{spec_path}"
     )
-    if rule is not None:
-        cfg["rule"] = rule
     cfg["msg"] = msg
     with temp_certora_file(
         root=working_dir,
@@ -609,13 +625,67 @@ def buffer_conf(
         yield (conf_path, cfg)
 
 
+_SUBMIT_BUFFER_DESCRIPTION = """
+Submit one run-target buffer for verification as an independent background prover job, and return
+immediately — the job proves while you keep working. Submit each buffer as soon as it is ready; buffers
+prove in parallel. Re-submitting a buffer relaunches it (superseding any in-flight job for it), which is
+how you re-verify a buffer after editing it, or after editing a shared buffer it imports. A buffer
+already verified at its current content, or already running, is not re-launched. Retrieve outcomes with
+collect_results.
+"""
+
+_COLLECT_RESULTS_DESCRIPTION = """
+Retrieve the results of finished buffer jobs (submitted with submit_buffer). Returns each finished
+buffer's prover outcome plus a status board: which buffers are complete, still running, or need
+(re)submission. By default it does NOT block — it returns whatever has finished so far (possibly
+nothing), so you can go author or submit other buffers instead of waiting. Pass wait=true ONLY when you
+have no other work: every buffer submitted and running, with no finished result left to process; it then
+sleeps until the next job finishes.
+"""
+
+
+@dataclass
+class ProverToolset:
+    """The prover-side agent tools. ``verify_spec`` is the single-``curr_spec`` tool; the
+    ``buffer_tools`` (``submit_buffer`` / ``collect_results``) are bound in its place when multi-buffer
+    authoring is enabled, so the agent submits per-buffer jobs asynchronously and consumes results as
+    they finish instead of blocking on a whole batch."""
+
+    verify_spec: BaseTool
+    buffer_tools: list[BaseTool]
+
+
+@dataclass
+class _BufJob:
+    """One in-flight (or just-finished) per-buffer prover job. At most one per buffer name at a time;
+    re-submitting a buffer supersedes (cancels) a stale predecessor. Lives in the prover tool's closure,
+    not in graph state — asyncio tasks span agent turns and are not serializable."""
+
+    name: str
+    #: The buffer's content digest at submit time; a completion is credited only at the current digest,
+    #: so a job whose digest is now stale (its buffer or a shared import changed) can't mark it done.
+    digest: str
+    task: "asyncio.Task[None]"
+
+
+@dataclass
+class _BufDone:
+    """A finished buffer job's payload, delivered through the completion queue to ``collect_results``."""
+
+    name: str
+    digest: str
+    #: The prover report, or a compile/toolchain error message (str) that aborts only this buffer.
+    result: ProverReport | str
+    all_rules: list[str]
+
+
 def get_prover_tool(
     llm: LLM,
     main_contract: str,
     project_directory: ProjectDirectory,
     prover_opts: ProverOptions,
     analysis_store: CexAnalysisStore | None = None,
-) -> BaseTool:
+) -> ProverToolset:
     sem = _prover_sem(prover_opts.cloud)
     stamper = make_validation_stamper(VALIDATION_KEY)
     # Serialize verify calls targeting the same spec name: the spec/conf are written
@@ -626,6 +696,19 @@ def get_prover_tool(
     # the per-run tool; popping a held lock would let a later same-stem call mint a fresh,
     # non-excluding one.
     spec_locks: dict[str, asyncio.Lock] = {}
+
+    # Multi-buffer async job state, held in the closure (not graph state) so it spans agent turns:
+    # submit_buffer launches a background task per buffer and returns immediately; collect_results
+    # drains finished jobs off the queue. At most one live job per buffer name — a re-submit supersedes
+    # a stale predecessor. See submit_buffer / collect_results below.
+    buffer_jobs: dict[str, _BufJob] = {}
+    done_queue: asyncio.Queue[_BufDone] = asyncio.Queue()
+    submit_counts: dict[str, int] = {}
+
+    def component_of(state: StateWithSkips) -> str:
+        """The label prefix for this generation's prover runs: its seeded spec stem, or the main
+        contract, with the ``autospec_`` prefix stripped."""
+        return (state.get("spec_stem") or main_contract).removeprefix("autospec_")
 
     @tool_display("Running prover", None)
     @tool(args_schema=VerifySpecSchema)
@@ -644,18 +727,13 @@ def get_prover_tool(
         if rules is not None and exclude_rules is not None:
             return "Cannot invoke the prover with both `rules` and `exclude_rules` set to non-none"
 
-        # Multi-buffer mode when the agent has declared run-target buffers; otherwise the single
-        # curr_spec path below (unchanged).
-        buffers = state.get("buffers") or {}
-        targets = run_targets(buffers)
-
         spec = state["curr_spec"]
-        if not targets and spec is None:
+        if spec is None:
             return "Specification not yet put on VFS"
 
-        spec_hash = string_hash(spec) if spec is not None else ""
+        spec_hash = string_hash(spec)
 
-        if not targets and (last_run := last_prover_run(state["prover_history"])) is not None:
+        if (last_run := last_prover_run(state["prover_history"])) is not None:
             if any(i == "TIMEOUT" for (_,i) in last_run["prover_results"]) and last_run["spec_digest"] == spec_hash:
                 return "Refusing to re-run prover on identical spec with a known TIMEOUT result; timeouts are not transient " \
                     "errors and will not go away by re-running the tool."
@@ -665,22 +743,16 @@ def get_prover_tool(
         # dump) under a lock; else fall back to unique uid names (no lock needed).
         spec_stem = state.get("spec_stem")
         summary = get_run_summary()
-        component = (spec_stem or main_contract).removeprefix("autospec_")
+        component = component_of(state)
         iteration = len(state["prover_history"]) + 1
 
         conf_dir = (CERTORA_DIR / "confs") if spec_stem is not None else CERTORA_DIR
         lock = spec_locks.setdefault(spec_stem, asyncio.Lock()) if spec_stem is not None else nullcontext()
         prover_msg = f"{component} iteration number {iteration}"
 
-        summary = get_run_summary()
-
-        component = (spec_stem or main_contract).removeprefix("autospec_")
-        iteration = len(state["prover_history"]) + 1
-        prover_msg = f"{component} iteration number {iteration}"
-
 
         async def run_in(run_root: str) -> str | Command:
-            assert spec is not None  # single-spec path; buffers mode dispatches to run_buffers
+            assert spec is not None  # single-spec path; buffers use submit_buffer / collect_results
             with setup_prover_config_in(
                 working_dir=run_root,
                 main_contract=main_contract,
@@ -774,116 +846,240 @@ def get_prover_tool(
         # The author's working copy decides where this run executes (in-situ for
         # an empty VFS, a temp materialization otherwise); the same-stem lock
         # guards the deterministic spec/conf names within it.
-        async def run_buffers(run_root: str, targets: list[NamedBuffer]) -> str | Command:
-            """Verify each run-target buffer as its own spec, concurrently; overall completion is the
-            AND of per-buffer completion. A buffer already complete at its current digest is skipped."""
-            conf = state["config"]
-            summary = get_run_summary()
-            conf_dir = CERTORA_DIR / "confs"
-            expected = set(state["rule_skips"].keys())
-            vh = state["version_history"]
-            skipped_pairs = [(str(s.property_title), str(s.reason)) for s in state["skipped"]]
+        async with lock, project_directory(state.get("vfs") or {}) as run_root:
+            return await run_in(run_root)
 
-            def digest_of(b: NamedBuffer) -> str:
-                return buffer_state_digest(buffers, b.name, skipped=skipped_pairs, version_history=vh)
+    # ---- Multi-buffer async submit / collect -------------------------------------------------
+    # verify_spec runs one whole curr_spec and blocks on it. The buffer flow instead lets the agent
+    # submit each run-target buffer as an independent background job and consume results as they finish,
+    # so a fast group is reviewed while a slow group is still proving. Correctness — a shared-buffer edit
+    # re-verifying every importer — rides the content digest, exactly as on the single-spec path.
 
-            plan = plan_buffer_runs(
-                buffers,
-                digest_of=digest_of,
-                is_complete=lambda b, d: buffer_is_complete(
-                    state["prover_history"], buffer=b.name, curr_digest=d,
-                    expected_to_fail=expected, curr_status=[], all_rules=list(b.owned_rules),
-                ),
-            )
-            pending = [r for r in plan if r.needs_run]
-            if not pending:
-                return tool_state_update(
-                    tool_call_id=tool_call_id,
-                    content="All buffers already verified at their current state; nothing to re-run.",
-                )
-
-            with materialize_buffers(run_root, buffers) as paths:
-                async def run_one(r: BufferRun):
-                    b = r.buffer
-                    spec_path = paths[b.name]
+    async def _run_buffer_job(
+        *, name: str, digest: str, tag: str, label: str, buffers: Mapping[str, NamedBuffer],
+        vfs: dict[str, str], conf: dict, cex_state: StateWithSkips, tool_call_id: str,
+        writer: Callable[[ProverEvents], None], summary: RunSummary,
+    ) -> None:
+        """Verify one buffer end-to-end against a frozen snapshot (taken at submit time) of the source
+        and all buffers, then push the outcome onto the completion queue. The per-submission ``tag``
+        isolates this job's spec/conf files, so editing + re-submitting a shared buffer (or a concurrent
+        sibling job) can never mutate the files this job is reading. Cancellation (a supersede) propagates
+        as CancelledError and pushes nothing — the superseded result is simply dropped."""
+        conf_dir = CERTORA_DIR / "confs"
+        stem = f"{name}__{tag}"
+        try:
+            async with sem, project_directory(vfs) as run_root:
+                with materialize_buffers(run_root, buffers, tag) as paths:
+                    spec_path = paths[name]
                     with buffer_conf(
                         working_dir=run_root, config=conf, main_contract=main_contract,
-                        spec_path=spec_path, buffer_name=b.name, conf_dir=conf_dir, rule=None, msg="",
+                        spec_path=spec_path, buffer_name=stem, conf_dir=conf_dir, msg="",
                     ) as (cpath, _cfg):
                         try:
                             all_rules = await declared_rules_list(folder=Path(run_root), args=[cpath])
                         except SpecCompilationError as exc:
-                            return (r, f"[buffer {b.name}] failed to compile:\n{exc.output}", [])
+                            await done_queue.put(_BufDone(
+                                name, digest, f"[buffer {name}] failed to compile:\n{exc.output}", [],
+                            ))
+                            return
                     with buffer_conf(
                         working_dir=run_root, config=conf, main_contract=main_contract,
-                        spec_path=spec_path, buffer_name=b.name, conf_dir=conf_dir, rule=None,
-                        msg=f"{b.name} iteration {len(state['prover_history']) + 1}",
+                        spec_path=spec_path, buffer_name=stem, conf_dir=conf_dir, msg=label,
                     ) as (cpath, cfg):
-                        async with sem:
-                            res = await run_prover(
-                                Path(run_root), [cpath], tool_call_id, prover_opts,
-                                _SpecCallbacks(get_stream_writer(), tool_call_id, summary, cfg,
-                                               analysis_store=analysis_store),
-                                DefaultCexHandler(llm, state, summarization_threshold=10),
-                            )
-                    return (r, res, all_rules)
+                        res = await run_prover(
+                            Path(run_root), [cpath], tool_call_id, prover_opts,
+                            _SpecCallbacks(writer, tool_call_id, summary, cfg, analysis_store=analysis_store),
+                            DefaultCexHandler(llm, cex_state, summarization_threshold=10),
+                        )
+            await done_queue.put(_BufDone(name, digest, res, all_rules))
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # a job crash must not sink silently — surface it on the queue
+            _logger.exception("buffer job %s crashed", name)
+            await done_queue.put(_BufDone(name, digest, f"[buffer {name}] job error: {exc}", []))
 
-                outcomes = await asyncio.gather(*(run_one(r) for r in pending))
+    def _cur_digest(state: StateWithSkips, buffers: Mapping[str, NamedBuffer], name: str) -> str:
+        skipped_pairs = [(str(s.property_title), str(s.reason)) for s in state["skipped"]]
+        return buffer_state_digest(
+            buffers, name, skipped=skipped_pairs, version_history=state["version_history"],
+        )
 
-            for (_r, res, _rules) in outcomes:
-                if isinstance(res, str):  # a hard compile/toolchain error in any buffer aborts the pass
-                    return res
+    def _buffer_complete_at(
+        state: StateWithSkips, buffers: Mapping[str, NamedBuffer], name: str, digest: str,
+        *, extra_history: Sequence[ProverHistoryItem] = (),
+    ) -> bool:
+        return buffer_is_complete(
+            list(state["prover_history"]) + list(extra_history), buffer=name, curr_digest=digest,
+            expected_to_fail=set(state["rule_skips"].keys()), curr_status=[],
+            all_rules=list(buffers[name].owned_rules),
+        )
 
-            prover_update: list[ProverHistoryItem] = []
-            fresh: dict[str, list[tuple[RulePath, StatusCodes]]] = {}
-            link: str | None = None
-            parts: list[str] = []
-            for (r, res, all_rules) in outcomes:
-                assert not isinstance(res, str)
-                results: list[tuple[RulePath, StatusCodes]] = [(k, v) for (k, v) in res.raw_rule_status.items()]
-                fresh[r.buffer.name] = results
-                link = res.link or link
-                parts.append(f"=== buffer {r.buffer.name} ===\n{res.result_str}")
-                prover_update.append(ProverRunLog(
-                    tool_call_id=tool_call_id,
-                    prover_results=results,
-                    rules=None,
-                    spec_digest=string_hash(r.buffer.cvl),
-                    sort="run",
-                    declared_rules=all_rules,
-                    state_digest=r.digest,
-                    buffer=r.buffer.name,
-                ))
+    submit_schema = create_model(
+        "SubmitBuffer", __doc__=_SUBMIT_BUFFER_DESCRIPTION,
+        name=(str, Field(description="The run-target buffer to submit for verification.")),
+        state=(Annotated[StateWithSkips, InjectedState], ...),
+        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
+    )
 
-            # Stamp the prover validation per buffer that is complete at its current digest (fresh
-            # results for the ones we ran, history for those skipped as already complete). Overall
-            # completion is checked per buffer at publish (check_buffer_completion).
-            history_after = state["prover_history"] + prover_update
-            prover_stamps: dict[str, str] = {}
-            for b in targets:
-                if buffer_is_complete(
-                    history_after, buffer=b.name, curr_digest=digest_of(b),
-                    expected_to_fail=expected, curr_status=fresh.get(b.name, []),
-                    all_rules=list(b.owned_rules),
-                ):
-                    prover_stamps[f"prover:{b.name}"] = digest_of(b)
+    @tool_display("Submitting buffer", None)
+    @tool(args_schema=submit_schema)
+    async def submit_buffer(**args) -> str | Command:
+        state: StateWithSkips = args["state"]
+        name: str = args["name"]
+        tool_call_id: str = args["tool_call_id"]
+        buffers = state.get("buffers") or {}
+        b = buffers.get(name)
+        if b is None:
+            return f"No buffer named {name!r}. Create it with put_buffer first."
+        if not b.is_run_target:
+            return f"Buffer {name!r} is a shared (imports-only) buffer; it runs no rules of its own."
 
-            # Nag on rules stuck on repeated failures across all buffers' runs (shared with run_in).
-            all_status = [pair for results in fresh.values() for pair in results]
-            nag_channel: dict = {}
-            if reminders := stuck_rule_nag(all_status, prover_update, state):
-                nag_channel["reminders_channel"] = reminders
+        digest = _cur_digest(state, buffers, name)
+        if _buffer_complete_at(state, buffers, name, digest):
+            return f"Buffer {name!r} is already verified at its current content; nothing to submit."
 
-            return tool_state_update(
-                tool_call_id=tool_call_id, content="\n\n".join(parts), prover_link=link,
-                validations=prover_stamps, prover_history=prover_update, **nag_channel,
+        existing = buffer_jobs.get(name)
+        if existing is not None and not existing.task.done():
+            if existing.digest == digest:
+                return f"Buffer {name!r} is already running. Use collect_results to retrieve its result."
+            existing.task.cancel()  # buffer (or a shared import) changed: supersede the stale job
+
+        n = submit_counts.get(name, 0) + 1
+        submit_counts[name] = n
+        component = component_of(state)
+        task = asyncio.create_task(_run_buffer_job(
+            name=name, digest=digest, tag=f"{digest[:8]}_{n}",
+            label=f"{component}/{name} submission {n}",
+            buffers=dict(buffers), vfs=dict(state.get("vfs") or {}), conf=state["config"],
+            cex_state=state, tool_call_id=tool_call_id,
+            # The stream writer is captured here and used by the detached task: its prover-progress
+            # events carry this submit call's tool_call_id, which has already returned, so background-job
+            # progress can render loosely in the UI (functional results are unaffected).
+            writer=get_stream_writer(), summary=get_run_summary(),
+        ))
+        buffer_jobs[name] = _BufJob(name=name, digest=digest, task=task)
+        running = sorted(nm for nm, j in buffer_jobs.items() if not j.task.done())
+        return (
+            f"Submitted buffer {name!r} (submission {n}); it is now proving in the background. "
+            f"Running: {running}. Call collect_results to retrieve results as jobs finish."
+        )
+
+    collect_schema = create_model(
+        "CollectResults", __doc__=_COLLECT_RESULTS_DESCRIPTION,
+        wait=(bool, Field(
+            default=False,
+            description="Block until the next job finishes. Set true ONLY when you have no other work: "
+            "every buffer is submitted and running and you have no finished result left to process. "
+            "Leave false to take whatever has finished so far without waiting.",
+        )),
+        state=(Annotated[StateWithSkips, InjectedState], ...),
+        tool_call_id=(Annotated[str, InjectedToolCallId], ...),
+    )
+
+    @tool_display("Collecting prover results", None)
+    @tool(args_schema=collect_schema)
+    async def collect_results(**args) -> str | Command:
+        state: StateWithSkips = args["state"]
+        tool_call_id: str = args["tool_call_id"]
+        wait: bool = args["wait"]
+        buffers = state.get("buffers") or {}
+        targets = run_targets(buffers)
+        if not targets:
+            return "No run-target buffers to collect. Author buffers and submit_buffer them first."
+
+        # Current digest per buffer is stable within this call (buffers/skips/edit-history are fixed);
+        # memoize it — each is a content hash over the import closure, read at several points below.
+        _digests: dict[str, str] = {}
+        def cur_digest(nm: str) -> str:
+            if nm not in _digests:
+                _digests[nm] = _cur_digest(state, buffers, nm)
+            return _digests[nm]
+
+        drained: list[_BufDone] = []
+        while not done_queue.empty():
+            drained.append(done_queue.get_nowait())
+        if not drained and wait and any(not j.task.done() for j in buffer_jobs.values()):
+            # Idle wait: nothing else to do, sleep until one job finishes. Unbounded, but every job is
+            # guaranteed to land on the queue — run_prover self-bounds its subprocess, and a crash is
+            # caught and enqueued as an error — so this can't hang on a wedged job.
+            drained.append(await done_queue.get())
+            while not done_queue.empty():
+                drained.append(done_queue.get_nowait())
+
+        # Cancel jobs left running against a now-stale digest: a shared buffer they import was edited, so
+        # their result would be discarded anyway — and on local runs a doomed job needlessly holds the
+        # single prover slot. The agent re-submits them (they show under needs-(re)submission below).
+        for nm, j in list(buffer_jobs.items()):
+            if not j.task.done() and nm in buffers and j.digest != cur_digest(nm):
+                j.task.cancel()
+                buffer_jobs.pop(nm, None)
+
+        # Retire finished jobs from the registry. A result that lands between the drain and here stays on
+        # the queue, so its buffer is picked up on the next collect even though its job is already gone.
+        for nm in [nm for nm, j in buffer_jobs.items() if j.task.done()]:
+            buffer_jobs.pop(nm, None)
+
+        prover_update: list[ProverHistoryItem] = []
+        fresh: dict[str, list[tuple[RulePath, StatusCodes]]] = {}
+        link: str | None = None
+        parts: list[str] = []
+        for d in drained:
+            if isinstance(d.result, str):  # compile/toolchain error: surface it, record no run
+                parts.append(f"=== buffer {d.name} ===\n{d.result}")
+                continue
+            results: list[tuple[RulePath, StatusCodes]] = list(d.result.raw_rule_status.items())
+            fresh[d.name] = results
+            link = d.result.link or link
+            stale = d.name in buffers and d.digest != cur_digest(d.name)
+            note = (" (NOTE: the spec changed since this was submitted — this result is STALE; re-submit "
+                    "this buffer.)") if stale else ""
+            parts.append(f"=== buffer {d.name} ==={note}\n{d.result.result_str}")
+            prover_update.append(ProverRunLog(
+                tool_call_id=tool_call_id, prover_results=results, rules=None,
+                spec_digest=string_hash(buffers[d.name].cvl) if d.name in buffers else "",
+                sort="run", declared_rules=d.all_rules, state_digest=d.digest, buffer=d.name,
+            ))
+
+        # Per-buffer completion is re-evaluated over history + this drain against the CURRENT digest, so
+        # a stale run (state_digest mismatch) never credits completion. Overall completion is the AND of
+        # these, checked at publish (check_buffer_completion).
+        prover_stamps: dict[str, str] = {}
+        for b in targets:
+            d = cur_digest(b.name)
+            if _buffer_complete_at(state, buffers, b.name, d, extra_history=prover_update):
+                prover_stamps[f"prover:{b.name}"] = d
+
+        # Status board — the agent's work-list. `running` counts only a live job at the CURRENT digest;
+        # a job left running at a stale digest (its shared import changed) is doomed, so its buffer falls
+        # under needs-(re)submission until the agent relaunches it.
+        complete = {b.name for b in targets if f"prover:{b.name}" in prover_stamps}
+        running = {
+            nm for nm, j in buffer_jobs.items()
+            if not j.task.done() and nm in buffers and j.digest == cur_digest(nm)
+        }
+        needs_submit = [b.name for b in targets if b.name not in complete and b.name not in running]
+        board = [
+            "",
+            f"[buffers] complete: {sorted(complete)}",
+            f"[buffers] running: {sorted(running)}",
+            f"[buffers] needs (re)submission: {sorted(needs_submit)}",
+        ]
+        if not drained:
+            parts.append("No finished jobs yet." if running else "No finished jobs and nothing running.")
+
+        nag_channel: dict = {}
+        all_status = [pair for results in fresh.values() for pair in results]
+        if reminders := stuck_rule_nag(all_status, prover_update, state):
+            nag_channel["reminders_channel"] = reminders
+        if not needs_submit and not running:
+            nag_channel.setdefault("reminders_channel", []).append(
+                "Every run-target buffer is verified at its current content. Once each also has "
+                "feedback, you can publish."
             )
 
-        if targets:
-            async with spec_locks.setdefault("__buffers__", asyncio.Lock()), \
-                    project_directory(state.get("vfs") or {}) as run_root:
-                return await run_buffers(run_root, targets)
-        async with lock, project_directory(state.get("vfs") or {}) as run_root:
-            return await run_in(run_root)
+        return tool_state_update(
+            tool_call_id=tool_call_id, content="\n".join(parts + board), prover_link=link,
+            validations=prover_stamps, prover_history=prover_update, **nag_channel,
+        )
 
-    return verify_spec
+    return ProverToolset(verify_spec=verify_spec, buffer_tools=[submit_buffer, collect_results])

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -1,11 +1,11 @@
 """
-Spec-side prover tool: wraps composer/prover/core.py into a LangGraph tool.
+Spec-side prover tools: wrap composer/prover/core.py into LangGraph tools.
 
-Provides get_prover_tool() which creates a verify_spec tool that:
-- Reads curr_spec from injected state
-- Writes a temporary .spec file
-- Runs the Certora prover via run_prover()
-- Streams output/polling events via custom stream writer
+Provides get_prover_tool(), whose submit_buffer / collect_results tools:
+- Materialize each run-target buffer to a temporary .spec file
+- Run the Certora prover via run_prover() as background per-buffer jobs
+- Stream output/polling events via a custom stream writer
+- Report results as jobs finish, without blocking on a whole batch
 """
 
 import asyncio
@@ -66,7 +66,7 @@ _logger = logging.getLogger("composer.prover")
 OVERLAY_OWNED_KEYS: frozenset[str] = frozenset({
     # forced by prover_config_overlay
     "verify", "parametric_contracts", "optimistic_loop", "rule_sanity",
-    # set per-run by verify_spec
+    # set per prover run
     "rule", "msg",
 })
 """Config keys the run pipeline forces onto the base config after spreading it: a
@@ -78,7 +78,7 @@ from this set, or an "accepted" flag edit would never reach the prover."""
 def prover_config_overlay(base_config: dict, *, main_contract: str, verify_target: str) -> dict:
     """The fixed prover settings the source pipeline layers on top of the base config.
 
-    Shared by the live ``verify_spec`` run and the persisted ``certora/confs`` dump so the
+    Shared by the live prover run and the persisted ``certora/confs`` dump so the
     two can't drift. ``verify_target`` is the ``<contract>:<spec path>`` the run verifies.
     """
     return {
@@ -298,7 +298,7 @@ class ProverStateExtra(TypedDict):
     prover_history: Annotated[list[ProverHistoryItem], _merge_prover_history]
     reminders_channel: list[str]
 
-    # The author's working copy of the source under verification; verify_spec runs
+    # The author's working copy of the source under verification; the prover runs
     # against its materialization when non-empty (see ProjectDirectory). Absent/empty
     # outside the editing-enabled pipeline. No merge op intentionally: the vfs is
     # only ever replaced wholesale (commit_edit / revert_to_edit).
@@ -306,7 +306,7 @@ class ProverStateExtra(TypedDict):
 
 type ProverEvents = CEXAnalysisStart | CloudPollingEvent | ProverOutputEvent | RuleAnalysisResult | ProverRun | ProverLink | ProverResult
 
-# ``verify_spec`` only runs in the source pipeline, whose state always seeds
+# The source pipeline's state always seeds
 # ``version_history`` — permanently empty in phases without the edit tools
 # (structural invariants, never-edited authors), in which case it contributes
 # nothing to the digest. The prover's validation stamp is bound to it so a
@@ -404,32 +404,6 @@ class _SpecCallbacks(ProverEventCallbacks):
             except Exception:
                 _logger.exception("failed to capture cex analysis for %s", rule.name)
         await super().on_analysis_complete(rule, explanation)
-
-
-class VerifySpecSchema(BaseModel):
-    """
-    Run the Certora prover to verify the current spec against the source code.
-
-    Returns verification results:
-    - VERIFIED: Rule holds for all inputs
-    - VIOLATED: Counterexample found (with CEX analysis)
-    - TIMEOUT: Verification did not complete in time
-
-    Use these results to refine your spec.
-    """
-    tool_call_id: Annotated[str, InjectedToolCallId]
-
-    rules: list[str] | None = Field(
-        default=None,
-        description="Specific rules to verify. If None, verifies all rules. Mutually exclusive with the `exclude_rules` argument"
-    )
-
-    exclude_rules: list[str] | None = Field(
-        default=None,
-        description="Specific rules to SKIP verifying. If none validates all rules. Mutually exclusive with `rules` argument"
-    )
-
-    state: Annotated[StateWithSkips, InjectedState]
 
 
 @contextmanager
@@ -545,7 +519,7 @@ def stuck_rule_nag(
     }
     known_tc_ids = {
         l["id"] for msg in state["messages"] if isinstance(msg, AIMessage)
-        for l in msg.tool_calls if l["name"] == "verify_spec"
+        for l in msg.tool_calls if l["name"] == "collect_results"
     }
     to_warn, seen_post_compaction_history = stuck_rule_warnings(
         stuck_rules, state["prover_history"], known_tc_ids
@@ -646,12 +620,9 @@ sleeps until the next job finishes.
 
 @dataclass
 class ProverToolset:
-    """The prover-side agent tools. ``verify_spec`` is the single-``curr_spec`` tool; the
-    ``buffer_tools`` (``submit_buffer`` / ``collect_results``) are bound in its place when multi-buffer
-    authoring is enabled, so the agent submits per-buffer jobs asynchronously and consumes results as
-    they finish instead of blocking on a whole batch."""
+    """The prover-side agent tools: ``buffer_tools`` (``submit_buffer`` / ``collect_results``), which
+    submit per-buffer jobs asynchronously and consume results as they finish."""
 
-    verify_spec: BaseTool
     buffer_tools: list[BaseTool]
 
 
@@ -688,14 +659,6 @@ def get_prover_tool(
 ) -> ProverToolset:
     sem = _prover_sem(prover_opts.cloud)
     stamper = make_validation_stamper(VALIDATION_KEY)
-    # Serialize verify calls targeting the same spec name: the spec/conf are written
-    # under a deterministic name and unlinked on exit, so two overlapping same-stem
-    # calls (e.g. parallel verify_spec for one component) would race. Distinct stems
-    # stay concurrent (notably on cloud, where ``sem`` is a no-op).
-    # Not pruned: bounded by this run's stems (per-component + invariants) and dies with
-    # the per-run tool; popping a held lock would let a later same-stem call mint a fresh,
-    # non-excluding one.
-    spec_locks: dict[str, asyncio.Lock] = {}
 
     # Multi-buffer async job state, held in the closure (not graph state) so it spans agent turns:
     # submit_buffer launches a background task per buffer and returns immediately; collect_results
@@ -713,150 +676,10 @@ def get_prover_tool(
         contract, with the ``autospec_`` prefix stripped."""
         return (state.get("spec_stem") or main_contract).removeprefix("autospec_")
 
-    @tool_display("Running prover", None)
-    @tool(args_schema=VerifySpecSchema)
-    async def verify_spec(
-        tool_call_id: Annotated[str, InjectedToolCallId],
-        state: Annotated[StateWithSkips, InjectedState],
-        rules: list[str] | None = None,
-        exclude_rules: list[str] | None = None
-    ) -> str | Command:
-        last_msg = state["messages"][-1]
-        if isinstance(last_msg, AIMessage) and any(
-            i["id"] != tool_call_id for i in last_msg.tool_calls
-        ):
-            return "Cannot call the verify_spec tool in parallel with other tool calls. verify_spec must be the only tool you call in a turn"
-
-        if rules is not None and exclude_rules is not None:
-            return "Cannot invoke the prover with both `rules` and `exclude_rules` set to non-none"
-
-        spec = state["curr_spec"]
-        if spec is None:
-            return "Specification not yet put on VFS"
-
-        spec_hash = string_hash(spec)
-
-        if (last_run := last_prover_run(state["prover_history"])) is not None:
-            if any(i == "TIMEOUT" for (_,i) in last_run["prover_results"]) and last_run["spec_digest"] == spec_hash:
-                return "Refusing to re-run prover on identical spec with a known TIMEOUT result; timeouts are not transient " \
-                    "errors and will not go away by re-running the tool."
-
-        conf = state["config"]
-        # With a seeded stem, name the spec/conf after it (so on-disk names match the
-        # dump) under a lock; else fall back to unique uid names (no lock needed).
-        spec_stem = state.get("spec_stem")
-        summary = get_run_summary()
-        component = component_of(state)
-        iteration = len(state["prover_history"]) + 1
-
-        conf_dir = (CERTORA_DIR / "confs") if spec_stem is not None else CERTORA_DIR
-        lock = spec_locks.setdefault(spec_stem, asyncio.Lock()) if spec_stem is not None else nullcontext()
-        prover_msg = f"{component} iteration number {iteration}"
-
-
-        async def run_in(run_root: str) -> str | Command:
-            assert spec is not None  # single-spec path; buffers use submit_buffer / collect_results
-            with setup_prover_config_in(
-                working_dir=run_root,
-                main_contract=main_contract,
-                spec_stem=spec_stem,
-                spec_contents=spec,
-                conf_dir=conf_dir,
-                config=conf,
-                rule=None,
-                exclude_rule=None,
-                msg=""
-            ) as (config_path, _ignored):
-                try:
-                    all_rules = await declared_rules_list(
-                        folder=Path(run_root),
-                        args=[config_path]
-                    )
-                except SpecCompilationError as exc:
-                    return f"The spec failed to compile:\n{exc.output}"
-            with setup_prover_config_in(
-                working_dir=run_root,
-                main_contract=main_contract,
-                spec_stem=spec_stem,
-                spec_contents=spec,
-                conf_dir=conf_dir,
-                config=conf,
-                rule=rules,
-                exclude_rule=exclude_rules,
-                msg=prover_msg
-            ) as (config_path, config):
-                async with sem:
-                    result = await run_prover(
-                        Path(run_root),
-                        [config_path],
-                        tool_call_id,
-                        prover_opts,
-                        _SpecCallbacks(get_stream_writer(), tool_call_id, summary, config,
-                                        analysis_store=analysis_store),
-                        DefaultCexHandler(llm, state, summarization_threshold=10)
-                    )
-
-            if isinstance(result, str):
-                return result
-
-            curr_state_digest = spec_digest(
-                spec, state["skipped"], state["version_history"]
-            )
-
-            prover_results : list[tuple[RulePath, StatusCodes]] = [(k, v) for (k,v) in result.raw_rule_status.items()]
-
-            all_verified = _is_completion_history(
-                l=state["prover_history"],
-                curr_digest=curr_state_digest,
-                expected_to_fail=set(state["rule_skips"].keys()),
-                curr_status=prover_results,
-                all_rules=all_rules
-            )
-
-            prover_update : list[ProverHistoryItem] = [
-                ProverRunLog(
-                    tool_call_id=tool_call_id,
-                    prover_results=[(k, v) for (k,v) in result.raw_rule_status.items()],
-                    rules={"sort": "exclude", "selector": exclude_rules } if exclude_rules is not None else \
-                        {"sort": "include", "selector": rules} if rules is not None else None,
-                    spec_digest=spec_hash,
-                    sort="run",
-                    declared_rules=all_rules,
-                    state_digest=curr_state_digest
-                )
-            ]
-            nag_channel: dict = {}
-            if reminders := stuck_rule_nag(prover_results, prover_update, state):
-                nag_channel["reminders_channel"] = reminders
-            if all_verified:
-                nag_channel.setdefault("reminders_channel", []).append(
-                    "You have successfully verified over your prior prover run(s) that all rules verify. This task is completed."
-                )
-                # Completing the coverage stamps, however the completing run was scoped:
-                # every declared rule was verified against exactly this authoring state
-                # (the state_digest match), so a piecemeal completion is as good as a
-                # full-run one.
-                return tool_state_update(
-                    tool_call_id=tool_call_id, content=result.result_str,
-                    prover_link=result.link, validations=stamper(state, state["version_history"]),
-                    prover_history=prover_update, **nag_channel
-                )
-            return tool_state_update(
-                tool_call_id=tool_call_id, content=result.result_str, prover_link=result.link,
-                prover_history=prover_update, **nag_channel
-            )
-
-        # The author's working copy decides where this run executes (in-situ for
-        # an empty VFS, a temp materialization otherwise); the same-stem lock
-        # guards the deterministic spec/conf names within it.
-        async with lock, project_directory(state.get("vfs") or {}) as run_root:
-            return await run_in(run_root)
-
     # ---- Multi-buffer async submit / collect -------------------------------------------------
-    # verify_spec runs one whole curr_spec and blocks on it. The buffer flow instead lets the agent
-    # submit each run-target buffer as an independent background job and consume results as they finish,
-    # so a fast group is reviewed while a slow group is still proving. Correctness — a shared-buffer edit
-    # re-verifying every importer — rides the content digest, exactly as on the single-spec path.
+    # The agent submits each run-target buffer as an independent background job and consumes results
+    # as they finish, so a fast group is reviewed while a slow group is still proving. A shared-buffer
+    # edit re-verifying every importer rides the content digest.
 
     async def _run_buffer_job(
         *, name: str, digest: str, tag: str, label: str, buffers: Mapping[str, NamedBuffer],
@@ -1093,4 +916,4 @@ def get_prover_tool(
             validations=prover_stamps, prover_history=prover_update, **nag_channel,
         )
 
-    return ProverToolset(verify_spec=verify_spec, buffer_tools=[submit_buffer, collect_results])
+    return ProverToolset(buffer_tools=[submit_buffer, collect_results])

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -26,15 +26,15 @@ from graphcore.tools.vfs import VFSAccessor, VFSState
 
 from composer.spec.source.live_explorer import VersionedHistory
 
-from langchain_core.tools import InjectedToolCallId, tool, BaseTool
+from langchain_core.tools import tool, BaseTool
 from langchain_core.messages import AIMessage
-from langgraph.prebuilt import InjectedState
-from pydantic import BaseModel, Field, Discriminator, create_model
+from pydantic import BaseModel, Field, Discriminator
 
 from langgraph.config import get_stream_writer
 from langgraph.types import Command
 from composer.prover.ptypes import RuleResult, RulePath
 from graphcore.graph import LLM
+from graphcore.tools.schemas import WithInjectedId, WithInjectedState
 
 from composer.prover.core import (
     ProverOptions, SpecCompilationError, declared_rules_list, run_prover,
@@ -578,23 +578,33 @@ def buffer_conf(
         yield (conf_path, cfg)
 
 
-_SUBMIT_BUFFER_DESCRIPTION = """
-Submit one run-target buffer for verification as an independent background prover job, and return
-immediately — the job proves while you keep working. Submit each buffer as soon as it is ready; buffers
-prove in parallel. Re-submitting a buffer relaunches it (superseding any in-flight job for it), which is
-how you re-verify a buffer after editing it, or after editing a shared buffer it imports. A buffer
-already verified at its current content, or already running, is not re-launched. Retrieve outcomes with
-collect_results.
-"""
+class _SubmitBufferArgs(WithInjectedState[StateWithSkips], WithInjectedId):
+    """
+    Submit one run-target buffer for verification as an independent background prover job, and return
+    immediately — the job proves while you keep working. Submit each buffer as soon as it is ready;
+    buffers prove in parallel. Re-submitting a buffer relaunches it (superseding any in-flight job for
+    it), which is how you re-verify a buffer after editing it, or after editing a shared buffer it
+    imports. A buffer already verified at its current content, or already running, is not re-launched.
+    Retrieve outcomes with collect_results.
+    """
+    name: str = Field(description="The run-target buffer to submit for verification.")
 
-_COLLECT_RESULTS_DESCRIPTION = """
-Retrieve the results of finished buffer jobs (submitted with submit_buffer). Returns each finished
-buffer's prover outcome plus a status board: which buffers are complete, still running, or need
-(re)submission. By default it does NOT block — it returns whatever has finished so far (possibly
-nothing), so you can go author or submit other buffers instead of waiting. Pass wait=true ONLY when you
-have no other work: every buffer submitted and running, with no finished result left to process; it then
-sleeps until the next job finishes.
-"""
+
+class _CollectResultsArgs(WithInjectedState[StateWithSkips], WithInjectedId):
+    """
+    Retrieve the results of finished buffer jobs (submitted with submit_buffer). Returns each finished
+    buffer's prover outcome plus a status board: which buffers are complete, still running, or need
+    (re)submission. By default it does NOT block — it returns whatever has finished so far (possibly
+    nothing), so you can go author or submit other buffers instead of waiting. Pass wait=true ONLY when
+    you have no other work: every buffer submitted and running, with no finished result left to process;
+    it then sleeps until the next job finishes.
+    """
+    wait: bool = Field(
+        default=False,
+        description="Block until the next job finishes. Set true ONLY when you have no other work: "
+        "every buffer is submitted and running and you have no finished result left to process. "
+        "Leave false to take whatever has finished so far without waiting.",
+    )
 
 
 @dataclass
@@ -725,15 +735,8 @@ def get_prover_tool(
                 all_rules=list(buffers[name].owned_rules),
             )
 
-        submit_schema = create_model(
-            "SubmitBuffer", __doc__=_SUBMIT_BUFFER_DESCRIPTION,
-            name=(str, Field(description="The run-target buffer to submit for verification.")),
-            state=(Annotated[StateWithSkips, InjectedState], ...),
-            tool_call_id=(Annotated[str, InjectedToolCallId], ...),
-        )
-
         @tool_display("Submitting buffer", None)
-        @tool(args_schema=submit_schema)
+        @tool(args_schema=_SubmitBufferArgs)
         async def submit_buffer(**args) -> str | Command:
             state: StateWithSkips = args["state"]
             name: str = args["name"]
@@ -775,20 +778,8 @@ def get_prover_tool(
                 f"Running: {running}. Call collect_results to retrieve results as jobs finish."
             )
 
-        collect_schema = create_model(
-            "CollectResults", __doc__=_COLLECT_RESULTS_DESCRIPTION,
-            wait=(bool, Field(
-                default=False,
-                description="Block until the next job finishes. Set true ONLY when you have no other work: "
-                "every buffer is submitted and running and you have no finished result left to process. "
-                "Leave false to take whatever has finished so far without waiting.",
-            )),
-            state=(Annotated[StateWithSkips, InjectedState], ...),
-            tool_call_id=(Annotated[str, InjectedToolCallId], ...),
-        )
-
         @tool_display("Collecting prover results", None)
-        @tool(args_schema=collect_schema)
+        @tool(args_schema=_CollectResultsArgs)
         async def collect_results(**args) -> str | Command:
             state: StateWithSkips = args["state"]
             tool_call_id: str = args["tool_call_id"]

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -57,7 +57,7 @@ from composer.spec.gen_types import CERTORA_DIR, SPECS_DIR
 from composer.spec.util import string_hash
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.spec.source.spec_buffers import (
-    NamedBuffer, SpecBuffersExtra, buffer_state_digest, duplicated_declarations, run_targets,
+    NamedBuffer, SpecBuffersExtra, buffer_state_digest, run_targets,
 )
 
 
@@ -731,9 +731,6 @@ def get_prover_tool(
         buffer_jobs: dict[tuple[str, str], _BufJob] = {}
         done_queue: asyncio.Queue[_BufDone] = asyncio.Queue()
         submit_counts: dict[str, int] = {}
-        # Declarations already flagged as duplicated-across-buffers, so collect_results nags about each at
-        # most once per run (advisory only — the agent may hoist them to a shared buffer or ignore).
-        reported_dupes: set[str] = set()
 
         async def _run_buffer_job(
             *, name: str, digest: str, label: str, buffers: Mapping[str, NamedBuffer],
@@ -843,6 +840,7 @@ def get_prover_tool(
             # sibling subsets at the *current* digest are the parallel stripes and stay running.
             for (nm, sk), j in list(buffer_jobs.items()):
                 if nm == name and j.digest != digest and not j.task.done():
+                    # TODO: this cancels the local task only; the cloud prover job itself keeps running.
                     j.task.cancel()
                     buffer_jobs.pop((nm, sk), None)
 
@@ -957,14 +955,6 @@ def get_prover_tool(
                 f"[buffers] running: {sorted(running)}",
                 f"[buffers] needs (re)submission: {sorted(needs_submit)}",
             ]
-            # Advisory: flag declarations duplicated verbatim across run-target buffers (once each) — likely
-            # belong in a shared buffer the duplicating buffers import.
-            fresh_dupes = {d: ns for d, ns in duplicated_declarations(buffers).items() if d not in reported_dupes}
-            if fresh_dupes:
-                reported_dupes.update(fresh_dupes)
-                board.append("[buffers] NOTE: these declarations are duplicated across run-target buffers — "
-                             "consider moving each to a shared buffer the duplicating buffers import:")
-                board.extend(f"  {d}  (in {ns})" for d, ns in fresh_dupes.items())
             if not drained:
                 parts.append("No finished jobs yet." if running else "No finished jobs and nothing running.")
 

--- a/composer/spec/source/prover.py
+++ b/composer/spec/source/prover.py
@@ -56,7 +56,7 @@ from composer.spec.gen_types import CERTORA_DIR, SPECS_DIR
 from composer.spec.util import string_hash
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.spec.source.spec_buffers import (
-    NamedBuffer, SpecBuffersExtra, buffer_state_digest, run_targets,
+    NamedBuffer, SpecBuffersExtra, buffer_state_digest, duplicated_declarations, run_targets,
 )
 
 
@@ -704,6 +704,9 @@ def get_prover_tool(
     buffer_jobs: dict[str, _BufJob] = {}
     done_queue: asyncio.Queue[_BufDone] = asyncio.Queue()
     submit_counts: dict[str, int] = {}
+    # Declarations already flagged as duplicated-across-buffers, so collect_results nags about each at
+    # most once per run (advisory only — the agent may hoist them to a shared buffer or ignore).
+    reported_dupes: set[str] = set()
 
     def component_of(state: StateWithSkips) -> str:
         """The label prefix for this generation's prover runs: its seeded spec stem, or the main
@@ -1064,6 +1067,14 @@ def get_prover_tool(
             f"[buffers] running: {sorted(running)}",
             f"[buffers] needs (re)submission: {sorted(needs_submit)}",
         ]
+        # Advisory: flag declarations duplicated verbatim across run-target buffers (once each) — likely
+        # belong in a shared buffer the duplicating buffers import.
+        fresh_dupes = {d: ns for d, ns in duplicated_declarations(buffers).items() if d not in reported_dupes}
+        if fresh_dupes:
+            reported_dupes.update(fresh_dupes)
+            board.append("[buffers] NOTE: these declarations are duplicated across run-target buffers — "
+                         "consider moving each to a shared buffer the duplicating buffers import:")
+            board.extend(f"  {d}  (in {ns})" for d, ns in fresh_dupes.items())
         if not drained:
             parts.append("No finished jobs yet." if running else "No finished jobs and nothing running.")
 

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -32,9 +32,10 @@ SPEC_BUFFERS_ENV = "AUTOPROVER_SPEC_BUFFERS"
 
 
 def spec_buffers_enabled() -> bool:
-    """Whether the multi-buffer authoring tools are offered to the agent (opt-in). Off by default so
-    the single ``curr_spec`` flow is untouched until multi-buffer is fully wired (publish, report)."""
-    return os.environ.get(SPEC_BUFFERS_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+    """Whether the multi-buffer authoring tools are offered to the agent — ``true`` enables, anything
+    else (unset or ``false``) leaves the single ``curr_spec`` flow untouched. A boolean feature switch,
+    not a buffer count: how many buffers the agent creates is a runtime decision."""
+    return os.environ.get(SPEC_BUFFERS_ENV, "").strip().lower() == "true"
 
 
 class NamedBuffer(BaseModel):

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -128,6 +128,18 @@ def run_targets(buffers: Mapping[str, NamedBuffer]) -> list[NamedBuffer]:
     return [buffers[n] for n in sorted(buffers) if buffers[n].is_run_target]
 
 
+def combined_buffers_view(buffers: Mapping[str, NamedBuffer]) -> str:
+    """All buffers (shared and run-target) concatenated into one reviewable document, each under a
+    header. For a judge or report that consumes the spec as a single text — NOT for verification
+    (each buffer is compiled and run separately)."""
+    parts: list[str] = []
+    for name in sorted(buffers):
+        b = buffers[name]
+        kind = "run-target" if b.is_run_target else "shared"
+        parts.append(f"// ===== buffer {name} ({kind}) =====\n{b.cvl.rstrip()}")
+    return "\n\n".join(parts)
+
+
 def validate_coverage(
     buffers: Mapping[str, NamedBuffer], *, all_properties: set[str], skipped: set[str]
 ) -> str | None:

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -1,0 +1,146 @@
+"""Multi-buffer CVL specs: the agent authors several independent spec buffers that share
+infrastructure through CVL ``import``.
+
+Policy-neutral substrate for generalizing the single ``curr_spec`` buffer
+(:mod:`composer.authoring.buffer`) into a named *set* of buffers. A *run-target* buffer is a
+self-contained spec — its own rules, its ``methods{}`` block, and ``import`` statements pulling in
+shared buffers — verified and reviewed on its own. A *shared* buffer holds common ghosts, invariants,
+and models that run-target buffers import; it runs no rules itself. Every non-skipped property is
+owned by exactly one run-target buffer, and every rule lives in exactly one buffer.
+
+Each buffer has a content *digest* over its own text plus its transitive import closure (reusing the
+autosetup content-cache hashing). Editing a shared buffer therefore changes the digest of every buffer
+that imports it, which is what lets the pipeline skip re-verifying / re-reviewing an unchanged buffer
+while correctly invalidating its importers.
+
+(``NamedBuffer`` is the value object — one buffer's text plus metadata — distinct from
+:class:`composer.authoring.buffer.SpecBuffer`, which is the single-buffer *state* shape.)
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+from typing_extensions import TypedDict
+
+from certora_autosetup.cache.content_cache import hash_content_parts, hash_text
+
+
+class NamedBuffer(BaseModel):
+    """One named CVL spec buffer the agent authors. Frozen and pydantic so it is both the substrate's
+    algorithm type and the shape stored (serializably) in graph state."""
+
+    model_config = {"frozen": True}
+
+    #: Stable identifier; also the on-disk stem when the buffer is materialized to a ``.spec`` file.
+    name: str
+    #: The buffer's own CVL text — its rules, its ``methods{}`` block, and its ``import`` statements.
+    cvl: str
+    #: For a run-target buffer, its property -> rule mapping: each property title it verifies -> the
+    #: rule/invariant names in ``cvl`` that verify it. Empty for a shared (imported-only) buffer.
+    property_rules: dict[str, list[str]] = Field(default_factory=dict)
+    #: Names of the buffers this one imports (its shared dependencies), used to build the digest
+    #: closure. Should track the actual ``import`` statements in ``cvl``.
+    imports: tuple[str, ...] = ()
+    #: False for a shared buffer that only supplies imports and runs no rules of its own.
+    is_run_target: bool = True
+
+    @property
+    def properties(self) -> frozenset[str]:
+        """The property titles this buffer covers (the keys of ``property_rules``)."""
+        return frozenset(self.property_rules)
+
+    @property
+    def owned_rules(self) -> frozenset[str]:
+        """The rules this buffer verifies (the union of its ``property_rules`` values)."""
+        return frozenset(r for rs in self.property_rules.values() for r in rs)
+
+
+def merge_buffers(
+    left: Mapping[str, NamedBuffer], right: Mapping[str, "NamedBuffer | None"]
+) -> dict[str, NamedBuffer]:
+    """State reducer for the buffers map: right-wins per name; a ``None`` value removes that buffer
+    (so a tool can merge/drop buffers). Granularity is the whole buffer — a tool that edits one
+    buffer's text passes the updated :class:`NamedBuffer` under its name."""
+    out = dict(left)
+    for name, val in right.items():
+        if val is None:
+            out.pop(name, None)
+        else:
+            out[name] = val
+    return out
+
+
+class SpecBuffersExtra(TypedDict):
+    """Graph-state slice holding the agent's spec buffers, keyed by name. Empty until the agent
+    creates buffers; a single run-target buffer is the behavior-preserving single-spec case."""
+
+    buffers: Annotated[dict[str, NamedBuffer], merge_buffers]
+
+
+def import_closure(buffers: Mapping[str, NamedBuffer], name: str) -> list[NamedBuffer]:
+    """Buffer ``name`` plus every buffer reachable through its ``imports``, transitively — deduped and
+    returned sorted by name. An import naming no known buffer is skipped here (a dangling import is a
+    coverage/validation concern, not a hashing one), and import cycles terminate safely."""
+    seen: set[str] = set()
+    stack = [name]
+    while stack:
+        n = stack.pop()
+        if n in seen or n not in buffers:
+            continue
+        seen.add(n)
+        stack.extend(buffers[n].imports)
+    return [buffers[n] for n in sorted(seen)]
+
+
+def buffer_digest(
+    buffers: Mapping[str, NamedBuffer], name: str, *, extra_parts: Sequence[str] = ()
+) -> str:
+    """A content digest of buffer ``name`` and its transitive import closure, plus any ``extra_parts``
+    (e.g. skipped-property or conf-flag markers). Editing the buffer OR any buffer it imports changes
+    the digest, so it keys the buffer's cached verify/review. Mirrors
+    :meth:`ContentCache.compute_cache_key` (content-keyed, order-independent)."""
+    parts = [f"{b.name}:{hash_text(b.cvl)}" for b in import_closure(buffers, name)]
+    parts += [f"extra:{p}" for p in extra_parts]
+    return hash_content_parts(parts)
+
+
+def run_targets(buffers: Mapping[str, NamedBuffer]) -> list[NamedBuffer]:
+    """The run-target buffers (those that verify rules), sorted by name."""
+    return [buffers[n] for n in sorted(buffers) if buffers[n].is_run_target]
+
+
+def validate_coverage(
+    buffers: Mapping[str, NamedBuffer], *, all_properties: set[str], skipped: set[str]
+) -> str | None:
+    """Whether the run-target buffers cover the property space exactly once — the publish-time contract:
+    every non-skipped property assigned to exactly one buffer, and no unknown or skipped property
+    assigned. Returns None when valid, else one message enumerating every problem."""
+    assigned: list[str] = [p for b in run_targets(buffers) for p in b.properties]
+    seen: set[str] = set()
+    duplicated: set[str] = set()
+    for p in assigned:
+        (duplicated if p in seen else seen).add(p)
+    required = all_properties - skipped
+    problems: list[str] = []
+    if duplicated:
+        problems.append(f"properties assigned to more than one buffer: {sorted(duplicated)}")
+    if missing := required - seen:
+        problems.append(f"non-skipped properties assigned to no buffer: {sorted(missing)}")
+    if unknown := seen - all_properties:
+        problems.append(f"unknown property titles: {sorted(unknown)}")
+    if skipped_assigned := seen & skipped:
+        problems.append(f"skipped properties should not be assigned to a buffer: {sorted(skipped_assigned)}")
+    return "; ".join(problems) if problems else None
+
+
+def validate_disjoint_rules(buffers: Mapping[str, NamedBuffer]) -> str | None:
+    """Whether every rule is owned by exactly one run-target buffer. Unlike overlay groups, buffers
+    hold their rules physically, so a rule name appearing in two buffers is an authoring mistake
+    (ambiguous ownership). Returns None when disjoint, else a message naming the shared rules."""
+    seen: set[str] = set()
+    dup: set[str] = set()
+    for b in run_targets(buffers):
+        for r in b.owned_rules:
+            (dup if r in seen else seen).add(r)
+    return f"rules owned by more than one buffer: {sorted(dup)}" if dup else None

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -17,6 +17,7 @@ while correctly invalidating its importers.
 :class:`composer.authoring.buffer.SpecBuffer`, which is the single-buffer *state* shape.)
 """
 
+import os
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Annotated
@@ -25,6 +26,15 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from certora_autosetup.cache.content_cache import hash_content_parts, hash_text
+
+
+SPEC_BUFFERS_ENV = "AUTOPROVER_SPEC_BUFFERS"
+
+
+def spec_buffers_enabled() -> bool:
+    """Whether the multi-buffer authoring tools are offered to the agent (opt-in). Off by default so
+    the single ``curr_spec`` flow is untouched until multi-buffer is fully wired (publish, report)."""
+    return os.environ.get(SPEC_BUFFERS_ENV, "").strip().lower() in ("1", "true", "yes", "on")
 
 
 class NamedBuffer(BaseModel):

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -128,6 +128,60 @@ def run_targets(buffers: Mapping[str, NamedBuffer]) -> list[NamedBuffer]:
     return [buffers[n] for n in sorted(buffers) if buffers[n].is_run_target]
 
 
+def buffer_state_digest(
+    buffers: Mapping[str, NamedBuffer],
+    name: str,
+    *,
+    skipped: Sequence[tuple[str, str]],
+    version_history: Sequence[str],
+) -> str:
+    """The per-buffer analogue of ``spec_digest``: a buffer's content + import closure bound to the
+    current authoring state (skip declarations as ``(title, reason)`` pairs, and the applied-edit
+    history). Every per-buffer stamp — feedback and prover — and the completion check key off this, so
+    editing the buffer, anything it imports, a skip, or the source invalidates that buffer's stamps."""
+    return buffer_digest(
+        buffers, name,
+        extra_parts=[
+            *(f"skip:{t}:{r}" for (t, r) in sorted(skipped)),
+            *(f"edit:{e}" for e in version_history),
+        ],
+    )
+
+
+def check_buffer_completion(
+    buffers: Mapping[str, NamedBuffer],
+    validations: Mapping[str, str],
+    required_validations: Sequence[str],
+    *,
+    skipped: Sequence[tuple[str, str]],
+    version_history: Sequence[str],
+) -> str | None:
+    """None if every run-target buffer carries each required validation (e.g. ``feedback``, ``prover``)
+    stamped at its current digest, else the first buffer/validation missing or stale. The buffers
+    analogue of ``check_completion``: a per-buffer stamp is keyed ``"<validation>:<buffer>"`` and goes
+    stale when that buffer (or anything it imports, or the skips/edit history) changes."""
+    targets = run_targets(buffers)
+    if not targets:
+        return "Completion REJECTED: no run-target buffers."
+    for b in targets:
+        d = buffer_state_digest(buffers, b.name, skipped=skipped, version_history=version_history)
+        for key in required_validations:
+            if validations.get(f"{key}:{b.name}") != d:
+                return f"Completion REJECTED: buffer {b.name!r} {key} validation not satisfied or stale."
+    return None
+
+
+def buffer_review_text(buffers: Mapping[str, NamedBuffer], name: str) -> str:
+    """One buffer's reviewable text for the judge: the buffer plus its transitive import closure, each
+    under a header marking the one under review vs its imports — so the judge sees the buffer in the
+    context it is actually verified in, without the unrelated buffers."""
+    parts: list[str] = []
+    for b in import_closure(buffers, name):
+        role = "under review" if b.name == name else "imported"
+        parts.append(f"// ===== buffer {b.name} ({role}) =====\n{b.cvl.rstrip()}")
+    return "\n\n".join(parts)
+
+
 def combined_buffers_view(buffers: Mapping[str, NamedBuffer]) -> str:
     """All buffers (shared and run-target) concatenated into one reviewable document, each under a
     header. For a judge or report that consumes the spec as a single text — NOT for verification

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -17,7 +17,8 @@ while correctly invalidating its importers.
 :class:`composer.authoring.buffer.SpecBuffer`, which is the single-buffer *state* shape.)
 """
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Annotated
 
 from pydantic import BaseModel, Field
@@ -105,6 +106,13 @@ def buffer_digest(
     return hash_content_parts(parts)
 
 
+def buffer_files(buffers: Mapping[str, NamedBuffer], name: str) -> dict[str, str]:
+    """The ``.spec`` files to materialize in order to run buffer ``name``: the buffer itself plus its
+    transitive import closure, each as ``"{buffer_name}.spec" -> its CVL``. A buffer's own
+    ``import "X.spec"`` lines resolve against these siblings written into the same directory."""
+    return {f"{b.name}.spec": b.cvl for b in import_closure(buffers, name)}
+
+
 def run_targets(buffers: Mapping[str, NamedBuffer]) -> list[NamedBuffer]:
     """The run-target buffers (those that verify rules), sorted by name."""
     return [buffers[n] for n in sorted(buffers) if buffers[n].is_run_target]
@@ -132,6 +140,34 @@ def validate_coverage(
     if skipped_assigned := seen & skipped:
         problems.append(f"skipped properties should not be assigned to a buffer: {sorted(skipped_assigned)}")
     return "; ".join(problems) if problems else None
+
+
+@dataclass(frozen=True)
+class BufferRun:
+    """One run-target buffer's execution decision for a verify pass."""
+
+    buffer: NamedBuffer
+    #: The buffer's current content digest (its text + import closure); keys its completion history.
+    digest: str
+    #: False when the buffer is already complete at this digest, so its prover run is skipped.
+    needs_run: bool
+
+
+def plan_buffer_runs(
+    buffers: Mapping[str, NamedBuffer],
+    *,
+    digest_of: Callable[[NamedBuffer], str],
+    is_complete: Callable[[NamedBuffer, str], bool],
+) -> list[BufferRun]:
+    """Decide, per run-target buffer, whether this verify pass must (re-)run it. A buffer already
+    complete at its current digest is skipped; editing it or any buffer it imports changes the digest
+    (:func:`buffer_digest`) and forces a re-run. ``digest_of`` and ``is_complete`` are injected so this
+    stays pure — the prover layer supplies the history-backed checks."""
+    plan: list[BufferRun] = []
+    for b in run_targets(buffers):
+        d = digest_of(b)
+        plan.append(BufferRun(buffer=b, digest=d, needs_run=not is_complete(b, d)))
+    return plan
 
 
 def validate_disjoint_rules(buffers: Mapping[str, NamedBuffer]) -> str | None:

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -27,14 +27,23 @@ from typing_extensions import TypedDict
 from certora_autosetup.cache.content_cache import hash_content_parts, hash_text
 
 
-SPEC_BUFFERS_ENV = "AUTOPROVER_SPEC_BUFFERS"
+MAX_SPEC_BUFFERS_ENV = "AUTOPROVER_MAX_SPEC_BUFFERS"
+DEFAULT_MAX_SPEC_BUFFERS = 6
 
 
-def spec_buffers_enabled() -> bool:
-    """Whether the multi-buffer authoring tools are offered to the agent. On by default; set
-    ``AUTOPROVER_SPEC_BUFFERS=false`` to fall back to the single ``curr_spec`` flow. A boolean feature
-    switch, not a buffer count: how many buffers the agent creates is a runtime decision."""
-    return os.environ.get(SPEC_BUFFERS_ENV, "true").strip().lower() != "false"
+def max_spec_buffers() -> int:
+    """The most run-target buffers the agent may create. Multi-buffer authoring is the only mode; this
+    caps how far the agent partitions. A cap of 1 is effectively the single-spec case (one run-target
+    buffer). Overridable via ``AUTOPROVER_MAX_SPEC_BUFFERS``; a non-integer or <1 value falls back to
+    the default."""
+    raw = os.environ.get(MAX_SPEC_BUFFERS_ENV)
+    if raw is None:
+        return DEFAULT_MAX_SPEC_BUFFERS
+    try:
+        n = int(raw.strip())
+    except ValueError:
+        return DEFAULT_MAX_SPEC_BUFFERS
+    return n if n >= 1 else DEFAULT_MAX_SPEC_BUFFERS
 
 
 class NamedBuffer(BaseModel):

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -31,10 +31,10 @@ SPEC_BUFFERS_ENV = "AUTOPROVER_SPEC_BUFFERS"
 
 
 def spec_buffers_enabled() -> bool:
-    """Whether the multi-buffer authoring tools are offered to the agent — ``true`` enables, anything
-    else (unset or ``false``) leaves the single ``curr_spec`` flow untouched. A boolean feature switch,
-    not a buffer count: how many buffers the agent creates is a runtime decision."""
-    return os.environ.get(SPEC_BUFFERS_ENV, "").strip().lower() == "true"
+    """Whether the multi-buffer authoring tools are offered to the agent. On by default; set
+    ``AUTOPROVER_SPEC_BUFFERS=false`` to fall back to the single ``curr_spec`` flow. A boolean feature
+    switch, not a buffer count: how many buffers the agent creates is a runtime decision."""
+    return os.environ.get(SPEC_BUFFERS_ENV, "true").strip().lower() != "false"
 
 
 class NamedBuffer(BaseModel):

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -29,6 +29,7 @@ from typing_extensions import TypedDict
 
 from certora_autosetup.cache.content_cache import hash_content_parts, hash_text
 from certora_autosetup.parsers.spec_imports import imports_in_cvl
+from composer.spec.cvl_generation import FEEDBACK_VALIDATION_KEY
 from composer.spec.gen_types import SPECS_DIR
 
 
@@ -182,18 +183,27 @@ def buffer_state_digest(
     *,
     skipped: Sequence[tuple[str, str]],
     version_history: Sequence[str],
+    include_claim: bool = False,
 ) -> str:
     """The per-buffer analogue of ``spec_digest``: a buffer's content + import closure bound to the
     current authoring state (skip declarations as ``(title, reason)`` pairs, and the applied-edit
     history). Every per-buffer stamp — feedback and prover — and the completion check key off this, so
-    editing the buffer, anything it imports, a skip, or the source invalidates that buffer's stamps."""
-    return buffer_digest(
-        buffers, name,
-        extra_parts=[
-            *(f"skip:{t}:{r}" for (t, r) in sorted(skipped)),
-            *(f"edit:{e}" for e in version_history),
-        ],
-    )
+    editing the buffer, anything it imports, a skip, or the source invalidates that buffer's stamps.
+
+    With ``include_claim`` the buffer's declared ``property_rules`` also key the digest, so re-assigning
+    a claim re-triggers review. The feedback stamp sets it (the judge reviews a buffer against the
+    properties it claims); the prover stamp leaves it False (a claim change does not affect what was
+    verified)."""
+    extra = [
+        *(f"skip:{t}:{r}" for (t, r) in sorted(skipped)),
+        *(f"edit:{e}" for e in version_history),
+    ]
+    if include_claim:
+        claim = ";".join(
+            f"{t}={','.join(rs)}" for t, rs in sorted(buffers[name].property_rules.items())
+        )
+        extra.append(f"claim:{claim}")
+    return buffer_digest(buffers, name, extra_parts=extra)
 
 
 def check_buffer_completion(
@@ -212,8 +222,13 @@ def check_buffer_completion(
     With no run-target buffers this is vacuously satisfied (there is nothing to stamp) — the
     all-properties-skipped case, whose validity is decided by ``validate_coverage`` instead."""
     for b in run_targets(buffers):
-        d = buffer_state_digest(buffers, b.name, skipped=skipped, version_history=version_history)
         for key in required_validations:
+            # The feedback stamp tracks a buffer's claimed properties (the judge reviews against them);
+            # the prover stamp does not.
+            d = buffer_state_digest(
+                buffers, b.name, skipped=skipped, version_history=version_history,
+                include_claim=(key == FEEDBACK_VALIDATION_KEY),
+            )
             if validations.get(f"{key}:{b.name}") != d:
                 return f"Completion REJECTED: buffer {b.name!r} {key} validation not satisfied or stale."
     return None

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -124,6 +124,12 @@ def buffer_digest(
     (e.g. skipped-property or conf-flag markers). Editing the buffer OR any buffer it imports changes
     the digest, so it keys the buffer's cached verify/review. Mirrors
     :meth:`ContentCache.compute_cache_key` (content-keyed, order-independent)."""
+    # TODO: a pure-comment edit (e.g. reframing a property's justification docstring) changes this
+    # digest and forces the prover to re-verify identical logic — a wasted job. A comment-stripped
+    # normalization would avoid that, but note this digest also keys the *feedback* review, and the
+    # judge legitimately reads justification comments — so stripping comments here would wrongly skip
+    # re-review after a comment-only edit. So find a solution to avoid running
+    # prover just because of comment-only change.
     parts = [f"{b.name}:{hash_text(b.cvl)}" for b in import_closure(buffers, name)]
     parts += [f"extra:{p}" for p in extra_parts]
     return hash_content_parts(parts)

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -18,6 +18,7 @@ while correctly invalidating its importers.
 """
 
 import os
+import re
 from collections.abc import Callable, Mapping, Sequence
 from typing import Annotated
 
@@ -100,8 +101,11 @@ class SpecBuffersExtra(TypedDict):
 
 def import_closure(buffers: Mapping[str, NamedBuffer], name: str) -> list[NamedBuffer]:
     """Buffer ``name`` plus every buffer reachable through its ``imports``, transitively — deduped and
-    returned sorted by name. An import naming no known buffer is skipped here (a dangling import is a
-    coverage/validation concern, not a hashing one), and import cycles terminate safely."""
+    returned sorted by name. A run-target buffer imports a shared (``is_run_target=false``) buffer only
+    when it declares it, so a shared buffer belongs to the closure (and invalidation set) of exactly the
+    run-targets that use it — that is what lets a subset of groups share a summary without invalidating
+    the others. An import naming no known buffer is skipped (a dangling import is a coverage concern, not
+    a hashing one), and cycles terminate safely."""
     seen: set[str] = set()
     stack = [name]
     while stack:
@@ -233,3 +237,42 @@ def validate_disjoint_rules(buffers: Mapping[str, NamedBuffer]) -> str | None:
         for r in b.owned_rules:
             (dup if r in seen else seen).add(r)
     return f"rules owned by more than one buffer: {sorted(dup)}" if dup else None
+
+
+_METHODS_BLOCK = re.compile(r"methods\s*\{([^}]*)\}", re.DOTALL)
+_GHOST_DECL = re.compile(r"\bghost\b[^;{]*;", re.DOTALL)
+
+
+def _normalize_decl(s: str) -> str:
+    """Strip comments and collapse whitespace so two textually-equivalent declarations compare equal."""
+    s = re.sub(r"/\*.*?\*/", "", s, flags=re.DOTALL)
+    s = re.sub(r"//[^\n]*", "", s)
+    return " ".join(s.split())
+
+
+def _extract_decls(cvl: str) -> set[str]:
+    """The `methods{}` entries and simple `ghost` declarations in ``cvl``, normalized. A light-regex
+    heuristic: ``methods`` entries are split on ``;`` within each block; ghost decls are single-statement
+    (axiom-block ghosts and multi-line CVL function *bodies* are not extracted). Good enough to flag
+    verbatim copy-paste across buffers, not a CVL parser."""
+    decls: set[str] = set()
+    for block in _METHODS_BLOCK.findall(cvl):
+        for entry in block.split(";"):
+            n = _normalize_decl(entry)
+            if n.startswith("function "):
+                decls.add(n + ";")
+    for g in _GHOST_DECL.findall(cvl):
+        decls.add(_normalize_decl(g))
+    return decls
+
+
+def duplicated_declarations(buffers: Mapping[str, NamedBuffer]) -> dict[str, list[str]]:
+    """Declarations (``methods{}`` entries / simple ghost decls) that appear verbatim in more than one
+    run-target buffer — copy-paste that likely belongs in a shared buffer the duplicating buffers import.
+    Returns ``{declaration: sorted buffer names}`` for each duplicated declaration (heuristic, text-based;
+    see :func:`_extract_decls`)."""
+    where: dict[str, list[str]] = {}
+    for b in run_targets(buffers):
+        for decl in _extract_decls(b.cvl):
+            where.setdefault(decl, []).append(b.name)
+    return {d: sorted(names) for d, names in where.items() if len(names) > 1}

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -19,7 +19,6 @@ while correctly invalidating its importers.
 
 import os
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
 from typing import Annotated
 
 from pydantic import BaseModel, Field
@@ -215,38 +214,10 @@ def validate_coverage(
     return "; ".join(problems) if problems else None
 
 
-@dataclass(frozen=True)
-class BufferRun:
-    """One run-target buffer's execution decision for a verify pass."""
-
-    buffer: NamedBuffer
-    #: The buffer's current content digest (its text + import closure); keys its completion history.
-    digest: str
-    #: False when the buffer is already complete at this digest, so its prover run is skipped.
-    needs_run: bool
-
-
-def plan_buffer_runs(
-    buffers: Mapping[str, NamedBuffer],
-    *,
-    digest_of: Callable[[NamedBuffer], str],
-    is_complete: Callable[[NamedBuffer, str], bool],
-) -> list[BufferRun]:
-    """Decide, per run-target buffer, whether this verify pass must (re-)run it. A buffer already
-    complete at its current digest is skipped; editing it or any buffer it imports changes the digest
-    (:func:`buffer_digest`) and forces a re-run. ``digest_of`` and ``is_complete`` are injected so this
-    stays pure — the prover layer supplies the history-backed checks."""
-    plan: list[BufferRun] = []
-    for b in run_targets(buffers):
-        d = digest_of(b)
-        plan.append(BufferRun(buffer=b, digest=d, needs_run=not is_complete(b, d)))
-    return plan
-
-
 def validate_disjoint_rules(buffers: Mapping[str, NamedBuffer]) -> str | None:
-    """Whether every rule is owned by exactly one run-target buffer. Unlike overlay groups, buffers
-    hold their rules physically, so a rule name appearing in two buffers is an authoring mistake
-    (ambiguous ownership). Returns None when disjoint, else a message naming the shared rules."""
+    """Whether every rule is owned by exactly one run-target buffer — a rule name appearing in two
+    buffers is an authoring mistake (ambiguous ownership). Returns None when disjoint, else a message
+    naming the shared rules."""
     seen: set[str] = set()
     dup: set[str] = set()
     for b in run_targets(buffers):

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from certora_autosetup.cache.content_cache import hash_content_parts, hash_text
+from certora_autosetup.parsers.spec_imports import imports_in_cvl
 
 
 MAX_SPEC_BUFFERS_ENV = "AUTOPROVER_MAX_SPEC_BUFFERS"
@@ -60,11 +61,19 @@ class NamedBuffer(BaseModel):
     #: For a run-target buffer, its property -> rule mapping: each property title it verifies -> the
     #: rule/invariant names in ``cvl`` that verify it. Empty for a shared (imported-only) buffer.
     property_rules: dict[str, list[str]] = Field(default_factory=dict)
-    #: Names of the buffers this one imports (its shared dependencies), used to build the digest
-    #: closure. Should track the actual ``import`` statements in ``cvl``.
-    imports: tuple[str, ...] = ()
     #: False for a shared buffer that only supplies imports and runs no rules of its own.
     is_run_target: bool = True
+
+    @property
+    def imports(self) -> tuple[str, ...]:
+        """The sibling-buffer names this buffer imports, derived from the ``import`` statements in
+        its ``cvl`` — a path'd resource import (e.g. ``"summaries/x.spec"``) is not a sibling buffer.
+        The CVL text is the single source of truth, so the digest closure can never disagree with
+        what the prover actually imports."""
+        return tuple(
+            t[: -len(".spec")] for t in imports_in_cvl(self.cvl)
+            if "/" not in t and t.endswith(".spec")
+        )
 
     @property
     def properties(self) -> frozenset[str]:

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -52,12 +52,12 @@ def max_spec_buffers() -> int:
 
 
 class NamedBuffer(BaseModel):
-    """One named CVL spec buffer the agent authors. Frozen and pydantic so it is both the substrate's
-    algorithm type and the shape stored (serializably) in graph state."""
+    """One named CVL spec buffer the agent authors. A frozen pydantic model, so the same type is both
+    what the buffer logic operates on and what is stored (serializably) in graph state."""
 
     model_config = {"frozen": True}
 
-    #: Stable identifier.
+    #: Stable identifier, and the key this buffer is stored under: ``buffers[nm].name == nm`` holds.
     name: str
     #: The buffer's own CVL text — its rules, its ``methods{}`` block, and its ``import`` statements.
     cvl: str
@@ -137,11 +137,11 @@ def buffer_imports(buffers: Mapping[str, NamedBuffer], name: str) -> tuple[str, 
 
 def import_closure(buffers: Mapping[str, NamedBuffer], name: str) -> list[NamedBuffer]:
     """Buffer ``name`` plus every buffer reachable through its imports, transitively — deduped and
-    returned sorted by name. A run-target buffer imports a shared (``is_run_target=false``) buffer only
-    when it does, so a shared buffer belongs to the closure (and invalidation set) of exactly the
-    run-targets that use it — that is what lets a subset of groups share a summary without invalidating
-    the others. An import resolving to no known buffer is skipped (a dangling/resource import is a
-    coverage concern, not a hashing one), and cycles terminate safely."""
+    returned sorted by name. A shared (``is_run_target=false``) buffer is in a run-target's closure only
+    if that run-target transitively imports it, so a shared buffer belongs to the closure (and
+    invalidation set) of exactly the run-targets that use it — that is what lets a subset of groups share
+    a summary without invalidating the others. An import resolving to no known buffer is skipped (a
+    dangling/resource import is a coverage concern, not a hashing one), and cycles terminate safely."""
     seen: set[str] = set()
     stack = [name]
     while stack:
@@ -312,7 +312,9 @@ def duplicated_declarations(buffers: Mapping[str, NamedBuffer]) -> dict[str, lis
     """Declarations (``methods{}`` entries / simple ghost decls) that appear verbatim in more than one
     run-target buffer — copy-paste that likely belongs in a shared buffer the duplicating buffers import.
     Returns ``{declaration: sorted buffer names}`` for each duplicated declaration (heuristic, text-based;
-    see :func:`_extract_decls`)."""
+    see :func:`_extract_decls`). Because it compares only the declaration text, it can false-positive:
+    two identical summary entries like ``function _.transfer() => cvlTransfer();`` are flagged even when
+    the CVL function ``cvlTransfer()`` they point at is defined differently in each buffer."""
     where: dict[str, list[str]] = {}
     for b in run_targets(buffers):
         for decl in _extract_decls(b.cvl):

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -117,13 +117,6 @@ def buffer_digest(
     return hash_content_parts(parts)
 
 
-def buffer_files(buffers: Mapping[str, NamedBuffer], name: str) -> dict[str, str]:
-    """The ``.spec`` files to materialize in order to run buffer ``name``: the buffer itself plus its
-    transitive import closure, each as ``"{buffer_name}.spec" -> its CVL``. A buffer's own
-    ``import "X.spec"`` lines resolve against these siblings written into the same directory."""
-    return {f"{b.name}.spec": b.cvl for b in import_closure(buffers, name)}
-
-
 def run_targets(buffers: Mapping[str, NamedBuffer]) -> list[NamedBuffer]:
     """The run-target buffers (those that verify rules), sorted by name."""
     return [buffers[n] for n in sorted(buffers) if buffers[n].is_run_target]
@@ -172,27 +165,30 @@ def check_buffer_completion(
     return None
 
 
+def _render_buffers(ordered: Sequence[NamedBuffer], label: Callable[[NamedBuffer], str]) -> str:
+    """The given buffers concatenated into one document, each under a ``// ===== buffer <name>
+    (<label>) =====`` header. For a judge or report that consumes the spec as a single text — NOT for
+    verification (each buffer is compiled and run separately)."""
+    return "\n\n".join(
+        f"// ===== buffer {b.name} ({label(b)}) =====\n{b.cvl.rstrip()}" for b in ordered
+    )
+
+
 def buffer_review_text(buffers: Mapping[str, NamedBuffer], name: str) -> str:
-    """One buffer's reviewable text for the judge: the buffer plus its transitive import closure, each
-    under a header marking the one under review vs its imports — so the judge sees the buffer in the
-    context it is actually verified in, without the unrelated buffers."""
-    parts: list[str] = []
-    for b in import_closure(buffers, name):
-        role = "under review" if b.name == name else "imported"
-        parts.append(f"// ===== buffer {b.name} ({role}) =====\n{b.cvl.rstrip()}")
-    return "\n\n".join(parts)
+    """One buffer's reviewable text for the judge: the buffer plus its transitive import closure, so
+    the judge sees it in the context it is actually verified in, without the unrelated buffers."""
+    return _render_buffers(
+        import_closure(buffers, name),
+        lambda b: "under review" if b.name == name else "imported",
+    )
 
 
 def combined_buffers_view(buffers: Mapping[str, NamedBuffer]) -> str:
-    """All buffers (shared and run-target) concatenated into one reviewable document, each under a
-    header. For a judge or report that consumes the spec as a single text — NOT for verification
-    (each buffer is compiled and run separately)."""
-    parts: list[str] = []
-    for name in sorted(buffers):
-        b = buffers[name]
-        kind = "run-target" if b.is_run_target else "shared"
-        parts.append(f"// ===== buffer {name} ({kind}) =====\n{b.cvl.rstrip()}")
-    return "\n\n".join(parts)
+    """All buffers (shared and run-target) concatenated into one reviewable document."""
+    return _render_buffers(
+        [buffers[n] for n in sorted(buffers)],
+        lambda b: "run-target" if b.is_run_target else "shared",
+    )
 
 
 def validate_coverage(

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -18,15 +18,18 @@ while correctly invalidating its importers.
 """
 
 import os
+import posixpath
 import re
 from collections.abc import Callable, Mapping, Sequence
+from pathlib import PurePosixPath
 from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing_extensions import TypedDict
 
 from certora_autosetup.cache.content_cache import hash_content_parts, hash_text
 from certora_autosetup.parsers.spec_imports import imports_in_cvl
+from composer.spec.gen_types import SPECS_DIR
 
 
 MAX_SPEC_BUFFERS_ENV = "AUTOPROVER_MAX_SPEC_BUFFERS"
@@ -54,26 +57,35 @@ class NamedBuffer(BaseModel):
 
     model_config = {"frozen": True}
 
-    #: Stable identifier; also the on-disk stem when the buffer is materialized to a ``.spec`` file.
+    #: Stable identifier.
     name: str
     #: The buffer's own CVL text — its rules, its ``methods{}`` block, and its ``import`` statements.
     cvl: str
+    #: Project-relative path of the ``.spec`` this buffer occupies — its identity for import
+    #: resolution: an ``import "<target>"`` in another buffer that resolves to this path depends on
+    #: this buffer (see :func:`buffer_imports`). The agent never sets this — it is not a ``put_buffer``
+    #: argument — and for now it is derived from ``name`` as ``SPECS_DIR/<name>.spec`` (see the
+    #: validator). It is a field rather than a computed property only as the hook for later letting the
+    #: *system* place a buffer elsewhere — notably overlaying an existing autosetup ``.spec`` so the
+    #: agent can edit it — without reshaping the type; resolution already keys on it. Lifting that stays
+    #: system-driven: it does not expose ``path`` to the agent.
+    path: str = ""
     #: For a run-target buffer, its property -> rule mapping: each property title it verifies -> the
     #: rule/invariant names in ``cvl`` that verify it. Empty for a shared (imported-only) buffer.
     property_rules: dict[str, list[str]] = Field(default_factory=dict)
     #: False for a shared buffer that only supplies imports and runs no rules of its own.
     is_run_target: bool = True
 
-    @property
-    def imports(self) -> tuple[str, ...]:
-        """The sibling-buffer names this buffer imports, derived from the ``import`` statements in
-        its ``cvl`` — a path'd resource import (e.g. ``"summaries/x.spec"``) is not a sibling buffer.
-        The CVL text is the single source of truth, so the digest closure can never disagree with
-        what the prover actually imports."""
-        return tuple(
-            t[: -len(".spec")] for t in imports_in_cvl(self.cvl)
-            if "/" not in t and t.endswith(".spec")
-        )
+    @model_validator(mode="before")
+    @classmethod
+    def _derive_path_from_name(cls, data):
+        # The agent never supplies a path (it is not a put_buffer argument), so for now every buffer's
+        # location is just derived from its name: SPECS_DIR/<name>.spec. To later let the SYSTEM place a
+        # buffer elsewhere (e.g. overlay an existing autosetup .spec), fill this only when a path is
+        # absent instead of deriving unconditionally — still not agent-controlled.
+        if isinstance(data, dict) and data.get("name"):
+            data = {**data, "path": (SPECS_DIR / f"{data['name']}.spec").as_posix()}
+        return data
 
     @property
     def properties(self) -> frozenset[str]:
@@ -108,13 +120,28 @@ class SpecBuffersExtra(TypedDict):
     buffers: Annotated[dict[str, NamedBuffer], merge_buffers]
 
 
+def buffer_imports(buffers: Mapping[str, NamedBuffer], name: str) -> tuple[str, ...]:
+    """The names of the sibling buffers ``name`` imports: each ``import "<target>"`` in its CVL,
+    resolved against where ``name`` is written (``buffers[name].path``), and looked up among the paths
+    the buffers occupy. A resolved path no buffer occupies — e.g. an autosetup summary under
+    ``specs/summaries/`` — is a resource, not a sibling, and is skipped. No string surgery: just path
+    resolution + a map lookup, mirroring how the prover resolves a spec's imports on disk."""
+    by_path = {posixpath.normpath(b.path): nm for nm, b in buffers.items()}
+    here = PurePosixPath(buffers[name].path).parent
+    out: list[str] = []
+    for target in imports_in_cvl(buffers[name].cvl):
+        if (nm := by_path.get(posixpath.normpath(str(here / target)))) is not None:
+            out.append(nm)
+    return tuple(out)
+
+
 def import_closure(buffers: Mapping[str, NamedBuffer], name: str) -> list[NamedBuffer]:
-    """Buffer ``name`` plus every buffer reachable through its ``imports``, transitively — deduped and
+    """Buffer ``name`` plus every buffer reachable through its imports, transitively — deduped and
     returned sorted by name. A run-target buffer imports a shared (``is_run_target=false``) buffer only
-    when it declares it, so a shared buffer belongs to the closure (and invalidation set) of exactly the
+    when it does, so a shared buffer belongs to the closure (and invalidation set) of exactly the
     run-targets that use it — that is what lets a subset of groups share a summary without invalidating
-    the others. An import naming no known buffer is skipped (a dangling import is a coverage concern, not
-    a hashing one), and cycles terminate safely."""
+    the others. An import resolving to no known buffer is skipped (a dangling/resource import is a
+    coverage concern, not a hashing one), and cycles terminate safely."""
     seen: set[str] = set()
     stack = [name]
     while stack:
@@ -122,7 +149,7 @@ def import_closure(buffers: Mapping[str, NamedBuffer], name: str) -> list[NamedB
         if n in seen or n not in buffers:
             continue
         seen.add(n)
-        stack.extend(buffers[n].imports)
+        stack.extend(buffer_imports(buffers, n))
     return [buffers[n] for n in sorted(seen)]
 
 

--- a/composer/spec/source/spec_buffers.py
+++ b/composer/spec/source/spec_buffers.py
@@ -94,7 +94,7 @@ def merge_buffers(
 
 class SpecBuffersExtra(TypedDict):
     """Graph-state slice holding the agent's spec buffers, keyed by name. Empty until the agent
-    creates buffers; a single run-target buffer is the behavior-preserving single-spec case."""
+    creates buffers; a single run-target buffer is the simple one-spec case."""
 
     buffers: Annotated[dict[str, NamedBuffer], merge_buffers]
 
@@ -171,11 +171,11 @@ def check_buffer_completion(
     """None if every run-target buffer carries each required validation (e.g. ``feedback``, ``prover``)
     stamped at its current digest, else the first buffer/validation missing or stale. The buffers
     analogue of ``check_completion``: a per-buffer stamp is keyed ``"<validation>:<buffer>"`` and goes
-    stale when that buffer (or anything it imports, or the skips/edit history) changes."""
-    targets = run_targets(buffers)
-    if not targets:
-        return "Completion REJECTED: no run-target buffers."
-    for b in targets:
+    stale when that buffer (or anything it imports, or the skips/edit history) changes.
+
+    With no run-target buffers this is vacuously satisfied (there is nothing to stamp) — the
+    all-properties-skipped case, whose validity is decided by ``validate_coverage`` instead."""
+    for b in run_targets(buffers):
         d = buffer_state_digest(buffers, b.name, skipped=skipped, version_history=version_history)
         for key in required_validations:
             if validations.get(f"{key}:{b.name}") != d:

--- a/composer/templates/property_generation_prompt.j2
+++ b/composer/templates/property_generation_prompt.j2
@@ -119,11 +119,10 @@ Similarly, you *must* have received positive feedback from the feedback judge on
 Like the prover tool, any changes to your state (include the spec, skip declarations, etc.) will invalidate
 the positive feedback result, and will necessitate "restamping".
 
-The `result` tool *also* requires a `property_rules` mapping: for every property you did NOT skip (referenced by
-its unique snake_case title from the batch listing above), list the name(s) of the rule(s)/invariant(s) in your
-spec that verify it. Every non-skipped property must appear in this mapping with at least one rule; skipped
-properties must NOT appear. The result tool will be rejected if this mapping is incomplete or references a
-skipped or unknown property title.
+Each run-target buffer declares its own property->rules mapping on `put_buffer`, so the `result` tool derives
+the published mapping from your buffers — you do not restate it. `result` is rejected unless every non-skipped
+property is owned by exactly one run-target buffer (and no skipped or unknown property is), so keep each
+buffer's `property_rules` complete and disjoint.
 
 To clarify: for your result to be accepted, all verification results from the prover must either be
 VERIFIED *or* that rule must be explicitly marked as "expected to fail" using the `expect_rule_failure` tool.

--- a/composer/templates/property_generation_system_prompt.j2
+++ b/composer/templates/property_generation_system_prompt.j2
@@ -5,24 +5,6 @@
 {% include "source_tools_system_prompt.j2" %}
 {% include "cvl_tools_system_prompt.j2" %}
 
-{% include "cvl_edit_guidance.j2" %}
-
-## Running the Prover
-
-The `verify_spec` tool runs the Certora prover on the current version of your spec against the
-source under verification, and reports a verdict (`VERIFIED`, `VIOLATED` with counterexample
-analysis, `TIMEOUT`, etc.) for each rule and invariant it ran.
-
-Its two optional arguments select which of the spec's declared rules/invariants the run executes;
-they are mutually exclusive:
-
-- **`rules`** — run only the named rules/invariants.
-- **`exclude_rules`** — run every declared rule/invariant *except* the named ones.
-
-With neither argument, the run executes every rule and invariant declared in the spec. Names in
-either list refer to the declarations in the current spec. `verify_spec` must be the only tool
-call in its turn.
-
 {% if source_editing %}
 ## Editing the Source Under Verification
 

--- a/composer/templates/property_generation_system_prompt.j2
+++ b/composer/templates/property_generation_system_prompt.j2
@@ -50,3 +50,5 @@ are good reasons to use this "expect failure" functionality:
   the rule failure is the intended result.
 2. Verifying the rule is hitting some limitation in the prover (including prover errors, etc.),
    and you have exhausted all reasonable alternative formulations to work around these prover limitations (errors, timeouts, imprecision).
+
+{% include "spec_buffers_guidance.j2" %}

--- a/composer/templates/spec_buffers_guidance.j2
+++ b/composer/templates/spec_buffers_guidance.j2
@@ -86,6 +86,12 @@ one):
   run-target buffers that depend on it.
 - `submit_buffer(name)` starts a buffer's prover job in the **background** and returns immediately.
   Submit each run-target buffer as soon as it and its shared imports are ready — they prove concurrently.
+- If one expensive rule in a multi-rule buffer holds up the cheap ones, stripe it off *without* splitting
+  the buffer: `submit_buffer(name, rule=[...])` runs just that subset and
+  `submit_buffer(name, exclude_rules=[...])` runs the rest — same compiled spec, proving in parallel,
+  their results combining (the buffer is done once every rule has been covered by some run). Split rules
+  into separate buffers when they differ in **precision** (summary needs); stripe by rule when they
+  differ only in **cost**.
 - `collect_results()` returns the outcomes of jobs that have **finished so far** (without blocking) plus
   a status board: which buffers are `complete`, `running`, or `needs (re)submission`. Process a finished
   buffer immediately — fix its issue if it has any (CEXs, timeouts, errors, ...) and `submit_buffer` it

--- a/composer/templates/spec_buffers_guidance.j2
+++ b/composer/templates/spec_buffers_guidance.j2
@@ -1,0 +1,104 @@
+## Splitting the spec into verification buffers
+
+Instead of one spec, you author several named CVL **buffers**, each a self-contained spec verified and
+reviewed on its own. Use `put_buffer` / `edit_buffer` / `get_buffer` / `list_buffers` / `delete_buffer`
+to author them, and `submit_buffer` / `collect_results` to verify them.
+
+**Strongly prefer splitting, and add over-approximating performance summaries preemptively.** A
+single spec has ONE global `methods{}` block, so every rule is verified under the *intersection* of
+what all rules need precise — one property that needs an expensive function kept exact forces EVERY
+rule to pay that cost, which is the usual source of a timeout. Splitting breaks that coupling: each
+buffer keeps precise only the expensive functions ITS properties need, and over-approximates the rest.
+
+Partition by **prover hotspots**, not by every function — most functions are cheap and should stay
+exact. The functions worth summarizing away (where a property does not need them) are the ones *toxic*
+to the prover's performance or precision:
+- heavy **nonlinear** arithmetic (variable `*` / `/` / exponentiation — not scaling by a constant);
+- non-trivial **bitwise** reasoning;
+- non-trivial **hashing** — ABI `encode`/`decode`, `keccak`;
+- non-trivial inline **assembly**;
+- **complex data structures**;
+- **external calls** the property does not need modeled;
+- **complex loops**, or heavy **branching** (path-count explosion).
+
+The method: (1) find these hotspots in the code the properties reach; (2) work out which properties
+genuinely need which hotspots *exact*; (3) group the properties into buffers on that basis, and in each
+buffer summarize the hotspots its own properties do not need exact. Do this partition up front — do not
+start with one monolithic buffer and wait for a timeout to force the split.
+
+When to split:
+- Properties have **conflicting precision needs** — one buffer can summarize a hotspot that another
+  keeps exact (each buffer has its own `methods{}`), with no global-methods-block conflict. This is
+  the primary axis: group the properties by the set of hotspots they genuinely need exact.
+- Separate **`assert`-only** properties (which can share aggressive over-approximations) from
+  **`satisfy`** properties (which need those functions exact) — see the soundness rule below.
+- To **isolate the hard/slow properties**: put the many easy properties in one buffer that verifies and
+  is approved once and never re-touched, while you iterate on a small hard buffer in isolation. Buffers
+  are verified, reviewed, and stamped independently, so once a buffer passes it is settled for the rest
+  of the run — you can ignore it and only the buffer you actually edit pays re-verification and re-review.
+
+Structuring buffers:
+- Put infrastructure shared by two or more run-target buffers (ghosts, common invariants, helper CVL
+  functions, token/oracle models, and summaries several groups need) in a buffer with
+  `is_run_target=false`, and `import "<shared>.spec"` it from **each run-target that uses it**. A shared
+  buffer is pulled in only by the buffers that import it, so
+  editing it re-verifies only those — you can make one shared buffer for a subset of groups and another
+  for a different subset. **Import the shared buffer where you need it; never restate its contents in a
+  run-target** (a duplicate `methods{}` entry or ghost is a compile error).
+- Each **run-target** buffer declares its `property_rules` (the properties it verifies + their rule
+  names). Across all run-target buffers, every non-skipped property must appear in **exactly one**
+  buffer, and each rule lives in exactly one buffer.
+
+Summaries — your main lever for tractability:
+- For each run-target buffer, **summarize now**, in its `methods{}`, the hotspot functions its
+  properties do not need exact (leave the cheap functions alone) — an over-approximation that *weakens*
+  the real body (a looser constraint on the return, or dropping an effect the buffer's properties never
+  read), written before the first `submit_buffer`. Keep every summary **sound**: a trivializing
+  `NONDET`/havoc that erases a
+  function's side effects is sound only for callees whose effects the buffer's properties never observe
+  (in practice `view`/`pure`). Before summarizing a state-mutating function, consult the
+  **CVL Summarization and Linking Guide** in your context for which summary constructs are sound for a
+  given function and how to write them.
+- **Soundness rule: an over-approximating summary is sound for `assert` rules but UNSOUND for `satisfy`
+  rules.** An over-approximation *adds* behaviors: an `assert` that holds over the larger behavior set
+  still holds over the real one (sound), whereas a `satisfy` may be witnessed only by an added, non-real
+  behavior (unsound — its witness need not correspond to a real execution). So over-approximate freely
+  in a buffer whose rules are **all `assert`**; in a buffer that contains any `satisfy` rule (or a
+  reachability check), keep the functions it exercises **exact**.
+- **Put each summary where it is USED.** A summary several run-target buffers need goes in a shared
+  buffer they each `import`; a summary only one buffer needs goes in *that* buffer's own `methods{}`. A
+  single-buffer summary parked in a shared buffer that others import makes every later edit re-verify all
+  of them — wasted work on buffers that never use it.
+- **Refine on a spurious counterexample.** A too-coarse over-approximation produces a *spurious* cex —
+  one reachable only because the summary admits behavior the real function cannot. When a buffer returns
+  VIOLATED, analyze the cex: if it hinges on behavior your summary allows but the real function forbids,
+  it is spurious → tighten that summary (add the missing constraint) or drop the over-approximation for
+  that function with `edit_buffer`, then re-`submit_buffer`. Start from the
+  simplest sound over-approximation and tighten only as spurious cexes force you to.
+
+Verifying — submit / collect (buffers prove in parallel; never wait on a slow buffer to work on a fast
+one):
+- **Settle the shared base before submitting anything that imports it.** Submit a run-target buffer only
+  once BOTH (i) you are done authoring that buffer AND (ii) every shared buffer it imports is likewise
+  done — the CVL is complete and you do not expect to edit it again. Editing a shared buffer after
+  submitting invalidates every buffer that imports it (submitted or already verified): those prover jobs
+  are wasted and must be re-run. So author and stabilize the shared infrastructure first, then submit the
+  run-target buffers that depend on it.
+- `submit_buffer(name)` starts a buffer's prover job in the **background** and returns immediately.
+  Submit each run-target buffer as soon as it and its shared imports are ready — they prove concurrently.
+- `collect_results()` returns the outcomes of jobs that have **finished so far** (without blocking) plus
+  a status board: which buffers are `complete`, `running`, or `needs (re)submission`. Process a finished
+  buffer immediately — fix its issue if it has any (CEXs, timeouts, errors, ...) and `submit_buffer` it
+  again — while the others keep proving.
+- Work this priority order, and only ever block at the last step:
+  1. A finished result not yet processed (a counterexample, but also a timeout, sanity failure, or
+     error) → handle it. Diagnose whether the fix belongs in this buffer or in a **shared** buffer it
+     imports (e.g. an under-approximation in shared infra). Once you edit a shared buffer, every buffer
+     importing it goes stale, so the board then lists them (including ones already verified) under `needs
+     (re)submission` — re-submit each. The board reflects that staleness only after your edit; it does
+     not infer that a result needs a shared fix.
+  2. Else a buffer still to author/submit → author it and `submit_buffer` it.
+  3. Else everything is submitted and running with nothing finished to process → call
+     `collect_results(wait=true)` to sleep until the next job finishes.
+- Editing a buffer (or a shared buffer it imports) makes its prior verification stale; re-submit it. A
+  buffer already verified at its current content is not re-run.

--- a/composer/ui/autoprove_app.py
+++ b/composer/ui/autoprove_app.py
@@ -26,7 +26,7 @@ from composer.spec.source.design_doc_finder import DesignDocChosenEvent
 
 
 # ---------------------------------------------------------------------------
-# Event type — events emitted by _SpecCallbacks (verify_spec tool)
+# Event type — events emitted by _SpecCallbacks (buffer prover jobs)
 # ---------------------------------------------------------------------------
 
 type AutoProveEvent = ProverOutputEvent | CloudPollingEvent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from pathlib import Path
 os.environ.setdefault("ANTHROPIC_API_KEY", "dummy-key-for-tests")
 from typing import Any, AsyncIterator, Iterator, Callable, Iterable, TYPE_CHECKING, Sequence
 from contextlib import asynccontextmanager
+import dataclasses
 from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
@@ -418,6 +419,17 @@ def certora_prover(
         # verify target "Dummy:certora/specs/<name>.spec" -> buffer name (the spec stem).
         return Path(conf["verify"].split(":", 1)[1]).stem
 
+    def _select_rules(resp: ProverToolResponse, conf: dict) -> ProverToolResponse:
+        # Mirror the prover's rule selection: keep only the rules the conf's rule/exclude_rule ask for.
+        if isinstance(resp, str) or ("rule" not in conf and "exclude_rule" not in conf):
+            return resp
+        if "rule" in conf:
+            keep = lambda rp: rp.rule in set(conf["rule"])
+        else:
+            keep = lambda rp: rp.rule not in set(conf["exclude_rule"])
+        selected = {rp: st for rp, st in resp.raw_rule_status.items() if keep(rp)}
+        return dataclasses.replace(resp, raw_rule_status=selected)
+
     async def mock_declared_rules(folder: Path, args: list[str]) -> list[str]:
         return SPEC_DECL_RE.findall(spec_of_prover_conf(folder, conf_of_prover_call(folder, args)))
 
@@ -429,7 +441,9 @@ def certora_prover(
         if buffer_responses:
             name = _buffer_of_conf(conf)
             assert name in buffer_responses, f"no buffer response for {name!r}"
-            return buffer_responses[name]
+            # Honour the conf's rule selection, as the real prover does: a rule-striped run reports only
+            # its selected rules, so completion has to union several runs.
+            return _select_rules(buffer_responses[name], conf)
         assert response_script is not None
         nonlocal response_ptr
         assert response_ptr < len(response_script)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -459,7 +459,7 @@ def certora_prover(
     def bind_buffers(responses_by_name: dict[str, ProverToolResponse]) -> list[BaseTool]:
         buffer_responses.clear()
         buffer_responses.update(responses_by_name)
-        return toolset.buffer_tools
+        return toolset.make_buffer_tools()
 
     return ProverMock(bind_tool, calls, bind_buffers)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -415,9 +415,8 @@ def certora_prover(
     calls: list[ProverCall] = []
 
     def _buffer_of_conf(conf: dict) -> str | None:
-        # verify target "Dummy:certora/specs/<name>__<tag>.spec" -> buffer name (stem before "__").
-        stem = Path(conf["verify"].split(":", 1)[1]).stem
-        return stem.rsplit("__", 1)[0] if "__" in stem else None
+        # verify target "Dummy:certora/specs/<name>.spec" -> buffer name (the spec stem).
+        return Path(conf["verify"].split(":", 1)[1]).stem
 
     async def mock_declared_rules(folder: Path, args: list[str]) -> list[str]:
         return SPEC_DECL_RE.findall(spec_of_prover_conf(folder, conf_of_prover_call(folder, args)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -382,12 +382,19 @@ class ProverMock:
         self,
         bind: Callable[[Iterable[ProverToolResponse]], BaseTool],
         calls: list[ProverCall],
+        bind_buffers: Callable[[dict[str, ProverToolResponse]], list[BaseTool]],
     ) -> None:
         self._bind = bind
         self.calls = calls
+        self._bind_buffers = bind_buffers
 
     def __call__(self, l: Iterable[ProverToolResponse]) -> BaseTool:
         return self._bind(l)
+
+    def buffers(self, responses_by_name: dict[str, ProverToolResponse]) -> list[BaseTool]:
+        """The multi-buffer submit_buffer / collect_results tools, wired to return ``responses_by_name``
+        keyed by buffer name (jobs run concurrently, so responses can't be order-scripted)."""
+        return self._bind_buffers(responses_by_name)
 
 
 @pytest.fixture
@@ -402,7 +409,15 @@ def certora_prover(
 ) -> ProverMock:
     response_script : list[ProverToolResponse] | None = None
     response_ptr = 0
+    # Per-buffer responses, keyed by buffer name (the multi-buffer submit/collect path). Keyed rather
+    # than ordered because buffer jobs run concurrently, so call order is nondeterministic.
+    buffer_responses: dict[str, ProverToolResponse] = {}
     calls: list[ProverCall] = []
+
+    def _buffer_of_conf(conf: dict) -> str | None:
+        # verify target "Dummy:certora/specs/<name>__<tag>.spec" -> buffer name (stem before "__").
+        stem = Path(conf["verify"].split(":", 1)[1]).stem
+        return stem.rsplit("__", 1)[0] if "__" in stem else None
 
     async def mock_declared_rules(folder: Path, args: list[str]) -> list[str]:
         return SPEC_DECL_RE.findall(spec_of_prover_conf(folder, conf_of_prover_call(folder, args)))
@@ -410,10 +425,15 @@ def certora_prover(
     async def mock_prover(
         folder: Path, args: list[str], *rest, **kwargs
     ) -> ProverToolResponse:
+        conf = conf_of_prover_call(folder, args)
+        calls.append(ProverCall(folder=folder, args=list(args), conf=conf))
+        if buffer_responses:
+            name = _buffer_of_conf(conf)
+            assert name in buffer_responses, f"no buffer response for {name!r}"
+            return buffer_responses[name]
         assert response_script is not None
         nonlocal response_ptr
         assert response_ptr < len(response_script)
-        calls.append(ProverCall(folder=folder, args=list(args), conf=conf_of_prover_call(folder, args)))
         to_ret = response_script[response_ptr]
         response_ptr += 1
         return to_ret
@@ -424,7 +444,7 @@ def certora_prover(
         lambda _: None
     ))
 
-    the_tool = get_prover_tool(
+    toolset = get_prover_tool(
         prover_opts=ProverOptions(),
         llm=fake_llm,
         main_contract="Dummy",
@@ -434,9 +454,14 @@ def certora_prover(
     def bind_tool(l: Iterable[ProverToolResponse]) -> BaseTool:
         nonlocal response_script
         response_script = list(l)
-        return the_tool
+        return toolset.verify_spec
 
-    return ProverMock(bind_tool, calls)
+    def bind_buffers(responses_by_name: dict[str, ProverToolResponse]) -> list[BaseTool]:
+        buffer_responses.clear()
+        buffer_responses.update(responses_by_name)
+        return toolset.buffer_tools
+
+    return ProverMock(bind_tool, calls, bind_buffers)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_buffer_completion.py
+++ b/tests/test_buffer_completion.py
@@ -1,0 +1,74 @@
+"""Per-buffer completion tracking: each buffer is judged complete over its own runs and digest."""
+
+from composer.prover.ptypes import RulePath
+from composer.spec.source.prover import (
+    NagMarker,
+    ProverHistoryItem,
+    ProverRunLog,
+    _history_for_buffer,
+    buffer_is_complete,
+)
+
+
+def _run(buffer: str, digest: str, results: list[tuple[str, str]]) -> ProverRunLog:
+    return ProverRunLog(
+        tool_call_id="t",
+        prover_results=[(RulePath(rule=r), s) for r, s in results],  # type: ignore[misc]
+        rules=None,
+        spec_digest="h",
+        sort="run",
+        declared_rules=[r for r, _ in results],
+        state_digest=digest,
+        buffer=buffer,
+    )
+
+
+def _complete(history, buffer, digest, all_rules, *, expected_to_fail: set[str] | frozenset[str] = frozenset()):
+    return buffer_is_complete(
+        history, buffer=buffer, curr_digest=digest,
+        expected_to_fail=set(expected_to_fail), curr_status=[], all_rules=all_rules,
+    )
+
+
+def test_complete_when_all_owned_verified():
+    h: list[ProverHistoryItem] = [_run("A", "dA", [("r1", "VERIFIED"), ("r2", "VERIFIED")])]
+    assert _complete(h, "A", "dA", ["r1", "r2"]) is True
+
+
+def test_incomplete_when_a_rule_not_verified():
+    h: list[ProverHistoryItem] = [_run("A", "dA", [("r1", "VERIFIED"), ("r2", "TIMEOUT")])]
+    assert _complete(h, "A", "dA", ["r1", "r2"]) is False
+
+
+def test_other_buffers_runs_do_not_affect_this_one():
+    # B's interleaved (newer) run at a different digest would truncate A's streak without the filter.
+    h: list[ProverHistoryItem] = [
+        _run("A", "dA", [("r1", "VERIFIED")]),
+        _run("B", "dB", [("r2", "VIOLATED")]),
+    ]
+    assert _complete(h, "A", "dA", ["r1"]) is True
+    assert _complete(h, "B", "dB", ["r2"]) is False
+
+
+def test_stale_digest_does_not_count():
+    # The buffer (or an import) was edited: the old run's digest no longer matches.
+    h: list[ProverHistoryItem] = [_run("A", "OLD", [("r1", "VERIFIED")])]
+    assert _complete(h, "A", "NEW", ["r1"]) is False
+
+
+def test_expected_to_fail_is_covered():
+    h: list[ProverHistoryItem] = [_run("A", "dA", [("r1", "VIOLATED")])]
+    assert _complete(h, "A", "dA", ["r1"], expected_to_fail={"r1"}) is True
+
+
+def test_history_for_buffer_keeps_nag_and_matching_runs():
+    nag = NagMarker(sort="nag", nagged_rules=[])
+    h: list[ProverHistoryItem] = [
+        _run("A", "dA", [("r1", "VERIFIED")]),
+        nag,
+        _run("B", "dB", [("r2", "VERIFIED")]),
+    ]
+    kept = _history_for_buffer(h, "A")
+    assert nag in kept
+    assert all(it["sort"] != "run" or it.get("buffer") == "A" for it in kept)
+    assert not any(it["sort"] == "run" and it.get("buffer") == "B" for it in kept)

--- a/tests/test_buffer_tools.py
+++ b/tests/test_buffer_tools.py
@@ -1,0 +1,47 @@
+"""Smoke + java-free logic tests for the multi-buffer authoring tools."""
+
+from langchain_core.tools import BaseTool
+
+from composer.spec.source.buffer_tools import (
+    WithBuffers,
+    delete_buffer,
+    edit_buffer,
+    get_buffer,
+    list_buffers,
+    put_buffer,
+)
+from composer.spec.source.spec_buffers import NamedBuffer
+
+
+def _state():
+    return {
+        "buffers": {
+            "shared": NamedBuffer(name="shared", cvl="ghost g(uint) returns uint;\n", is_run_target=False),
+            "easy": NamedBuffer(
+                name="easy", cvl="rule r_easy { assert true; }\n",
+                property_rules={"P-easy": ["r_easy"]}, imports=("shared",),
+            ),
+        }
+    }
+
+
+def test_all_factories_build():
+    for factory in (put_buffer, edit_buffer, get_buffer, list_buffers, delete_buffer):
+        assert isinstance(factory(WithBuffers), BaseTool)
+
+
+def test_get_buffer_returns_text_or_message():
+    tool = get_buffer(WithBuffers)
+    assert "r_easy" in tool.invoke({"state": _state(), "name": "easy"})
+    assert "No buffer" in tool.invoke({"state": _state(), "name": "nope"})
+
+
+def test_list_buffers_reports_kind_imports_and_rulecount():
+    out = list_buffers(WithBuffers).invoke({"state": _state()})
+    assert "easy (run-target, 1 rules" in out
+    assert "imports ['shared']" in out
+    assert "shared (shared, 0 rules)" in out
+
+
+def test_list_buffers_empty():
+    assert "No spec buffers" in list_buffers(WithBuffers).invoke({"state": {"buffers": {}}})

--- a/tests/test_buffer_tools.py
+++ b/tests/test_buffer_tools.py
@@ -45,3 +45,33 @@ def test_list_buffers_reports_kind_imports_and_rulecount():
 
 def test_list_buffers_empty():
     assert "No spec buffers" in list_buffers(WithBuffers).invoke({"state": {"buffers": {}}})
+
+
+def test_put_buffer_enforces_run_target_cap(monkeypatch):
+    # put_buffer validates via the CVL typechecker jar (absent in CI) before the cap check; bypass it.
+    monkeypatch.setattr("composer.spec.source.buffer_tools.cvl_syntax_error", lambda *a, **k: None)
+    monkeypatch.setenv("AUTOPROVER_MAX_SPEC_BUFFERS", "2")
+    tool = put_buffer(WithBuffers)
+    state = {"buffers": {
+        "a": NamedBuffer(name="a", cvl="rule ra { assert true; }\n", property_rules={"P-a": ["ra"]}),
+        "b": NamedBuffer(name="b", cvl="rule rb { assert true; }\n", property_rules={"P-b": ["rb"]}),
+    }}
+
+    def put_msg(**args) -> str:
+        # Invoke via the tool-call form so InjectedToolCallId is supplied; normalize str/Command result.
+        res = tool.invoke({"name": "put_buffer", "args": {"state": state, **args},
+                           "id": "t", "type": "tool_call"})
+        if hasattr(res, "content"):
+            return str(res.content)
+        msgs = res.update.get("messages", []) if hasattr(res, "update") else []
+        return str(msgs[0].content) if msgs else ""
+
+    # a third NEW run-target exceeds the cap of 2 -> rejected
+    assert "cap" in put_msg(name="c", cvl="rule rc { assert true; }\n",
+                            property_rules={"P-c": ["rc"]}, imports=[], is_run_target=True)
+    # re-putting an EXISTING run-target is always allowed (not a new one)
+    assert "cap" not in put_msg(name="a", cvl="rule ra { assert true; }\n// edit\n",
+                                property_rules={"P-a": ["ra"]}, imports=[], is_run_target=True)
+    # a new SHARED buffer (is_run_target=false) is exempt from the cap
+    assert "cap" not in put_msg(name="shared", cvl="ghost g(uint) returns uint;\n",
+                                property_rules={}, imports=[], is_run_target=False)

--- a/tests/test_buffer_tools.py
+++ b/tests/test_buffer_tools.py
@@ -47,6 +47,56 @@ def test_list_buffers_empty():
     assert "No spec buffers" in list_buffers(WithBuffers).invoke({"state": {"buffers": {}}})
 
 
+def _invoke_msg(tool, tool_name, state, **args) -> str:
+    res = tool.invoke({"name": tool_name, "args": {"state": state, **args}, "id": "t", "type": "tool_call"})
+    if hasattr(res, "content"):
+        return str(res.content)
+    msgs = res.update.get("messages", []) if hasattr(res, "update") else []
+    return str(msgs[0].content) if msgs else ""
+
+
+def test_put_buffer_warns_on_cross_buffer_duplicate_of_this_buffer(monkeypatch):
+    """Writing a run-target buffer whose declaration already lives in another run-target is flagged at
+    authoring time (before proving), naming only the current buffer's duplicates."""
+    monkeypatch.setattr("composer.spec.source.buffer_tools.cvl_syntax_error", lambda *a, **k: None)
+    state = {"buffers": {
+        "easy": NamedBuffer(
+            name="easy", cvl="ghost dup(uint) returns uint;\nrule r_easy { assert true; }\n",
+            property_rules={"P-easy": ["r_easy"]},
+        ),
+    }}
+    msg = _invoke_msg(put_buffer(WithBuffers), "put_buffer", state,
+                      name="hard", cvl="ghost dup(uint) returns uint;\nrule r_hard { assert true; }\n",
+                      is_run_target=True, imports=[], property_rules={"P-hard": ["r_hard"]})
+    assert "NOTE" in msg and "ghost dup(uint) returns uint;" in msg and "easy" in msg
+
+
+def test_put_buffer_no_warning_without_duplicate(monkeypatch):
+    """A buffer that duplicates nothing is accepted with no note."""
+    monkeypatch.setattr("composer.spec.source.buffer_tools.cvl_syntax_error", lambda *a, **k: None)
+    msg = _invoke_msg(put_buffer(WithBuffers), "put_buffer", _state(),
+                      name="hard", cvl="rule r_hard { assert true; }\n",
+                      is_run_target=True, imports=[], property_rules={"P-hard": ["r_hard"]})
+    assert msg == "Accepted"
+
+
+def test_edit_buffer_warns_when_edit_introduces_duplicate(monkeypatch):
+    """Editing a buffer to add a declaration another run-target already has is flagged at edit time."""
+    monkeypatch.setattr("composer.spec.source.buffer_tools.cvl_syntax_error", lambda *a, **k: None)
+    state = {"buffers": {
+        "easy": NamedBuffer(
+            name="easy", cvl="ghost dup(uint) returns uint;\nrule r_easy { assert true; }\n",
+            property_rules={"P-easy": ["r_easy"]},
+        ),
+        "hard": NamedBuffer(
+            name="hard", cvl="rule r_hard { assert true; }\n", property_rules={"P-hard": ["r_hard"]},
+        ),
+    }}
+    msg = _invoke_msg(edit_buffer(WithBuffers), "edit_buffer", state, name="hard",
+                      old_string="rule r_hard", new_string="ghost dup(uint) returns uint;\nrule r_hard")
+    assert "NOTE" in msg and "easy" in msg
+
+
 def test_put_buffer_enforces_run_target_cap(monkeypatch):
     # put_buffer validates via the CVL typechecker jar (absent in CI) before the cap check; bypass it.
     monkeypatch.setattr("composer.spec.source.buffer_tools.cvl_syntax_error", lambda *a, **k: None)

--- a/tests/test_buffer_tools.py
+++ b/tests/test_buffer_tools.py
@@ -18,8 +18,8 @@ def _state():
         "buffers": {
             "shared": NamedBuffer(name="shared", cvl="ghost g(uint) returns uint;\n", is_run_target=False),
             "easy": NamedBuffer(
-                name="easy", cvl="rule r_easy { assert true; }\n",
-                property_rules={"P-easy": ["r_easy"]}, imports=("shared",),
+                name="easy", cvl='import "shared.spec";\nrule r_easy { assert true; }\n',
+                property_rules={"P-easy": ["r_easy"]},
             ),
         }
     }
@@ -68,10 +68,10 @@ def test_put_buffer_enforces_run_target_cap(monkeypatch):
 
     # a third NEW run-target exceeds the cap of 2 -> rejected
     assert "cap" in put_msg(name="c", cvl="rule rc { assert true; }\n",
-                            property_rules={"P-c": ["rc"]}, imports=[], is_run_target=True)
+                            property_rules={"P-c": ["rc"]}, is_run_target=True)
     # re-putting an EXISTING run-target is always allowed (not a new one)
     assert "cap" not in put_msg(name="a", cvl="rule ra { assert true; }\n// edit\n",
-                                property_rules={"P-a": ["ra"]}, imports=[], is_run_target=True)
+                                property_rules={"P-a": ["ra"]}, is_run_target=True)
     # a new SHARED buffer (is_run_target=false) is exempt from the cap
     assert "cap" not in put_msg(name="shared", cvl="ghost g(uint) returns uint;\n",
-                                property_rules={}, imports=[], is_run_target=False)
+                                property_rules={}, is_run_target=False)

--- a/tests/test_cloud_fetch_retry.py
+++ b/tests/test_cloud_fetch_retry.py
@@ -1,0 +1,52 @@
+"""Unit tests for cloud_results' fetch retry: re-fetch a *completed* job, never re-prove."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import composer.prover.cloud as cloud
+
+
+class _FakeAPI:
+    """Stand-in for the POU results client whose fetch fails ``fail_times`` times, then succeeds."""
+
+    def __init__(self, fail_times: int, files: list[str]):
+        self.fail_times = fail_times
+        self.files = files
+        self.calls = 0
+
+    def fetch_sources_and_treeview_files(self, job_id: str, dest: Path) -> None:
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            # a mid-transfer reset can leave a partial file behind
+            (Path(dest) / f"partial_{self.calls}.txt").write_text("x")
+            raise ConnectionResetError("Connection reset by peer")
+        for name in self.files:
+            (Path(dest) / name).write_text("ok")
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_wait(monkeypatch):
+    # keep the test instant — exercise the retry loop, not the clock
+    monkeypatch.setattr(cloud, "_FETCH_BACKOFF_BASE_S", 0.0)
+
+
+def _fetch(fake: _FakeAPI, dest: Path, monkeypatch) -> None:
+    monkeypatch.setattr(cloud, "_results_api", lambda: fake)
+    asyncio.run(cloud._fetch_results("deadbeefcafebabe", dest))
+
+
+def test_succeeds_after_transient_failures(tmp_path, monkeypatch):
+    fake = _FakeAPI(fail_times=2, files=["a.json", "b.json"])
+    _fetch(fake, tmp_path, monkeypatch)
+    assert fake.calls == 3  # 2 transient failures, then success — the finished job is only re-read
+    # each failed attempt's partial write was cleared before the next; only the good set remains
+    assert {p.name for p in tmp_path.iterdir()} == {"a.json", "b.json"}
+
+
+def test_gives_up_after_max_attempts(tmp_path, monkeypatch):
+    fake = _FakeAPI(fail_times=99, files=["a.json"])
+    with pytest.raises(ConnectionResetError):
+        _fetch(fake, tmp_path, monkeypatch)
+    assert fake.calls == cloud._FETCH_MAX_ATTEMPTS  # capped — it never loops forever

--- a/tests/test_focus_exits.py
+++ b/tests/test_focus_exits.py
@@ -26,8 +26,9 @@ _Skip = RecordSkip.with_template(description="Skip it.", reason="why")
 
 
 def _prover_calls(n: int) -> list[AIMessage]:
+    # `_verify_attempts` counts prover attempts by the buffer-submission tool.
     return [
-        AIMessage(content="", tool_calls=[{"name": "verify_spec", "args": {}, "id": f"c{i}"}])
+        AIMessage(content="", tool_calls=[{"name": "submit_buffer", "args": {}, "id": f"c{i}"}])
         for i in range(n)
     ]
 

--- a/tests/test_rule_skips.py
+++ b/tests/test_rule_skips.py
@@ -1,49 +1,58 @@
-"""
-Tests for the prover tool, rule skip machinery, and their interactions.
+"""Prover report handling and rule-skip machinery over the async multi-buffer path.
 
-Uses a monkeypatched prover (certora_prover fixture) to test report handling,
-validation stamping, and rule skip reducer behavior end-to-end.
+Each run-target buffer is verified whole as a background job (submit_buffer) whose outcome is
+drained and stamped by collect_results. These tests drive that flow with a monkeypatched prover
+(the certora_prover fixture) to cover: how a buffer's prover report (string error, summarized
+to-do list, raw rule statuses) is surfaced and stamped; how a skipped rule that fails is forgiven
+so its buffer still completes; and the rule-skip reducer itself.
 """
 import pytest
 
 from composer.spec.source.author import ExpectRuleFailure, ExpectRulePassage
-from composer.spec.source.prover import (
-    StateWithSkips, VALIDATION_KEY,
-)
-from composer.authoring.state import check_completion
+from composer.spec.source.prover import StateWithSkips, VALIDATION_KEY
 from composer.prover.core import ProverReport
 from composer.prover.ptypes import RulePath
-from composer.prover.results import StatusCodes
 
 from graphcore.testing import Scenario, tool_call_raw, ToolCallDict
-from graphcore.tools.results import result_tool_generator
+from composer.spec.source.spec_buffers import NamedBuffer, check_buffer_completion
 
-from .conftest import ProverMock, ProverToolResponse
+from .conftest import ProverMock
 
 pytestmark = pytest.mark.asyncio
 
 
-# ---------------------------------------------------------------------------
-# State type (StateWithSkips already has `result: NotRequired[str]`)
-# ---------------------------------------------------------------------------
-
-_PROVER = "verify_spec"
 _SKIP = "expect_rule_failure"
 _UNSKIP = "expect_rule_passage"
-_RESULT = "result"
 
 
 # ---------------------------------------------------------------------------
-# Tool call constructors
+# Buffer + tool-call constructors
 # ---------------------------------------------------------------------------
 
 
-def _verify(rules: list[str] | None = None) -> ToolCallDict:
-    return tool_call_raw(_PROVER, rules=rules)
+def _buf(name: str, *rules: str) -> NamedBuffer:
+    """A run-target buffer declaring exactly ``rules`` — the mocked ``declared_rules_list`` parses
+    these declarations back out, and the buffer owns them (property->rule mapping), so completion
+    requires each to verify against this buffer."""
+    cvl = "".join(f"rule {r} {{ assert true; }}\n" for r in rules)
+    return NamedBuffer(
+        name=name,
+        cvl=cvl,
+        property_rules={f"P-{name}": list(rules)} if rules else {},
+    )
 
 
-def _verify_rules(*rules: str) -> ToolCallDict:
-    return tool_call_raw(_PROVER, rules=list(rules))
+def _buffers(**named: NamedBuffer) -> dict[str, NamedBuffer]:
+    return dict(named)
+
+
+def _submit(name: str) -> ToolCallDict:
+    # `name` is also tool_call_raw's first positional, so build the ToolCallDict directly.
+    return {"name": "submit_buffer", "args": {"name": name}}
+
+
+def _collect(wait: bool = False) -> ToolCallDict:
+    return tool_call_raw("collect_results", wait=wait)
 
 
 def _skip(rule_name: str, reason: str) -> ToolCallDict:
@@ -54,99 +63,73 @@ def _unskip(rule_name: str) -> ToolCallDict:
     return tool_call_raw(_UNSKIP, rule_name=rule_name)
 
 
-def _result(commentary: str) -> ToolCallDict:
-    return tool_call_raw(_RESULT, value=commentary)
-
-
 # ---------------------------------------------------------------------------
 # Prover response constructors
 # ---------------------------------------------------------------------------
 
 
-def _spec_decls(*rules: str) -> str:
-    """A spec declaring exactly ``rules`` — the mocked ``declared_rules_list`` parses
-    these declarations back out, so a report's rules must be declared here for the
-    completion check to treat them as the spec's."""
-    return "\n".join(f"rule {r} {{ assert true; }}" for r in rules)
-
-
 def _raw_report(**rule_status: bool) -> ProverReport:
-    return ProverReport(result_str="Prover report output", link="local://test-run", raw_rule_status={
-            RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k,v) in rule_status.items()
+    return ProverReport(
+        result_str="Prover report output", link="local://test-run",
+        raw_rule_status={
+            RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k, v) in rule_status.items()
         },
-        certora_run_stdout="certoraRun output"
+        certora_run_stdout="certoraRun output",
     )
 
 
 def _summarized_report(todo: str, **rule_status: bool) -> ProverReport:
     return ProverReport(
-        result_str=todo, link="local://test-run", raw_rule_status={
-            RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k,v) in rule_status.items()
+        result_str=todo, link="local://test-run",
+        raw_rule_status={
+            RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k, v) in rule_status.items()
         },
-        certora_run_stdout="certoraRun output"
+        certora_run_stdout="certoraRun output",
     )
 
 
 # ---------------------------------------------------------------------------
-# Scenario builder
+# Scenario builder + extractors
 # ---------------------------------------------------------------------------
-
-
-result_tool = result_tool_generator(
-    "result",
-    (str, "Commentary"),
-    "Signal completion",
-    validator=(StateWithSkips, lambda st, *_: check_completion(st)),
-)
 
 
 def _scenario(
     certora_prover: ProverMock,
-    *responses: ProverToolResponse,
-    curr_spec: str | None = "rule foo { assert true; }",
+    buffers: dict[str, NamedBuffer],
+    *,
     rule_skips: dict[str, str] | None = None,
-    required: list[str] | None = None,
+    **responses: ProverReport | str,
 ):
-    prover_tool = certora_prover(responses)
+    """A scenario over the buffer prover tools (submit_buffer / collect_results) plus the skip
+    tools. ``responses`` maps a buffer name to the report (or error string) its job returns."""
     tools = [
-        prover_tool,
+        *certora_prover.buffers(dict(responses)),
         ExpectRuleFailure.as_tool(_SKIP),
         ExpectRulePassage.as_tool(_UNSKIP),
-        result_tool,
     ]
     return Scenario(StateWithSkips, *tools).init(
-        curr_spec=curr_spec,
+        curr_spec=None,
+        buffers=buffers,
         skipped=[],
         property_rules=[],
         validations={},
-        required_validations=required if required is not None else [VALIDATION_KEY],
+        required_validations=[VALIDATION_KEY],
         rule_skips=rule_skips or {},
         config={"files": ["src/Foo.sol"]},
         reminders_channel=[],
-        # verify_spec's stamp is bound to the applied-edit history; the source
-        # pipeline always seeds it, so the test state must too.
         version_history=[],
     )
 
 
-# ---------------------------------------------------------------------------
-# Extractors for map_run
-# ---------------------------------------------------------------------------
+def _prover_complete(st: StateWithSkips) -> str | None:
+    """None once every run-target buffer carries a prover stamp at its current digest."""
+    return check_buffer_completion(
+        st["buffers"], st["validations"], ["prover"], skipped=[], version_history=[]
+    )
 
 
 def _rule_skips(st: StateWithSkips) -> dict[str, str]:
     return st["rule_skips"]
-
-
-def _result_accepted(st: StateWithSkips) -> str:
-    assert "result" in st
-    return st["result"]
-
-
-def _is_result_rejection(st: StateWithSkips) -> bool:
-    return "result" not in st and Scenario.last_single_tool(
-        _RESULT, st
-    ).startswith("Completion REJECTED:")
 
 
 # =========================================================================
@@ -155,111 +138,104 @@ def _is_result_rejection(st: StateWithSkips) -> bool:
 
 
 class TestProverReportHandling:
-    async def test_no_spec_returns_error(self, certora_prover: ProverMock):
-        msg = await _scenario(
-            certora_prover, curr_spec=None,
-        ).turn(
-            _verify()
-        ).run_last_single_tool(_PROVER)
-        assert "not yet" in msg.lower()
+    async def test_no_run_targets_returns_error(self, certora_prover: ProverMock):
+        msg = await _scenario(certora_prover, _buffers()).turn(
+            _collect()
+        ).run_last_single_tool("collect_results")
+        assert "no run-target" in msg.lower()
 
     async def test_string_error_passthrough(self, certora_prover: ProverMock):
         msg = await _scenario(
-            certora_prover, "Internal prover error: out of memory",
-        ).turn(
-            _verify()
-        ).run_last_single_tool(_PROVER)
+            certora_prover, _buffers(b=_buf("b", "r")),
+            b="Internal prover error: out of memory",
+        ).turns(
+            _submit("b"), _collect(wait=True),
+        ).run_last_single_tool("collect_results")
         assert "out of memory" in msg
 
-    async def test_summarized_report_returns_todo(self, certora_prover: ProverMock):
+    async def test_summarized_report_surfaces_todo(self, certora_prover: ProverMock):
         msg = await _scenario(
-            certora_prover,
-            _summarized_report("1. Fix rule foo\n2. Fix rule bar", foo=False, bar=False),
-            curr_spec=_spec_decls("foo", "bar"),
-        ).turn(
-            _verify()
-        ).run_last_single_tool(_PROVER)
+            certora_prover, _buffers(b=_buf("b", "foo", "bar")),
+            b=_summarized_report("1. Fix rule foo\n2. Fix rule bar", foo=False, bar=False),
+        ).turns(
+            _submit("b"), _collect(wait=True),
+        ).run_last_single_tool("collect_results")
         assert "Fix rule foo" in msg
 
     async def test_raw_report_failures_no_stamp(self, certora_prover: ProverMock):
-        assert await _scenario(
-            certora_prover,
-            _raw_report(foo=True, bar=False),
-            curr_spec=_spec_decls("foo", "bar"),
+        st = await _scenario(
+            certora_prover, _buffers(b=_buf("b", "foo", "bar")),
+            b=_raw_report(foo=True, bar=False),
         ).turns(
-            _verify(),
-            _result("done"),
-        ).map_run(_is_result_rejection)
+            _submit("b"), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is not None
 
     async def test_raw_report_all_verified_stamps(self, certora_prover: ProverMock):
-        assert await _scenario(
-            certora_prover,
-            _raw_report(foo=True, bar=True),
-            curr_spec=_spec_decls("foo", "bar"),
+        st = await _scenario(
+            certora_prover, _buffers(b=_buf("b", "foo", "bar")),
+            b=_raw_report(foo=True, bar=True),
         ).turns(
-            _verify(),
-            _result("done"),
-        ).map_run(_result_accepted) == "done"
+            _submit("b"), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is None
 
     async def test_partial_coverage_doesnt_stamp(self, certora_prover: ProverMock):
-        # A rule-scoped run that verifies only part of the declared rules must not
-        # stamp — bar was never exercised against this spec.
-        assert await _scenario(
-            certora_prover,
-            _raw_report(foo=True),
-            curr_spec=_spec_decls("foo", "bar"),
+        # The buffer owns foo and bar, but its run reports only foo — bar was never exercised
+        # against this buffer, so the buffer stays uncovered and does not stamp.
+        st = await _scenario(
+            certora_prover, _buffers(b=_buf("b", "foo", "bar")),
+            b=_raw_report(foo=True),
         ).turns(
-            _verify_rules("foo"),
-            _result("done"),
-        ).map_run(_is_result_rejection)
+            _submit("b"), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is not None
 
 
 # =========================================================================
-# Rule skip interactions with prover
+# Rule skip interactions with the prover
 # =========================================================================
 
 
 class TestRuleSkipProverInteraction:
     async def test_skipped_failure_counts_as_verified(self, certora_prover: ProverMock):
-        """ruleA fails but is skipped, ruleB passes → all verified."""
-        assert await _scenario(
-            certora_prover,
-            _raw_report(ruleA=False, ruleB=True),
-            curr_spec=_spec_decls("ruleA", "ruleB"),
+        """ruleA fails but is skipped, ruleB passes → the buffer completes."""
+        st = await _scenario(
+            certora_prover, _buffers(b=_buf("b", "ruleA", "ruleB")),
+            b=_raw_report(ruleA=False, ruleB=True),
         ).turn(
             _skip("ruleA", "known issue"),
         ).turns(
-            _verify(),
-            _result("done"),
-        ).map_run(_result_accepted) == "done"
+            _submit("b"), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is None
 
     async def test_unskipped_failure_blocks_verification(self, certora_prover: ProverMock):
-        """Skip ruleA, then unskip it. Prover returns ruleA=fail → not verified."""
-        assert await _scenario(
-            certora_prover,
-            _raw_report(ruleA=False, ruleB=True),
-            curr_spec=_spec_decls("ruleA", "ruleB"),
+        """Skip ruleA, then unskip it. The prover returns ruleA=fail → the buffer does not complete."""
+        st = await _scenario(
+            certora_prover, _buffers(b=_buf("b", "ruleA", "ruleB")),
+            b=_raw_report(ruleA=False, ruleB=True),
         ).turn(
             _skip("ruleA", "temp"),
         ).turn(
             _unskip("ruleA"),
         ).turns(
-            _verify(),
-            _result("done"),
-        ).map_run(_is_result_rejection)
+            _submit("b"), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is not None
 
     async def test_non_skipped_failure_blocks_despite_other_skips(self, certora_prover: ProverMock):
-        """ruleA is skipped and fails, ruleB is NOT skipped and also fails → not verified."""
-        assert await _scenario(
-            certora_prover,
-            _raw_report(ruleA=False, ruleB=False),
-            curr_spec=_spec_decls("ruleA", "ruleB"),
+        """ruleA is skipped and fails, ruleB is NOT skipped and also fails → the buffer does not
+        complete."""
+        st = await _scenario(
+            certora_prover, _buffers(b=_buf("b", "ruleA", "ruleB")),
+            b=_raw_report(ruleA=False, ruleB=False),
         ).turn(
             _skip("ruleA", "known"),
         ).turns(
-            _verify(),
-            _result("done"),
-        ).map_run(_is_result_rejection)
+            _submit("b"), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is not None
 
 
 # =========================================================================
@@ -269,7 +245,7 @@ class TestRuleSkipProverInteraction:
 
 class TestRuleSkipReducer:
     async def test_multiple_skips_merge(self, certora_prover: ProverMock):
-        skips = await _scenario(certora_prover).turn(
+        skips = await _scenario(certora_prover, _buffers()).turn(
             _skip("ruleA", "reason A"),
         ).turn(
             _skip("ruleB", "reason B"),
@@ -278,15 +254,14 @@ class TestRuleSkipReducer:
 
     async def test_skip_preserves_existing(self, certora_prover: ProverMock):
         skips = await _scenario(
-            certora_prover,
-            rule_skips={"ruleA": "existing"},
+            certora_prover, _buffers(), rule_skips={"ruleA": "existing"},
         ).turn(
             _skip("ruleB", "new"),
         ).map_run(_rule_skips)
         assert skips == {"ruleA": "existing", "ruleB": "new"}
 
     async def test_skip_overwrites_reason(self, certora_prover: ProverMock):
-        skips = await _scenario(certora_prover).turn(
+        skips = await _scenario(certora_prover, _buffers()).turn(
             _skip("ruleA", "old"),
         ).turn(
             _skip("ruleA", "new"),
@@ -294,7 +269,7 @@ class TestRuleSkipReducer:
         assert skips["ruleA"] == "new"
 
     async def test_unskip_removes(self, certora_prover: ProverMock):
-        skips = await _scenario(certora_prover).turn(
+        skips = await _scenario(certora_prover, _buffers()).turn(
             _skip("ruleA", "temp"),
         ).turn(
             _unskip("ruleA"),

--- a/tests/test_rules_striping.py
+++ b/tests/test_rules_striping.py
@@ -1,14 +1,13 @@
-"""Tests for rules striping: satisfying a spec's rules piecemeal across several
-``verify_spec`` calls (rule-scoped includes and excludes) instead of one full run.
+"""Tests for coverage accrual across spec buffers: each run-target buffer is verified whole, and
+the task completes once every buffer carries a fresh prover stamp.
 
 Covers:
 
-- the pure helpers — which rules a logged run executed (``_executed_rules``) and
-  whether the run history against the current authoring state adds up to full
-  coverage (``_is_completion_history``);
-- the ``verify_spec`` tool surface — include/exclude plumbing into the conf, the
-  ``ProverRunLog`` entries, and completion (validation stamp + reminder) arriving
-  on whichever run completes coverage, however it was scoped;
+- the pure helpers — which rules a logged run executed (``_executed_rules``) and whether the run
+  history against the current authoring state adds up to full coverage (``_is_completion_history``);
+- the buffer prover surface — ``submit_buffer`` / ``collect_results`` logging ``ProverRunLog``
+  entries and stamping per-buffer completion, so coverage accrues across buffers and the completion
+  reminder arrives once the last run-target buffer verifies;
 - ``declared_rules_list``, with its certoraRun/typechecker subprocesses faked;
 - the ``known_rules`` cross-check of ``validate_property_rules``.
 
@@ -18,31 +17,26 @@ The prover core is mocked throughout (the ``certora_prover`` fixture's seams:
 import asyncio
 import json
 from pathlib import Path
-from typing import Annotated
 
 import pytest
 
-from langchain_core.tools import InjectedToolCallId, tool
-from langgraph.types import Command
-
-from composer.authoring.state import check_completion, spec_digest
 from composer.prover.core import (
     ProverReport, SpecCompilationError, declared_rules_list
 )
 from composer.prover.ptypes import RulePath, StatusCodes
 from composer.spec.cvl_generation import PropertyRuleMapping, validate_property_rules
 from composer.spec.source.author import ExpectRuleFailure
+from composer.spec.source.buffer_tools import put_buffer
 from composer.spec.source.prover import (
     NagMarker, ProverHistoryItem, ProverRunLog, RuleSelection, StateWithSkips,
     VALIDATION_KEY, _executed_rules, _is_completion_history,
 )
+from composer.spec.source.spec_buffers import NamedBuffer, check_buffer_completion
 from composer.spec.types import PropertyTitle, RuleName
 
-from graphcore.graph import tool_state_update
 from graphcore.testing import Scenario, ToolCallDict, tool_call_raw
-from graphcore.tools.results import result_tool_generator
 
-from .conftest import ProverMock, ProverToolResponse
+from .conftest import ProverMock
 
 RA = RulePath(rule="a")
 RB = RulePath(rule="b")
@@ -329,35 +323,34 @@ class TestDeclaredRulesList:
 
 
 # =========================================================================
-# verify_spec: striped runs through the tool surface
+# Coverage accrual across buffers: submit_buffer / collect_results
 # =========================================================================
 
-_PROVER = "verify_spec"
 _SKIP = "expect_rule_failure"
-_RESULT = "result"
 
 
-result_tool = result_tool_generator(
-    "result",
-    (str, "Commentary"),
-    "Signal completion",
-    validator=(StateWithSkips, lambda st, *_: check_completion(st)),
-)
+@pytest.fixture(autouse=True)
+def _accept_cvl(monkeypatch):
+    """put_buffer validates writes by shelling out to the real CVL typechecker jar, which is absent
+    in unit-test CI. These tests exercise the async submit/collect flow, not CVL parsing, so accept
+    all writes."""
+    monkeypatch.setattr(
+        "composer.spec.source.buffer_tools.cvl_syntax_error", lambda *a, **k: None
+    )
 
 
-@tool
-def set_spec(
-    spec: str,
-    tool_call_id: Annotated[str, InjectedToolCallId],
-) -> Command:
-    """Replace the spec under authoring (a digest-changing edit)."""
-    return tool_state_update(tool_call_id=tool_call_id, content="spec updated", curr_spec=spec)
-
-
-def _spec_decls(*rules: str) -> str:
-    """A spec declaring exactly ``rules`` — the mocked ``declared_rules_list``
+def _buf(name: str, *rules: str) -> NamedBuffer:
+    """A run-target buffer declaring and owning exactly ``rules``; the mocked ``declared_rules_list``
     parses these declarations back out as the run's declared-rules ground truth."""
-    return "\n".join(f"rule {r} {{ assert true; }}" for r in rules)
+    cvl = "".join(f"rule {r} {{ assert true; }}\n" for r in rules)
+    return NamedBuffer(
+        name=name, cvl=cvl,
+        property_rules={f"P-{name}": list(rules)} if rules else {},
+    )
+
+
+def _buffers(**named: NamedBuffer) -> dict[str, NamedBuffer]:
+    return dict(named)
 
 
 def _report(**rule_status: bool) -> ProverReport:
@@ -372,18 +365,18 @@ def _report(**rule_status: bool) -> ProverReport:
     )
 
 
-def _verify(
-    rules: list[str] | None = None, exclude_rules: list[str] | None = None
-) -> ToolCallDict:
-    return tool_call_raw(_PROVER, rules=rules, exclude_rules=exclude_rules)
+def _submit(name: str) -> ToolCallDict:
+    # `name` is also tool_call_raw's first positional, so build the ToolCallDict directly.
+    return {"name": "submit_buffer", "args": {"name": name}}
 
 
-def _result(commentary: str) -> ToolCallDict:
-    return tool_call_raw(_RESULT, value=commentary)
+def _collect(wait: bool = False) -> ToolCallDict:
+    return tool_call_raw("collect_results", wait=wait)
 
 
-def _set_spec(spec: str) -> ToolCallDict:
-    return tool_call_raw("set_spec", spec=spec)
+def _put(name: str, cvl: str) -> ToolCallDict:
+    return {"name": "put_buffer", "args": {"name": name, "cvl": cvl,
+                                           "property_rules": {}, "imports": [], "is_run_target": True}}
 
 
 def _skip(rule_name: str, reason: str) -> ToolCallDict:
@@ -392,18 +385,21 @@ def _skip(rule_name: str, reason: str) -> ToolCallDict:
 
 def _scenario(
     certora_prover: ProverMock,
-    *responses: ProverToolResponse,
-    curr_spec: str,
+    buffers: dict[str, NamedBuffer],
+    *,
     rule_skips: dict[str, str] | None = None,
+    **responses: ProverReport | str,
 ):
+    """A scenario over the buffer prover tools plus put_buffer and the skip tool. ``responses`` maps
+    a buffer name to the report (or error string) its background job returns."""
     tools = [
-        certora_prover(responses),
+        *certora_prover.buffers(dict(responses)),
+        put_buffer(StateWithSkips),
         ExpectRuleFailure.as_tool(_SKIP),
-        result_tool,
-        set_spec,
     ]
     return Scenario(StateWithSkips, *tools).init(
-        curr_spec=curr_spec,
+        curr_spec=None,
+        buffers=buffers,
         skipped=[],
         property_rules=[],
         validations={},
@@ -415,26 +411,28 @@ def _scenario(
     )
 
 
-def _result_accepted(st: StateWithSkips) -> str:
-    assert "result" in st
-    return st["result"]
+def _prover_complete(st: StateWithSkips) -> str | None:
+    """None once every run-target buffer carries a prover stamp at its current digest."""
+    return check_buffer_completion(
+        st["buffers"], st["validations"], ["prover"], skipped=[], version_history=[]
+    )
 
 
-def _is_result_rejection(st: StateWithSkips) -> bool:
-    return "result" not in st and Scenario.last_single_tool(
-        _RESULT, st
-    ).startswith("Completion REJECTED:")
+# Dropped from the striping suite: test_rules_and_exclude_rules_mutually_exclusive,
+# test_include_selection_reaches_conf_and_history, and test_exclude_selection_reaches_conf_and_history
+# tested the removed single-run rule-scoping surface (verify_spec's include/exclude args plumbed into
+# one conf). A buffer is verified whole, so there is no include/exclude arg to plumb; the surviving
+# "a run reaches prover_history" intent is kept below as test_buffer_run_is_logged_in_history.
 
 
 @pytest.mark.asyncio
-class TestStripedVerification:
-    async def test_a_spec_that_does_not_compile_comes_back_to_the_agent(
+class TestBufferCoverage:
+    async def test_a_buffer_that_does_not_compile_comes_back_to_the_agent(
         self, certora_prover: ProverMock, monkeypatch
     ):
-        """The rule-listing pre-pass runs the compiler before the prover. A spec that
-        fails to compile is the author agent's to fix and the compiler says exactly
-        where, so it has to arrive as a tool result — raising past the agent ends the
-        whole run over a repairable mistake."""
+        """The rule-listing pre-pass runs the compiler before the prover. A buffer that fails to
+        compile is the author agent's to fix and the compiler says exactly where, so it has to arrive
+        as a collect_results tool result rather than sinking the whole run over a repairable mistake."""
         async def failing(**_kwargs):
             raise SpecCompilationError(
                 'Error in spec file (invariants.spec:34:5): could not type '
@@ -446,126 +444,106 @@ class TestStripedVerification:
             "composer.spec.source.prover.declared_rules_list", failing
         )
         msg = await _scenario(
-            certora_prover, curr_spec=_spec_decls("a", "b"),
-        ).turn(
-            _verify()
-        ).run_last_single_tool(_PROVER)
+            certora_prover, _buffers(b=_buf("b", "a", "b")),
+        ).turns(
+            _submit("b"), _collect(wait=True),
+        ).run_last_single_tool("collect_results")
         assert "failed to compile" in msg
         assert "invariants.spec:34:5" in msg
         assert "non-envfree" in msg
         # The prover is never reached — there is nothing to verify.
         assert certora_prover.calls == []
 
-
-    async def test_rules_and_exclude_rules_mutually_exclusive(self, certora_prover: ProverMock):
-        msg = await _scenario(
-            certora_prover, curr_spec=_spec_decls("a", "b"),
-        ).turn(
-            _verify(rules=["a"], exclude_rules=["b"])
-        ).run_last_single_tool(_PROVER)
-        assert "both" in msg
-        assert certora_prover.calls == []
-
-    async def test_include_selection_reaches_conf_and_history(self, certora_prover: ProverMock):
-        spec = _spec_decls("a", "b")
+    async def test_buffer_run_is_logged_in_history(self, certora_prover: ProverMock):
+        # A whole-buffer run is logged in prover_history against the buffer's current state, with its
+        # declared rules and results — the buffer analogue of the old include/exclude conf-history check
+        # (rules is None because a buffer is verified whole, not rule-scoped).
         history = await _scenario(
-            certora_prover, _report(a=True), curr_spec=spec,
-        ).turn(
-            _verify(rules=["a"])
+            certora_prover, _buffers(b=_buf("b", "a", "b")),
+            b=_report(a=True, b=True),
+        ).turns(
+            _submit("b"), _collect(wait=True),
         ).map_run(lambda st: st["prover_history"])
-        [entry] = history
-        assert entry["sort"] == "run"
-        assert entry["rules"] == {"sort": "include", "selector": ["a"]}
-        assert entry["declared_rules"] == ["a", "b"]
-        assert entry["state_digest"] == spec_digest(spec, [], [])
-        [call] = certora_prover.calls
-        assert call.conf["rule"] == ["a"]
-        assert "exclude_rule" not in call.conf
+        [entry] = [h for h in history if h["sort"] == "run"]
+        assert entry["buffer"] == "b"
+        assert entry["rules"] is None
+        assert sorted(entry["declared_rules"]) == ["a", "b"]
+        assert (RulePath(rule="a"), "VERIFIED") in entry["prover_results"]
 
-    async def test_exclude_selection_reaches_conf_and_history(self, certora_prover: ProverMock):
-        history = await _scenario(
-            certora_prover, _report(a=True), curr_spec=_spec_decls("a", "b"),
-        ).turn(
-            _verify(exclude_rules=["b"])
-        ).map_run(lambda st: st["prover_history"])
-        [entry] = history
-        assert entry["sort"] == "run"
-        assert entry["rules"] == {"sort": "exclude", "selector": ["b"]}
-        [call] = certora_prover.calls
-        assert call.conf["exclude_rule"] == ["b"]
-        assert "rule" not in call.conf
-
-    async def test_piecemeal_completion_stamps(self, certora_prover: ProverMock):
-        # The whole point of striping: two rule-scoped runs that together cover the
-        # spec complete the task, no full run required.
-        assert await _scenario(
-            certora_prover, _report(a=True), _report(b=True),
-            curr_spec=_spec_decls("a", "b"),
+    async def test_all_buffers_verified_completes(self, certora_prover: ProverMock):
+        # Coverage accrues across buffers: two run-target buffers, each verified whole, together
+        # complete the task — no single full run required.
+        st = await _scenario(
+            certora_prover, _buffers(b1=_buf("b1", "a"), b2=_buf("b2", "b")),
+            b1=_report(a=True), b2=_report(b=True),
         ).turns(
-            _verify(rules=["a"]),
-            _verify(rules=["b"]),
-            _result("done"),
-        ).map_run(_result_accepted) == "done"
+            _submit("b1"), _submit("b2"), _collect(wait=True), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is None
 
-    async def test_exclude_run_alone_doesnt_complete(self, certora_prover: ProverMock):
-        assert await _scenario(
-            certora_prover, _report(a=True), curr_spec=_spec_decls("a", "b"),
+    async def test_one_unverified_buffer_blocks_completion(self, certora_prover: ProverMock):
+        # One run-target buffer verified, the other never submitted → coverage is partial.
+        st = await _scenario(
+            certora_prover, _buffers(b1=_buf("b1", "a"), b2=_buf("b2", "b")),
+            b1=_report(a=True),
         ).turns(
-            _verify(exclude_rules=["b"]),
-            _result("done"),
-        ).map_run(_is_result_rejection)
+            _submit("b1"), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is not None
 
-    async def test_exclude_then_include_completes(self, certora_prover: ProverMock):
-        assert await _scenario(
-            certora_prover, _report(a=True, b=True), _report(c=True),
-            curr_spec=_spec_decls("a", "b", "c"),
+    async def test_coverage_accrues_across_separate_collect_rounds(self, certora_prover: ProverMock):
+        # The buffers are verified in separate submit/collect rounds; completion arrives on the round
+        # that verifies the last run-target buffer.
+        st = await _scenario(
+            certora_prover, _buffers(b1=_buf("b1", "a"), b2=_buf("b2", "b")),
+            b1=_report(a=True), b2=_report(b=True),
         ).turns(
-            _verify(exclude_rules=["c"]),
-            _verify(rules=["c"]),
-            _result("done"),
-        ).map_run(_result_accepted) == "done"
+            _submit("b1"), _collect(wait=True),
+            _submit("b2"), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is None
 
-    async def test_spec_edit_resets_piecemeal_coverage(self, certora_prover: ProverMock):
-        spec_v1 = _spec_decls("a", "b")
-        spec_v2 = spec_v1 + "\n// tightened"
-        assert await _scenario(
-            certora_prover, _report(a=True), _report(b=True), curr_spec=spec_v1,
+    async def test_editing_a_buffer_resets_its_coverage(self, certora_prover: ProverMock):
+        # Both buffers verify, then editing b1 changes its digest, so its prover stamp goes stale and
+        # overall completion is withdrawn until b1 is re-verified.
+        st = await _scenario(
+            certora_prover, _buffers(b1=_buf("b1", "a"), b2=_buf("b2", "b")),
+            b1=_report(a=True), b2=_report(b=True),
         ).turns(
-            _verify(rules=["a"]),
-            _set_spec(spec_v2),
-            _verify(rules=["b"]),
-            _result("done"),
-        ).map_run(_is_result_rejection)
+            _submit("b1"), _submit("b2"), _collect(wait=True), _collect(wait=True),
+            _put("b1", "rule a { assert true; }\n// tightened\n"),
+        ).run()
+        assert _prover_complete(st) is not None
 
     async def test_skipped_rule_failure_counts_toward_coverage(self, certora_prover: ProverMock):
-        assert await _scenario(
-            certora_prover, _report(a=True), _report(b=False),
-            curr_spec=_spec_decls("a", "b"),
+        # b2's rule fails but is skipped, so its buffer still completes and coverage is met across both.
+        st = await _scenario(
+            certora_prover, _buffers(b1=_buf("b1", "a"), b2=_buf("b2", "b")),
+            b1=_report(a=True), b2=_report(b=False),
         ).turn(
             _skip("b", "known limitation"),
         ).turns(
-            _verify(rules=["a"]),
-            _verify(rules=["b"]),
-            _result("done"),
-        ).map_run(_result_accepted) == "done"
+            _submit("b1"), _submit("b2"), _collect(wait=True), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is None
 
-    async def test_completion_reminder_delivered_on_completing_run(self, certora_prover: ProverMock):
+    async def test_completion_reminder_delivered_once_all_buffers_verify(self, certora_prover: ProverMock):
         reminders = await _scenario(
-            certora_prover, _report(a=True), _report(b=True),
-            curr_spec=_spec_decls("a", "b"),
+            certora_prover, _buffers(b1=_buf("b1", "a"), b2=_buf("b2", "b")),
+            b1=_report(a=True), b2=_report(b=True),
         ).turns(
-            _verify(rules=["a"]),
-            _verify(rules=["b"]),
+            _submit("b1"), _submit("b2"), _collect(wait=True), _collect(wait=True),
         ).map_run(lambda st: st["reminders_channel"])
-        assert any("task is completed" in r for r in reminders)
+        assert any("verified at its current content" in r for r in reminders)
 
     async def test_no_completion_reminder_while_coverage_is_partial(self, certora_prover: ProverMock):
         reminders = await _scenario(
-            certora_prover, _report(a=True), curr_spec=_spec_decls("a", "b"),
-        ).turn(
-            _verify(rules=["a"]),
+            certora_prover, _buffers(b1=_buf("b1", "a"), b2=_buf("b2", "b")),
+            b1=_report(a=True),
+        ).turns(
+            _submit("b1"), _collect(wait=True),
         ).map_run(lambda st: st["reminders_channel"])
-        assert reminders == []
+        assert not any("verified at its current content" in r for r in reminders)
 
 
 # =========================================================================

--- a/tests/test_sanity_timeout.py
+++ b/tests/test_sanity_timeout.py
@@ -1,0 +1,25 @@
+"""Unit tests for the AUTOPROVER_SANITY_TIMEOUT override on the sanity phase's per-job timeout."""
+
+from certora_autosetup.setup.sanity import (
+    DEFAULT_SANITY_TIMEOUT,
+    SANITY_TIMEOUT_ENV,
+    sanity_global_timeout,
+)
+
+
+class TestSanityGlobalTimeout:
+    def test_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv(SANITY_TIMEOUT_ENV, raising=False)
+        assert sanity_global_timeout() == DEFAULT_SANITY_TIMEOUT == 1200
+
+    def test_integer_env_value_used(self, monkeypatch):
+        monkeypatch.setenv(SANITY_TIMEOUT_ENV, "300")
+        assert sanity_global_timeout() == 300
+
+    def test_non_integer_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(SANITY_TIMEOUT_ENV, "five-minutes")
+        assert sanity_global_timeout() == DEFAULT_SANITY_TIMEOUT
+
+    def test_non_positive_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(SANITY_TIMEOUT_ENV, "0")
+        assert sanity_global_timeout() == DEFAULT_SANITY_TIMEOUT

--- a/tests/test_spec_buffer_prover.py
+++ b/tests/test_spec_buffer_prover.py
@@ -92,6 +92,16 @@ def _prover_complete(st: StateWithSkips) -> str | None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _accept_cvl(monkeypatch):
+    """put_buffer/edit_buffer validate writes by shelling out to the real CVL typechecker jar
+    (cvl_syntax_error); that jar is absent in unit-test CI, so every buffer write would be rejected.
+    This suite exercises the async submit/collect flow, not CVL parsing, so accept all writes."""
+    monkeypatch.setattr(
+        "composer.spec.source.buffer_tools.cvl_syntax_error", lambda *a, **k: None
+    )
+
+
 @pytest.mark.asyncio
 class TestBufferSubmitCollect:
     async def test_submit_then_collect_stamps_each_buffer(self, certora_prover: ProverMock):

--- a/tests/test_spec_buffer_prover.py
+++ b/tests/test_spec_buffer_prover.py
@@ -148,6 +148,30 @@ class TestBufferSubmitCollect:
         ).run()
         assert _prover_complete(st) is None
 
+    async def test_isolated_pairs_do_not_drain_each_others_jobs(self, certora_prover: ProverMock):
+        """Each ``make_buffer_tools()`` pair owns its job state: submitting on one pair must not let a
+        second pair's blocking collect drain that job. A second pair stands in for a concurrent
+        component author, which shares the prover semaphore but must never share the result queue."""
+        pair_a = certora_prover.buffers({"easy": _report(r_easy=True)})
+        pair_b = certora_prover.buffers({"easy": _report(r_easy=True)})
+
+        def scene(pair):
+            return Scenario(StateWithSkips, *pair).init(
+                curr_spec=None, buffers=_buffers(), skipped=[], property_rules=[], validations={},
+                required_validations=[VALIDATION_KEY], rule_skips={}, config={"files": ["src/Foo.sol"]},
+                reminders_channel=[], version_history=[],
+            )
+
+        # A submits easy (same tool pair reused across turns, so its background job persists).
+        await scene(pair_a).turns(_submit("easy")).run()
+        # B submitted nothing, so its blocking collect has no job of its own to await and drains nothing.
+        # A shared queue would let B drain A's result here.
+        st_b = await scene(pair_b).turns(_collect(wait=True)).run()
+        assert st_b["validations"].get("prover:easy") is None
+        # A still finds and stamps its own job.
+        st_a = await scene(pair_a).turns(_collect(wait=True)).run()
+        assert st_a["validations"].get("prover:easy") is not None
+
     async def test_collect_without_finished_jobs_does_not_block(self, certora_prover: ProverMock):
         """A non-blocking collect with nothing submitted returns a status board rather than hanging."""
         st = await _scenario(certora_prover, _buffers()).turns(

--- a/tests/test_spec_buffer_prover.py
+++ b/tests/test_spec_buffer_prover.py
@@ -38,6 +38,22 @@ def _buffers() -> dict[str, NamedBuffer]:
     }
 
 
+def _buf2(name: str, r1: str, r2: str) -> NamedBuffer:
+    return NamedBuffer(
+        name=name,
+        cvl=f'import "shared.spec";\nrule {r1} {{ assert true; }}\nrule {r2} {{ assert true; }}\n',
+        property_rules={f"P-{r1}": [r1], f"P-{r2}": [r2]},
+    )
+
+
+def _buffers2() -> dict[str, NamedBuffer]:
+    """One shared buffer plus a two-rule run target, for rule-striping within a single buffer."""
+    return {
+        "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
+        "both": _buf2("both", "r_a", "r_b"),
+    }
+
+
 def _report(**rule_status: bool) -> ProverReport:
     return ProverReport(
         result_str="Prover report output",
@@ -71,6 +87,15 @@ def _scenario(certora_prover: ProverMock, buffers: dict[str, NamedBuffer], **res
 def _submit(name: str):
     # `name` is also tool_call_raw's first positional, so build the ToolCallDict directly.
     return {"name": "submit_buffer", "args": {"name": name}}
+
+
+def _submit_sel(name: str, *, rule=None, exclude_rules=None):
+    args: dict = {"name": name}
+    if rule is not None:
+        args["rule"] = rule
+    if exclude_rules is not None:
+        args["exclude_rules"] = exclude_rules
+    return {"name": "submit_buffer", "args": args}
 
 
 def _collect(wait: bool = False):
@@ -138,6 +163,58 @@ class TestBufferSubmitCollect:
         assert st["validations"].get("prover:easy") == buffer_state_digest(
             st["buffers"], "easy", skipped=[], version_history=[]
         )
+
+    async def test_rule_stripe_unions_to_completion(self, certora_prover: ProverMock):
+        """Two rule subsets of one buffer, submitted separately, each verify their own rule; the runs
+        union at the same digest so the buffer completes without ever running both rules together."""
+        st = await _scenario(
+            certora_prover, _buffers2(), both=_report(r_a=True, r_b=True),
+        ).turns(
+            _submit_sel("both", rule=["r_a"]),
+            _submit_sel("both", rule=["r_b"]),
+            _collect(wait=True),
+            _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is None
+        runs = [it for it in st["prover_history"] if it["sort"] == "run" and it.get("buffer") == "both"]
+        assert len(runs) == 2
+        assert {tuple(r["rules"]["selector"]) for r in runs} == {("r_a",), ("r_b",)}
+        assert all(len(r["prover_results"]) == 1 for r in runs)  # each run reported only its own rule
+
+    async def test_striped_subsets_launch_as_separate_jobs(self, certora_prover: ProverMock):
+        """Different subsets of one buffer at the same content are distinct jobs — both launch, unlike a
+        re-submit of the identical subset."""
+        await _scenario(
+            certora_prover, _buffers2(), both=_report(r_a=True, r_b=True),
+        ).turns(
+            _submit_sel("both", rule=["r_a"]),
+            _submit_sel("both", rule=["r_b"]),
+            _collect(wait=True), _collect(wait=True),
+        ).run()
+        both_runs = [c for c in certora_prover.calls if "both" in str(c.conf.get("verify", ""))]
+        assert len(both_runs) == 2
+
+    async def test_resubmit_same_subset_does_not_duplicate(self, certora_prover: ProverMock):
+        """Re-submitting the identical subset at unchanged content does not launch a second job."""
+        await _scenario(
+            certora_prover, _buffers2(), both=_report(r_a=True, r_b=True),
+        ).turns(
+            _submit_sel("both", rule=["r_a"]),
+            _submit_sel("both", rule=["r_a"]),  # identical subset → deduped
+            _collect(wait=True),
+        ).run()
+        both_runs = [c for c in certora_prover.calls if "both" in str(c.conf.get("verify", ""))]
+        assert len(both_runs) == 1
+
+    async def test_submit_rejects_bad_selection(self, certora_prover: ProverMock):
+        """An unknown rule, or `rule` and `exclude_rules` together, is rejected without launching a job."""
+        await _scenario(
+            certora_prover, _buffers2(), both=_report(r_a=True, r_b=True),
+        ).turns(
+            _submit_sel("both", rule=["r_nonexistent"]),
+            _submit_sel("both", rule=["r_a"], exclude_rules=["r_b"]),
+        ).run()
+        assert certora_prover.calls == []
 
     async def test_shared_edit_makes_verified_buffers_stale(self, certora_prover: ProverMock):
         """After both buffers verify, editing the shared buffer they import changes their digests, so

--- a/tests/test_spec_buffer_prover.py
+++ b/tests/test_spec_buffer_prover.py
@@ -27,7 +27,6 @@ def _buf(name: str, rule: str) -> NamedBuffer:
         name=name,
         cvl=f'import "shared.spec";\nrule {rule} {{ assert true; }}\n',
         property_rules={f"P-{name}": [rule]},
-        imports=("shared",),
     )
 
 

--- a/tests/test_spec_buffer_prover.py
+++ b/tests/test_spec_buffer_prover.py
@@ -123,6 +123,22 @@ class TestBufferSubmitCollect:
         assert st["validations"].get("prover:hard") == digest("hard")
         assert _prover_complete(st) is None
 
+    async def test_resubmit_same_content_does_not_duplicate(self, certora_prover: ProverMock):
+        """Re-submitting a buffer at unchanged content (its job still in flight or finished but not yet
+        collected) must not launch a second prover job — the guard tells the agent to collect instead."""
+        st = await _scenario(
+            certora_prover, _buffers(), easy=_report(r_easy=True),
+        ).turns(
+            _submit("easy"),
+            _submit("easy"),      # identical content, not collected → must NOT re-run
+            _collect(wait=True),
+        ).run()
+        easy_runs = [c for c in certora_prover.calls if "easy" in str(c.conf.get("verify", ""))]
+        assert len(easy_runs) == 1, f"expected one prover run for easy, got {len(easy_runs)}"
+        assert st["validations"].get("prover:easy") == buffer_state_digest(
+            st["buffers"], "easy", skipped=[], version_history=[]
+        )
+
     async def test_shared_edit_makes_verified_buffers_stale(self, certora_prover: ProverMock):
         """After both buffers verify, editing the shared buffer they import changes their digests, so
         their prover stamps no longer match — the refine case that must force a re-run."""

--- a/tests/test_spec_buffer_prover.py
+++ b/tests/test_spec_buffer_prover.py
@@ -155,3 +155,43 @@ class TestBufferSubmitCollect:
             _collect(wait=False),
         ).run()
         assert _prover_complete(st) is not None  # nothing verified yet
+
+    async def test_non_editing_feedback_stamps_per_buffer(self):
+        """The non-editing feedback tool (structural invariants / immutable source) must review each
+        buffer and stamp feedback:<buffer> — the path that previously read empty curr_spec and returned
+        'No spec put yet', deadlocking publish."""
+        from dataclasses import dataclass
+        from composer.spec.source.author import BufferPropertyFeedbackTool
+        from composer.spec.cvl_generation import FeedbackServices
+        from composer.spec.types import PropertyTitle
+
+        @dataclass
+        class _V:
+            good: bool
+            feedback: str
+
+        async def judge(spec, skipped, rebuttals, within_tool):
+            return _V(good=True, feedback="")
+
+        tool = BufferPropertyFeedbackTool.bind(
+            FeedbackServices(feedback_thunk=judge, titles=[PropertyTitle("P-easy")])
+        ).as_tool("feedback_tool")
+        buffers = {
+            "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
+            "easy": _buf("easy", "r_easy"),
+        }
+        state = {
+            "buffers": buffers, "curr_spec": None, "skipped": [],
+            "validations": {}, "version_history": [], "messages": [],
+            "required_validations": [], "property_rules": [], "rule_skips": {},
+            "config": {}, "prover_history": [], "reminders_channel": [],
+            "failed": None, "budget_curtailed": False,
+        }
+        res = await tool.ainvoke(
+            {"name": "feedback_tool", "args": {"state": state, "rebuttals": []},
+             "id": "t", "type": "tool_call"}
+        )
+        val = res.update.get("validations", {}) if hasattr(res, "update") else {}
+        assert val.get("feedback:easy") == buffer_state_digest(
+            buffers, "easy", skipped=[], version_history=[]
+        )

--- a/tests/test_spec_buffer_prover.py
+++ b/tests/test_spec_buffer_prover.py
@@ -184,7 +184,7 @@ class TestBufferSubmitCollect:
         buffer and stamp feedback:<buffer> — the path that previously read empty curr_spec and returned
         'No spec put yet', deadlocking publish."""
         from dataclasses import dataclass
-        from composer.spec.source.author import BufferPropertyFeedbackTool
+        from composer.spec.source.author import BufferPropertyFeedbackTool, _PerBufferJudge
         from composer.spec.cvl_generation import FeedbackServices
         from composer.spec.types import PropertyTitle
 
@@ -197,7 +197,12 @@ class TestBufferSubmitCollect:
             return _V(good=True, feedback="")
 
         tool = BufferPropertyFeedbackTool.bind(
-            FeedbackServices(feedback_thunk=judge, titles=[PropertyTitle("P-easy")])
+            _PerBufferJudge(
+                build=lambda name, claimed: FeedbackServices(
+                    feedback_thunk=judge, titles=[PropertyTitle("P-easy")]
+                ),
+                properties=[],
+            )
         ).as_tool("feedback_tool")
         buffers = {
             "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
@@ -216,5 +221,5 @@ class TestBufferSubmitCollect:
         )
         val = res.update.get("validations", {}) if hasattr(res, "update") else {}
         assert val.get("feedback:easy") == buffer_state_digest(
-            buffers, "easy", skipped=[], version_history=[]
+            buffers, "easy", skipped=[], version_history=[], include_claim=True
         )

--- a/tests/test_spec_buffer_prover.py
+++ b/tests/test_spec_buffer_prover.py
@@ -1,0 +1,147 @@
+"""Async multi-buffer verification through the tool surface: submit_buffer launches a background
+prover job per buffer, collect_results drains finished ones and stamps per-buffer completion, and a
+shared-buffer edit invalidates every importer's stamp (the refine step). The prover/compiler seams are
+mocked (see the ``certora_prover`` fixture); each buffer's response is keyed by name because jobs run
+concurrently."""
+
+import pytest
+
+from graphcore.testing import Scenario, tool_call_raw
+
+from composer.prover.core import ProverReport
+from composer.prover.ptypes import RulePath
+from composer.spec.source.buffer_tools import put_buffer
+from composer.spec.source.prover import StateWithSkips, VALIDATION_KEY
+from composer.spec.source.spec_buffers import (
+    NamedBuffer, buffer_state_digest, check_buffer_completion,
+)
+
+from .conftest import ProverMock
+
+
+SHARED = "ghost g(uint) returns uint;\n"
+
+
+def _buf(name: str, rule: str) -> NamedBuffer:
+    return NamedBuffer(
+        name=name,
+        cvl=f'import "shared.spec";\nrule {rule} {{ assert true; }}\n',
+        property_rules={f"P-{name}": [rule]},
+        imports=("shared",),
+    )
+
+
+def _buffers() -> dict[str, NamedBuffer]:
+    return {
+        "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
+        "easy": _buf("easy", "r_easy"),
+        "hard": _buf("hard", "r_hard"),
+    }
+
+
+def _report(**rule_status: bool) -> ProverReport:
+    return ProverReport(
+        result_str="Prover report output",
+        link="local://test-run",
+        raw_rule_status={
+            RulePath(rule=k): "VERIFIED" if v else "VIOLATED" for (k, v) in rule_status.items()
+        },
+        certora_run_stdout="",
+    )
+
+
+def _scenario(certora_prover: ProverMock, buffers: dict[str, NamedBuffer], **responses: ProverReport):
+    tools = [
+        *certora_prover.buffers(dict(responses)),
+        put_buffer(StateWithSkips),
+    ]
+    return Scenario(StateWithSkips, *tools).init(
+        curr_spec=None,
+        buffers=buffers,
+        skipped=[],
+        property_rules=[],
+        validations={},
+        required_validations=[VALIDATION_KEY],
+        rule_skips={},
+        config={"files": ["src/Foo.sol"]},
+        reminders_channel=[],
+        version_history=[],
+    )
+
+
+def _submit(name: str):
+    # `name` is also tool_call_raw's first positional, so build the ToolCallDict directly.
+    return {"name": "submit_buffer", "args": {"name": name}}
+
+
+def _collect(wait: bool = False):
+    return tool_call_raw("collect_results", wait=wait)
+
+
+def _put_shared(cvl: str):
+    return {
+        "name": "put_buffer",
+        "args": {"name": "shared", "cvl": cvl, "is_run_target": False,
+                 "imports": [], "property_rules": {}},
+    }
+
+
+def _prover_complete(st: StateWithSkips) -> str | None:
+    return check_buffer_completion(
+        st["buffers"], st["validations"], ["prover"], skipped=[], version_history=[]
+    )
+
+
+@pytest.mark.asyncio
+class TestBufferSubmitCollect:
+    async def test_submit_then_collect_stamps_each_buffer(self, certora_prover: ProverMock):
+        """Submitting each run-target buffer and collecting its result stamps that buffer's prover
+        completion; once both are in, overall prover-completion holds."""
+        st = await _scenario(
+            certora_prover, _buffers(),
+            easy=_report(r_easy=True), hard=_report(r_hard=True),
+        ).turns(
+            _submit("easy"),
+            _submit("hard"),
+            _collect(wait=True),
+            _collect(wait=True),
+        ).run()
+
+        def digest(n: str) -> str:
+            return buffer_state_digest(st["buffers"], n, skipped=[], version_history=[])
+
+        assert st["validations"].get("prover:easy") == digest("easy")
+        assert st["validations"].get("prover:hard") == digest("hard")
+        assert _prover_complete(st) is None
+
+    async def test_shared_edit_makes_verified_buffers_stale(self, certora_prover: ProverMock):
+        """After both buffers verify, editing the shared buffer they import changes their digests, so
+        their prover stamps no longer match — the refine case that must force a re-run."""
+        st = await _scenario(
+            certora_prover, _buffers(),
+            easy=_report(r_easy=True), hard=_report(r_hard=True),
+        ).turns(
+            _submit("easy"), _submit("hard"), _collect(wait=True), _collect(wait=True),
+            _put_shared(SHARED + "ghost h(uint) returns uint;\n"),
+        ).run()
+        assert _prover_complete(st) is not None
+
+    async def test_resubmit_after_shared_edit_recompletes(self, certora_prover: ProverMock):
+        """Re-submitting the invalidated buffers at the new shared content re-verifies and re-completes
+        them — the stamp lands at the new digest."""
+        st = await _scenario(
+            certora_prover, _buffers(),
+            easy=_report(r_easy=True), hard=_report(r_hard=True),
+        ).turns(
+            _submit("easy"), _submit("hard"), _collect(wait=True), _collect(wait=True),
+            _put_shared(SHARED + "ghost h(uint) returns uint;\n"),
+            _submit("easy"), _submit("hard"), _collect(wait=True), _collect(wait=True),
+        ).run()
+        assert _prover_complete(st) is None
+
+    async def test_collect_without_finished_jobs_does_not_block(self, certora_prover: ProverMock):
+        """A non-blocking collect with nothing submitted returns a status board rather than hanging."""
+        st = await _scenario(certora_prover, _buffers()).turns(
+            _collect(wait=False),
+        ).run()
+        assert _prover_complete(st) is not None  # nothing verified yet

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -4,6 +4,8 @@ from composer.spec.source.spec_buffers import (
     NamedBuffer,
     buffer_digest,
     buffer_files,
+    buffer_state_digest,
+    check_buffer_completion,
     combined_buffers_view,
     import_closure,
     merge_buffers,
@@ -167,6 +169,56 @@ def test_plan_buffer_runs_skips_complete_and_excludes_shared():
     assert set(by) == {"easy", "hard"}  # shared is not a run target
     assert by["easy"].needs_run is False and by["hard"].needs_run is True
     assert by["easy"].digest == "d-easy"
+
+
+# --- per-buffer completion (validation stamps) -----------------------------
+
+
+def _stamp(buffers, name, key):
+    d = buffer_state_digest(buffers, name, skipped=[], version_history=[])
+    return {f"{key}:{name}": d}
+
+
+def test_buffer_completion_ok_when_all_stamped_at_digest():
+    b = _buffers()
+    validations = {}
+    for name in ("easy", "hard"):
+        validations.update(_stamp(b, name, "feedback"))
+        validations.update(_stamp(b, name, "prover"))
+    assert check_buffer_completion(
+        b, validations, ["feedback", "prover"], skipped=[], version_history=[]
+    ) is None
+
+
+def test_buffer_completion_rejects_missing_stamp():
+    b = _buffers()
+    validations = _stamp(b, "easy", "feedback")  # hard + prover missing
+    err = check_buffer_completion(b, validations, ["feedback", "prover"], skipped=[], version_history=[])
+    assert err is not None and ("hard" in err or "prover" in err)
+
+
+def test_buffer_completion_stamp_goes_stale_on_edit():
+    b = _buffers()
+    validations = {}
+    for name in ("easy", "hard"):
+        validations.update(_stamp(b, name, "feedback"))
+        validations.update(_stamp(b, name, "prover"))
+    # Edit `easy`: its digest changes, so its stamps go stale.
+    b["easy"] = NamedBuffer(name="easy", cvl=EASY + "// edit\n", property_rules={"P-easy": ["r_easy"]}, imports=("shared",))
+    err = check_buffer_completion(b, validations, ["feedback", "prover"], skipped=[], version_history=[])
+    assert err is not None and "easy" in err
+
+
+def test_buffer_completion_stamp_goes_stale_on_shared_import_edit():
+    b = _buffers()
+    validations = {}
+    for name in ("easy", "hard"):
+        validations.update(_stamp(b, name, "feedback"))
+        validations.update(_stamp(b, name, "prover"))
+    # Editing the shared buffer invalidates BOTH importers' stamps.
+    b["shared"] = NamedBuffer(name="shared", cvl=SHARED + "// edit\n", is_run_target=False)
+    err = check_buffer_completion(b, validations, ["feedback", "prover"], skipped=[], version_history=[])
+    assert err is not None
 
 
 # --- buffers-map reducer ---------------------------------------------------

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -4,6 +4,7 @@ from composer.spec.source.spec_buffers import (
     NamedBuffer,
     buffer_digest,
     buffer_files,
+    combined_buffers_view,
     import_closure,
     merge_buffers,
     plan_buffer_runs,
@@ -107,6 +108,13 @@ def test_buffer_files_shared_only_itself():
 
 def test_run_targets_excludes_shared():
     assert [b.name for b in run_targets(_buffers())] == ["easy", "hard"]
+
+
+def test_combined_buffers_view_includes_all_with_headers():
+    out = combined_buffers_view(_buffers())
+    assert "buffer easy (run-target)" in out
+    assert "buffer shared (shared)" in out
+    assert "r_easy" in out and "ghost g" in out
 
 
 # --- coverage --------------------------------------------------------------

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -1,0 +1,166 @@
+"""Unit tests for the multi-spec-buffer substrate."""
+
+from composer.spec.source.spec_buffers import (
+    NamedBuffer,
+    buffer_digest,
+    import_closure,
+    merge_buffers,
+    run_targets,
+    validate_coverage,
+    validate_disjoint_rules,
+)
+
+SHARED = "ghost g(uint) returns uint;\n"
+EASY = 'import "shared.spec";\nrule r_easy { assert true; }\n'
+HARD = 'import "shared.spec";\nrule r_hard { assert g(0) >= 0; }\n'
+
+
+def _buffers(**overrides):
+    b = {
+        "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
+        "easy": NamedBuffer(
+            name="easy", cvl=EASY, property_rules={"P-easy": ["r_easy"]}, imports=("shared",)
+        ),
+        "hard": NamedBuffer(
+            name="hard", cvl=HARD, property_rules={"P-hard": ["r_hard"]}, imports=("shared",)
+        ),
+    }
+    b.update(overrides)
+    return b
+
+
+# --- model -----------------------------------------------------------------
+
+
+def test_owned_rules_and_properties_derive_from_mapping():
+    b = NamedBuffer(name="g", cvl="", property_rules={"P1": ["a", "b"], "P2": ["c"]})
+    assert b.properties == {"P1", "P2"}
+    assert b.owned_rules == {"a", "b", "c"}
+
+
+def test_shared_buffer_owns_nothing():
+    b = _buffers()["shared"]
+    assert b.owned_rules == frozenset()
+    assert b.is_run_target is False
+
+
+# --- import closure --------------------------------------------------------
+
+
+def test_import_closure_includes_transitive_imports():
+    b = _buffers()
+    b["mid"] = NamedBuffer(name="mid", cvl="// mid\n", imports=("shared",), is_run_target=False)
+    b["top"] = NamedBuffer(name="top", cvl="// top\n", property_rules={"P-top": ["r_top"]}, imports=("mid",))
+    names = {x.name for x in import_closure(b, "top")}
+    assert names == {"top", "mid", "shared"}
+
+
+def test_import_closure_tolerates_cycles_and_dangling():
+    b = {
+        "a": NamedBuffer(name="a", cvl="a", imports=("b", "missing")),
+        "b": NamedBuffer(name="b", cvl="b", imports=("a",)),
+    }
+    names = {x.name for x in import_closure(b, "a")}
+    assert names == {"a", "b"}  # cycle terminates; unknown "missing" skipped
+
+
+# --- digest ----------------------------------------------------------------
+
+
+def test_digest_changes_when_shared_import_changes():
+    b = _buffers()
+    before = buffer_digest(b, "easy")
+    b["shared"] = NamedBuffer(name="shared", cvl=SHARED + "ghost h(uint) returns uint;\n", is_run_target=False)
+    after = buffer_digest(b, "easy")
+    assert before != after  # editing an imported buffer invalidates the importer
+
+
+def test_digest_stable_and_independent_across_buffers():
+    b = _buffers()
+    assert buffer_digest(b, "easy") == buffer_digest(b, "easy")  # deterministic
+    b["hard"] = NamedBuffer(name="hard", cvl=HARD + "// tweak\n", property_rules={"P-hard": ["r_hard"]}, imports=("shared",))
+    assert buffer_digest(_buffers(), "easy") == buffer_digest(b, "easy")  # editing hard doesn't touch easy
+
+
+def test_digest_folds_in_extra_parts():
+    b = _buffers()
+    assert buffer_digest(b, "easy", extra_parts=["skipped:P-x"]) != buffer_digest(b, "easy")
+
+
+# --- run targets -----------------------------------------------------------
+
+
+def test_run_targets_excludes_shared():
+    assert [b.name for b in run_targets(_buffers())] == ["easy", "hard"]
+
+
+# --- coverage --------------------------------------------------------------
+
+
+def test_coverage_ok():
+    assert validate_coverage(_buffers(), all_properties={"P-easy", "P-hard"}, skipped=set()) is None
+
+
+def test_coverage_missing_property():
+    err = validate_coverage(_buffers(), all_properties={"P-easy", "P-hard", "P-extra"}, skipped=set())
+    assert err is not None and "no buffer" in err
+
+
+def test_coverage_duplicate_property():
+    b = _buffers()
+    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-easy": ["r_hard"]}, imports=("shared",))
+    err = validate_coverage(b, all_properties={"P-easy", "P-hard"}, skipped=set())
+    assert err is not None and "more than one buffer" in err
+
+
+def test_coverage_skipped_not_required_nor_assignable():
+    ok = {
+        "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
+        "easy": NamedBuffer(name="easy", cvl=EASY, property_rules={"P-easy": ["r_easy"]}, imports=("shared",)),
+    }
+    assert validate_coverage(ok, all_properties={"P-easy", "P-hard"}, skipped={"P-hard"}) is None
+    err = validate_coverage(_buffers(), all_properties={"P-easy", "P-hard"}, skipped={"P-hard"})
+    assert err is not None and "skipped" in err
+
+
+def test_coverage_unknown_property():
+    b = _buffers()
+    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-ghost": ["r_hard"]}, imports=("shared",))
+    err = validate_coverage(b, all_properties={"P-easy", "P-hard"}, skipped=set())
+    assert err is not None and "unknown" in err
+
+
+# --- buffers-map reducer ---------------------------------------------------
+
+
+def test_merge_buffers_right_wins_and_adds():
+    left = {"a": NamedBuffer(name="a", cvl="A")}
+    right = {"a": NamedBuffer(name="a", cvl="A2"), "b": NamedBuffer(name="b", cvl="B")}
+    out = merge_buffers(left, right)
+    assert out["a"].cvl == "A2" and out["b"].cvl == "B"
+
+
+def test_merge_buffers_none_deletes():
+    left = {"a": NamedBuffer(name="a", cvl="A"), "b": NamedBuffer(name="b", cvl="B")}
+    out = merge_buffers(left, {"b": None})
+    assert set(out) == {"a"}
+
+
+def test_merge_buffers_does_not_mutate_left():
+    left = {"a": NamedBuffer(name="a", cvl="A")}
+    merge_buffers(left, {"a": None, "b": NamedBuffer(name="b", cvl="B")})
+    assert set(left) == {"a"}
+
+
+# --- disjoint rules --------------------------------------------------------
+
+
+def test_disjoint_rules_ok():
+    assert validate_disjoint_rules(_buffers()) is None
+
+
+def test_disjoint_rules_detects_shared_rule_name():
+    b = _buffers()
+    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-hard": ["r_easy"]}, imports=("shared",))
+    err = validate_disjoint_rules(b)
+    assert err is not None and "r_easy" in err

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -3,8 +3,10 @@
 from composer.spec.source.spec_buffers import (
     NamedBuffer,
     buffer_digest,
+    buffer_files,
     import_closure,
     merge_buffers,
+    plan_buffer_runs,
     run_targets,
     validate_coverage,
     validate_disjoint_rules,
@@ -87,6 +89,19 @@ def test_digest_folds_in_extra_parts():
     assert buffer_digest(b, "easy", extra_parts=["skipped:P-x"]) != buffer_digest(b, "easy")
 
 
+# --- materialization -------------------------------------------------------
+
+
+def test_buffer_files_includes_buffer_and_its_imports():
+    files = buffer_files(_buffers(), "easy")
+    assert set(files) == {"easy.spec", "shared.spec"}  # easy + its import, not hard
+    assert files["easy.spec"] == EASY and files["shared.spec"] == SHARED
+
+
+def test_buffer_files_shared_only_itself():
+    assert set(buffer_files(_buffers(), "shared")) == {"shared.spec"}
+
+
 # --- run targets -----------------------------------------------------------
 
 
@@ -128,6 +143,22 @@ def test_coverage_unknown_property():
     b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-ghost": ["r_hard"]}, imports=("shared",))
     err = validate_coverage(b, all_properties={"P-easy", "P-hard"}, skipped=set())
     assert err is not None and "unknown" in err
+
+
+# --- run planning ----------------------------------------------------------
+
+
+def test_plan_buffer_runs_skips_complete_and_excludes_shared():
+    b = _buffers()
+    plan = plan_buffer_runs(
+        b,
+        digest_of=lambda buf: f"d-{buf.name}",
+        is_complete=lambda buf, d: buf.name == "easy",  # easy already verified at its digest
+    )
+    by = {r.buffer.name: r for r in plan}
+    assert set(by) == {"easy", "hard"}  # shared is not a run target
+    assert by["easy"].needs_run is False and by["hard"].needs_run is True
+    assert by["easy"].digest == "d-easy"
 
 
 # --- buffers-map reducer ---------------------------------------------------

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -189,7 +189,21 @@ def test_coverage_unknown_property():
     assert err is not None and "unknown" in err
 
 
+def test_coverage_all_properties_skipped_needs_no_run_target():
+    # Every property skipped: nothing must be assigned, so a buffer map with no run-target is valid.
+    b = {"shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False)}
+    assert validate_coverage(b, all_properties={"P-easy", "P-hard"}, skipped={"P-easy", "P-hard"}) is None
+
+
 # --- per-buffer completion (validation stamps) -----------------------------
+
+
+def test_buffer_completion_vacuous_without_run_targets():
+    # No run-target buffers means no stamps to require; completion is vacuously satisfied.
+    b = {"shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False)}
+    assert check_buffer_completion(
+        b, {}, ["feedback", "prover"], skipped=[], version_history=[]
+    ) is None
 
 
 def _stamp(buffers, name, key):

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -8,7 +8,6 @@ from composer.spec.source.spec_buffers import (
     combined_buffers_view,
     import_closure,
     merge_buffers,
-    plan_buffer_runs,
     run_targets,
     validate_coverage,
     validate_disjoint_rules,
@@ -139,22 +138,6 @@ def test_coverage_unknown_property():
     b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-ghost": ["r_hard"]}, imports=("shared",))
     err = validate_coverage(b, all_properties={"P-easy", "P-hard"}, skipped=set())
     assert err is not None and "unknown" in err
-
-
-# --- run planning ----------------------------------------------------------
-
-
-def test_plan_buffer_runs_skips_complete_and_excludes_shared():
-    b = _buffers()
-    plan = plan_buffer_runs(
-        b,
-        digest_of=lambda buf: f"d-{buf.name}",
-        is_complete=lambda buf, d: buf.name == "easy",  # easy already verified at its digest
-    )
-    by = {r.buffer.name: r for r in plan}
-    assert set(by) == {"easy", "hard"}  # shared is not a run target
-    assert by["easy"].needs_run is False and by["hard"].needs_run is True
-    assert by["easy"].digest == "d-easy"
 
 
 # --- per-buffer completion (validation stamps) -----------------------------

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -228,8 +228,39 @@ def test_buffer_completion_vacuous_without_run_targets():
 
 
 def _stamp(buffers, name, key):
-    d = buffer_state_digest(buffers, name, skipped=[], version_history=[])
+    # The feedback stamp also tracks the buffer's claimed properties (include_claim); the prover stamp
+    # does not — mirrors check_buffer_completion.
+    d = buffer_state_digest(
+        buffers, name, skipped=[], version_history=[], include_claim=(key == "feedback")
+    )
     return {f"{key}:{name}": d}
+
+
+def test_feedback_digest_tracks_claim_but_prover_digest_does_not():
+    # Re-assigning a buffer's claimed properties (property_rules) with unchanged CVL must invalidate the
+    # feedback stamp (the judge reviews against the claim) but NOT the prover stamp (the same rules were
+    # verified).
+    b = _buffers()
+    reclaimed = {**b, "easy": b["easy"].model_copy(update={"property_rules": {"P-moved": ["r_easy"]}})}
+    kw = dict(skipped=[], version_history=[])
+    assert buffer_state_digest(b, "easy", include_claim=True, **kw) != \
+        buffer_state_digest(reclaimed, "easy", include_claim=True, **kw)   # feedback: stale
+    assert buffer_state_digest(b, "easy", **kw) == \
+        buffer_state_digest(reclaimed, "easy", **kw)                       # prover: unchanged
+
+
+def test_buffer_completion_rejects_stale_feedback_after_claim_change():
+    # A feedback stamp taken before a claim change is stale for completion; the prover stamp is not.
+    b = _buffers()
+    validations = {}
+    for name in ("easy", "hard"):
+        validations.update(_stamp(b, name, "feedback"))
+        validations.update(_stamp(b, name, "prover"))
+    reclaimed = {**b, "easy": b["easy"].model_copy(update={"property_rules": {"P-moved": ["r_easy"]}})}
+    err = check_buffer_completion(
+        reclaimed, validations, ["feedback", "prover"], skipped=[], version_history=[]
+    )
+    assert err is not None and "easy" in err and "feedback" in err
 
 
 def test_buffer_completion_ok_when_all_stamped_at_digest():

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -1,17 +1,30 @@
 """Unit tests for the multi-spec-buffer substrate."""
 
 from composer.spec.source.spec_buffers import (
+    DEFAULT_MAX_SPEC_BUFFERS,
     NamedBuffer,
     buffer_digest,
     buffer_state_digest,
     check_buffer_completion,
     combined_buffers_view,
     import_closure,
+    max_spec_buffers,
     merge_buffers,
     run_targets,
     validate_coverage,
     validate_disjoint_rules,
 )
+
+
+def test_max_spec_buffers_default_override_and_fallback(monkeypatch):
+    monkeypatch.delenv("AUTOPROVER_MAX_SPEC_BUFFERS", raising=False)
+    assert max_spec_buffers() == DEFAULT_MAX_SPEC_BUFFERS == 6
+    monkeypatch.setenv("AUTOPROVER_MAX_SPEC_BUFFERS", "3")
+    assert max_spec_buffers() == 3
+    monkeypatch.setenv("AUTOPROVER_MAX_SPEC_BUFFERS", "0")  # <1 -> default
+    assert max_spec_buffers() == 6
+    monkeypatch.setenv("AUTOPROVER_MAX_SPEC_BUFFERS", "nope")  # non-int -> default
+    assert max_spec_buffers() == 6
 
 SHARED = "ghost g(uint) returns uint;\n"
 EASY = 'import "shared.spec";\nrule r_easy { assert true; }\n'

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -71,10 +71,10 @@ def _buffers(**overrides):
     b = {
         "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
         "easy": NamedBuffer(
-            name="easy", cvl=EASY, property_rules={"P-easy": ["r_easy"]}, imports=("shared",)
+            name="easy", cvl=EASY, property_rules={"P-easy": ["r_easy"]}
         ),
         "hard": NamedBuffer(
-            name="hard", cvl=HARD, property_rules={"P-hard": ["r_hard"]}, imports=("shared",)
+            name="hard", cvl=HARD, property_rules={"P-hard": ["r_hard"]}
         ),
     }
     b.update(overrides)
@@ -101,16 +101,16 @@ def test_shared_buffer_owns_nothing():
 
 def test_import_closure_includes_transitive_imports():
     b = _buffers()
-    b["mid"] = NamedBuffer(name="mid", cvl="// mid\n", imports=("shared",), is_run_target=False)
-    b["top"] = NamedBuffer(name="top", cvl="// top\n", property_rules={"P-top": ["r_top"]}, imports=("mid",))
+    b["mid"] = NamedBuffer(name="mid", cvl='import "shared.spec";\n', is_run_target=False)
+    b["top"] = NamedBuffer(name="top", cvl='import "mid.spec";\n', property_rules={"P-top": ["r_top"]})
     names = {x.name for x in import_closure(b, "top")}
     assert names == {"top", "mid", "shared"}
 
 
 def test_import_closure_tolerates_cycles_and_dangling():
     b = {
-        "a": NamedBuffer(name="a", cvl="a", imports=("b", "missing")),
-        "b": NamedBuffer(name="b", cvl="b", imports=("a",)),
+        "a": NamedBuffer(name="a", cvl='import "b.spec"; import "missing.spec";'),
+        "b": NamedBuffer(name="b", cvl='import "a.spec";'),
     }
     names = {x.name for x in import_closure(b, "a")}
     assert names == {"a", "b"}  # cycle terminates; unknown "missing" skipped
@@ -130,7 +130,7 @@ def test_digest_changes_when_shared_import_changes():
 def test_digest_stable_and_independent_across_buffers():
     b = _buffers()
     assert buffer_digest(b, "easy") == buffer_digest(b, "easy")  # deterministic
-    b["hard"] = NamedBuffer(name="hard", cvl=HARD + "// tweak\n", property_rules={"P-hard": ["r_hard"]}, imports=("shared",))
+    b["hard"] = NamedBuffer(name="hard", cvl=HARD + "// tweak\n", property_rules={"P-hard": ["r_hard"]})
     assert buffer_digest(_buffers(), "easy") == buffer_digest(b, "easy")  # editing hard doesn't touch easy
 
 
@@ -167,7 +167,7 @@ def test_coverage_missing_property():
 
 def test_coverage_duplicate_property():
     b = _buffers()
-    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-easy": ["r_hard"]}, imports=("shared",))
+    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-easy": ["r_hard"]})
     err = validate_coverage(b, all_properties={"P-easy", "P-hard"}, skipped=set())
     assert err is not None and "more than one buffer" in err
 
@@ -175,7 +175,7 @@ def test_coverage_duplicate_property():
 def test_coverage_skipped_not_required_nor_assignable():
     ok = {
         "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
-        "easy": NamedBuffer(name="easy", cvl=EASY, property_rules={"P-easy": ["r_easy"]}, imports=("shared",)),
+        "easy": NamedBuffer(name="easy", cvl=EASY, property_rules={"P-easy": ["r_easy"]}),
     }
     assert validate_coverage(ok, all_properties={"P-easy", "P-hard"}, skipped={"P-hard"}) is None
     err = validate_coverage(_buffers(), all_properties={"P-easy", "P-hard"}, skipped={"P-hard"})
@@ -184,7 +184,7 @@ def test_coverage_skipped_not_required_nor_assignable():
 
 def test_coverage_unknown_property():
     b = _buffers()
-    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-ghost": ["r_hard"]}, imports=("shared",))
+    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-ghost": ["r_hard"]})
     err = validate_coverage(b, all_properties={"P-easy", "P-hard"}, skipped=set())
     assert err is not None and "unknown" in err
 
@@ -236,7 +236,7 @@ def test_buffer_completion_stamp_goes_stale_on_edit():
         validations.update(_stamp(b, name, "feedback"))
         validations.update(_stamp(b, name, "prover"))
     # Edit `easy`: its digest changes, so its stamps go stale.
-    b["easy"] = NamedBuffer(name="easy", cvl=EASY + "// edit\n", property_rules={"P-easy": ["r_easy"]}, imports=("shared",))
+    b["easy"] = NamedBuffer(name="easy", cvl=EASY + "// edit\n", property_rules={"P-easy": ["r_easy"]})
     err = check_buffer_completion(b, validations, ["feedback", "prover"], skipped=[], version_history=[])
     assert err is not None and "easy" in err
 
@@ -284,6 +284,6 @@ def test_disjoint_rules_ok():
 
 def test_disjoint_rules_detects_shared_rule_name():
     b = _buffers()
-    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-hard": ["r_easy"]}, imports=("shared",))
+    b["hard"] = NamedBuffer(name="hard", cvl=HARD, property_rules={"P-hard": ["r_easy"]})
     err = validate_disjoint_rules(b)
     assert err is not None and "r_easy" in err

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -3,7 +3,6 @@
 from composer.spec.source.spec_buffers import (
     NamedBuffer,
     buffer_digest,
-    buffer_files,
     buffer_state_digest,
     check_buffer_completion,
     combined_buffers_view,
@@ -90,19 +89,6 @@ def test_digest_stable_and_independent_across_buffers():
 def test_digest_folds_in_extra_parts():
     b = _buffers()
     assert buffer_digest(b, "easy", extra_parts=["skipped:P-x"]) != buffer_digest(b, "easy")
-
-
-# --- materialization -------------------------------------------------------
-
-
-def test_buffer_files_includes_buffer_and_its_imports():
-    files = buffer_files(_buffers(), "easy")
-    assert set(files) == {"easy.spec", "shared.spec"}  # easy + its import, not hard
-    assert files["easy.spec"] == EASY and files["shared.spec"] == SHARED
-
-
-def test_buffer_files_shared_only_itself():
-    assert set(buffer_files(_buffers(), "shared")) == {"shared.spec"}
 
 
 # --- run targets -----------------------------------------------------------

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -7,6 +7,7 @@ from composer.spec.source.spec_buffers import (
     buffer_state_digest,
     check_buffer_completion,
     combined_buffers_view,
+    duplicated_declarations,
     import_closure,
     max_spec_buffers,
     merge_buffers,
@@ -14,6 +15,41 @@ from composer.spec.source.spec_buffers import (
     validate_coverage,
     validate_disjoint_rules,
 )
+
+
+_COMMON = (
+    "ghost mapping(uint => uint) gm;\n"
+    "methods {\n"
+    "    function _.foo() external => NONDET;\n"
+    "    function _.bar(address) external => NONDET;\n"
+    "}\n"
+)
+
+
+def test_duplicated_declarations_flags_copypaste_across_run_targets():
+    b = {
+        "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
+        "a": NamedBuffer(name="a", cvl=_COMMON + "rule ra { assert true; }\n",
+                         property_rules={"P-a": ["ra"]}),
+        "b": NamedBuffer(name="b", cvl=_COMMON + "rule rb { assert true; }\n",
+                         property_rules={"P-b": ["rb"]}),
+    }
+    dups = duplicated_declarations(b)
+    assert dups["ghost mapping(uint => uint) gm;"] == ["a", "b"]
+    assert dups["function _.foo() external => NONDET;"] == ["a", "b"]
+    assert dups["function _.bar(address) external => NONDET;"] == ["a", "b"]
+
+
+def test_duplicated_declarations_ignores_single_buffer_and_shared():
+    b = {
+        # a shared buffer carrying the entry is the CORRECT structure, not a duplication
+        "shared": NamedBuffer(name="shared", cvl="methods {\n function _.z() external => NONDET;\n}\n",
+                              is_run_target=False),
+        "a": NamedBuffer(name="a", cvl="methods {\n function _.foo() external => NONDET;\n}\n"
+                         "rule ra { assert true; }\n", property_rules={"P-a": ["ra"]}),
+        "b": NamedBuffer(name="b", cvl="rule rb { assert true; }\n", property_rules={"P-b": ["rb"]}),
+    }
+    assert duplicated_declarations(b) == {}  # foo only in a; z only in the shared buffer
 
 
 def test_max_spec_buffers_default_override_and_fallback(monkeypatch):

--- a/tests/test_spec_buffers.py
+++ b/tests/test_spec_buffers.py
@@ -4,6 +4,7 @@ from composer.spec.source.spec_buffers import (
     DEFAULT_MAX_SPEC_BUFFERS,
     NamedBuffer,
     buffer_digest,
+    buffer_imports,
     buffer_state_digest,
     check_buffer_completion,
     combined_buffers_view,
@@ -15,6 +16,26 @@ from composer.spec.source.spec_buffers import (
     validate_coverage,
     validate_disjoint_rules,
 )
+
+
+def test_buffer_path_is_fixed_to_specs_dir():
+    # The buffer's location is enforced (agent cannot choose it), overwriting any passed path.
+    assert NamedBuffer(name="foo", cvl="").path == "certora/specs/foo.spec"
+    assert NamedBuffer(name="foo", cvl="", path="elsewhere/foo.spec").path == "certora/specs/foo.spec"
+
+
+def test_buffer_imports_resolves_siblings_by_path_ignores_resources():
+    b = {
+        "shared": NamedBuffer(name="shared", cvl=SHARED, is_run_target=False),
+        "r": NamedBuffer(
+            name="r",
+            cvl='import "shared.spec";\nimport "summaries/oracle.spec";\nrule x { assert true; }\n',
+            property_rules={"P-r": ["x"]},
+        ),
+    }
+    # the sibling buffer resolves (certora/specs/shared.spec); the path'd autosetup resource
+    # (certora/specs/summaries/oracle.spec) is no buffer's path, so it is not a dependency.
+    assert buffer_imports(b, "r") == ("shared",)
 
 
 _COMMON = (

--- a/tests/test_spec_imports.py
+++ b/tests/test_spec_imports.py
@@ -1,0 +1,46 @@
+"""Unit tests for the CVL import extractor.
+
+``imports_in_cvl`` feeds prover-cache invalidation (a spec's imports are hashed into the cache key),
+so *missing* a real import is a soundness bug — a changed import
+would not invalidate the cache. These cases pin the char-level scan against
+the line-based regex it replaced, which missed a second import on the same line and any import
+preceded by an inline block comment.
+"""
+
+import pytest
+
+from certora_autosetup.parsers.spec_imports import imports_in_cvl, parse_imports_from_spec
+
+
+@pytest.mark.parametrize("text, expected", [
+    # --- the cases the old line-regex got WRONG (soundness-critical) ---
+    ('import "a.spec"; import "b.spec";\nrule r {}', ["a.spec", "b.spec"]),   # two on one line
+    ('/* header */ import "a.spec";\nrule r {}', ["a.spec"]),                 # inline block comment before
+    # --- comments must NOT yield phantom imports ---
+    ('import "a.spec";\n// import "x.spec";\nrule r {}', ["a.spec"]),          # // commented out
+    ('import "a.spec";\n/* import "x.spec"; */\nrule r {}', ["a.spec"]),       # /* */ commented out
+    ('/* a\n import "x.spec";\n b */\nimport "real.spec";', ["real.spec"]),    # multi-line block comment
+    # --- strings must NOT yield phantom imports, nor swallow real ones ---
+    ('rule r { string s = "import \\"x.spec\\""; }', []),                      # import text inside a string
+    ('methods { function _.u() external => f("a // b"); }\nimport "a.spec";', ["a.spec"]),  # // in a string
+    # --- keyword boundary: importFoo is an identifier, not an import ---
+    ('methods { function importFoo() external; }\nimport "a.spec";', ["a.spec"]),
+    # --- resource (path'd) and sibling (bare) imports both surface ---
+    ('import "shared.spec";\nimport "summaries/o.spec";\nrule r {}', ["shared.spec", "summaries/o.spec"]),
+    ('rule r { assert true; }', []),                                          # none
+])
+def test_imports_in_cvl(text, expected):
+    assert imports_in_cvl(text) == expected
+
+
+def test_parse_imports_from_spec_recursive(tmp_path):
+    # a -> b -> c (transitive); a also imports a missing file (skipped with a warning, not crash)
+    (tmp_path / "c.spec").write_text("rule rc { assert true; }\n")
+    (tmp_path / "b.spec").write_text('import "c.spec";\nrule rb { assert true; }\n')
+    (tmp_path / "a.spec").write_text('import "b.spec"; import "gone.spec";\nrule ra { assert true; }\n')
+
+    recursive = {p.name for p in parse_imports_from_spec(tmp_path / "a.spec", recursive=True)}
+    assert recursive == {"b.spec", "c.spec"}  # transitive closure; unresolvable "gone.spec" dropped
+
+    direct = {p.name for p in parse_imports_from_spec(tmp_path / "a.spec", recursive=False)}
+    assert direct == {"b.spec"}  # only the resolvable direct import


### PR DESCRIPTION
## Summary

Today the CVL-generation agent authors **one** spec with **one** global `methods{}` block, so
every rule is verified under the *intersection* of what all rules need precise — one property
that needs an expensive function (nonlinear math, hashing, a heavy external) kept exact forces
**every** rule to pay that cost. That coupling is a common source of timeouts, and a single
combined run cannot escape it.

This PR replaces the single-spec model with **named spec buffers**: the agent partitions its
properties into several self-contained CVL buffers, each with its **own** `methods{}` (so a
function summarized in one buffer can stay exact in another), and each **verified and reviewed
independently and in parallel**. A function's precision cost is now paid only by the buffer that
needs it.

It also converts the prover interaction from a blocking, one-spec-at-a-time call into an
**async submit/collect** model, so buffers prove concurrently and the agent keeps working
(authoring the next buffer, or processing a finished result) instead of blocking on the slowest
job.

Validated end-to-end on a real project (see *Validation*).

## The buffer model

- **Named buffers.** `put_buffer` / `edit_buffer` / `get_buffer` / `list_buffers` /
  `delete_buffer` author CVL buffers; `submit_buffer` / `collect_results` verify them (replacing
  `verify_spec`).
- **Run-target vs shared.** A **run-target** buffer declares `property_rules` (the properties it
  verifies + their rule names) and is run by the prover. A **shared** buffer (`is_run_target=false`)
  carries infrastructure (ghosts, common invariants, helper CVL, token/oracle models, summaries)
  and is never run itself.
- **Selective imports.** A shared buffer is imported only by the run-targets that declare it — so
  a subset of run-targets can share one base while another subset shares a different one, and
  editing a shared buffer re-verifies only its importers.
- **Coverage is enforced.** Every non-skipped property must appear in **exactly one** run-target,
  and each rule lives in exactly one buffer (`validate_coverage` / `validate_disjoint_rules`).
- **Per-buffer completion.** Publishing requires, per run-target, both a **prover** and a
  **feedback** stamp keyed to a content digest over the buffer's *import closure* — so editing a
  buffer (or a shared buffer it imports) invalidates exactly the buffers affected, and nothing
  else is re-run.

## The async prover model

- `submit_buffer(name)` launches a prover job in the **background** and returns immediately
  (concurrency-throttled; idempotent; supersedes a stale in-flight job for the same buffer).
- `collect_results()` **drains finished jobs without blocking** and returns a status board
  (`complete` / `running` / `needs (re)submission`); it blocks only when there is nothing else to
  do. The agent works a strict priority order — process a finished result, else author/submit the
  next buffer, else block on the next completion.
- **Snapshot isolation.** Each job materializes its buffers to tagged `{name}__{digest}.spec`
  files with sibling imports retargeted, so concurrent jobs never read each other's in-flight
  edits.
- **Shared-base refine.** Editing a shared buffer invalidates every importer (including
  already-verified ones); the board lists them under `needs (re)submission` so the agent re-runs
  exactly those.

## Guidance & advisories

- **Prompt guidance** now leads with the intersection argument and **strongly recommends**
  splitting by precision need + adding over-approximating performance summaries *preemptively*
  (before a monolithic run), including the `assert`-only vs `satisfy` soundness split. It is a
  recommendation, not a mandate.
- **Duplication linter** (advisory, report-once): flags `methods{}`/ghost declarations duplicated
  verbatim across run-targets and suggests hoisting them into a shared buffer. It only *tells* —
  it never blocks.

## Reliability fixes (independent; bundled here — can be split if preferred)

- **Anthropic mid-stream retry** (`composer/llm/anthropic.py`): a mid-stream connection drop
  surfaces as a raw `httpx.RemoteProtocolError`; treat it as retryable.
- **Cloud re-fetch, never re-prove** (`composer/prover/cloud.py`): a transient failure while
  downloading a *completed* job's results used to bubble up and re-run the whole (often
  hours-long) proof. Now the fetch itself is retried with capped exponential backoff against the
  already-`SUCCEEDED` job.
- **Configurable sanity timeout** (`certora_autosetup/setup/sanity.py`): `AUTOPROVER_SANITY_TIMEOUT`
  (default 1200s) caps the sanity phase's per-job timeout.

## Config knobs

- `AUTOPROVER_MAX_SPEC_BUFFERS` — max run-target buffers (default **6**).
- `AUTOPROVER_SANITY_TIMEOUT` — sanity-phase per-job timeout in seconds (default **1200**).

## Files

New substrate & tools:
- `composer/spec/source/spec_buffers.py` — pure buffer substrate (model, import closure, digests,
  coverage/disjointness validation, completion stamps, dup detection).
- `composer/spec/source/buffer_tools.py` — the authoring tools (`put/get/edit/list/delete_buffer`,
  cap enforcement).

Wiring & orchestration:
- `composer/spec/source/prover.py` — async `submit_buffer` / `collect_results`, materialization,
  job supersession, dup-linter surfacing.
- `composer/spec/source/author.py` — buffer-only authoring mode, per-buffer review/feedback,
  buffer guidance.
- `composer/spec/source/pipeline.py`, `autoprove_common.py`, `composer/spec/cvl_generation.py`,
  `composer/certora_env.py`, `certora_autosetup/cache/content_cache.py` — supporting wiring.
- `composer/templates/property_generation_system_prompt.j2` — prompt updates.

## Testing

**51 new unit tests** across 7 files, all pure (no live prover / no jar):
- `test_spec_buffers.py` (26) — substrate: ownership, import closure, digests, coverage,
  disjoint rules, completion stamps, dup detection, buffer-map reducer.
- `test_buffer_completion.py` (6), `test_spec_buffer_prover.py` (5), `test_buffer_tools.py` (5) —
  completion tracking, async submit/collect + per-buffer feedback, cap enforcement.
- `test_cloud_fetch_retry.py` (2), `test_sanity_timeout.py` (4), `test_anthropic_retry.py` (3) —
  the reliability fixes.

Full non-expensive suite green (**1219 passed**; the only errors are pre-existing
`test_rag_db.py [postgres]` env cases that need the local RAG container). `pyright` clean.

## Validation (live cloud run)

Run on a testing real project:
- The agent **split into 6 run-target buffers across multiple property classes** (
  init/ownership, impl/upgrade-auth, attack-vectors; combinatorial-collateral: core, operations,
  attack) — i.e. multiple buffers *within* a property class, not merely one per class.
- **52 cloud jobs driven in parallel** (up to 3 concurrent in flight), with re-submissions as
  buffers were refined.
- **0 rules timed out** (146 VERIFIED / 75 VIOLATED instantiations; the VIOLATED set is the
  expected-failure attack vectors + refinement CEXes).
- The **dup-linter fired advisorily** (e.g. `owner()` across the 3 buffers) and the agent
  correctly treated it as a non-blocking suggestion.
- The **cloud re-fetch path saw 0 connection failures** across the full 52-job fetch load (the
  same volume that previously surfaced transient stalls).

## Follow-ups (out of scope)

- **Comment-only re-verification** (TODO in `spec_buffers.py`): a pure-comment edit changes the
  buffer digest and re-runs an identical proof. The fix is a separate comment-stripped *prover*
  digest distinct from the raw *feedback* digest — noted, not done here.
- A spurious-CEX issue observed on the run traces to an **agent-authored summary in
  `custom_summaries.spec`** (SafeTransferLib path not covered) and the summarizer↔CVL-agent
  one-way handoff — a **pre-existing, unrelated** issue, not introduced by this PR; handed off
  separately.