### PR TITLE
Do not enable storage extensions when the Prover cannot read the namespaces

### DIFF
--- a/certora_autosetup/setup/setup_erc7201.py
+++ b/certora_autosetup/setup/setup_erc7201.py
@@ -18,14 +18,48 @@ from certora_autosetup.utils.progress_display import make_tqdm
 from certora_autosetup.utils.logger import logger
 
 
+# certora-cli re-parses the namespace id out of the natspec tag itself, and its
+# parser is narrower than ERC-7201 allows: an id is cut at the first character
+# outside [a-zA-Z.0-9], so "my_project.storage.Token" reaches the Prover as "my"
+# and every id sharing that prefix lands on one storage slot. Probe the installed
+# parser instead of restating its alphabet here, so this check stops firing by
+# itself once the Prover is fixed.
+_FALLBACK_NAMESPACE_PATTERN = re.compile(r'[a-zA-Z.0-9]+')
+
+
+def prover_visible_namespace(namespace: str) -> str:
+    """Return `namespace` as the installed certora-cli would read it back."""
+    try:
+        from certora_cli.CertoraProver.storageExtension import (  # type: ignore[import-not-found]
+            erc7201_of_node,
+        )
+    except ImportError:
+        match = _FALLBACK_NAMESPACE_PATTERN.match(namespace)
+        return match.group(0) if match else ""
+
+    parsed = erc7201_of_node({
+        "nodeType": "StructDefinition",
+        "canonicalName": "AutosetupNamespaceProbe",
+        "documentation": {
+            "nodeType": "StructuredDocumentation",
+            "text": f"@custom:storage-location erc7201:{namespace}",
+        },
+    })
+    return parsed[1] if parsed else ""
+
+
 class ERC7201Scanner:
     """Scanner for ERC-7201 storage location patterns."""
     
     def __init__(self, verbose: bool = False, log_func=None):
         self.verbose = verbose
         self.log = log_func if log_func else logger.log
+        # solc hands the Prover the natspec text with every comment delimiter
+        # stripped, so the comment style the annotation is written in tells us
+        # nothing. Matching '///' alone misses the '/** ... */' form, which is
+        # what OpenZeppelin's upgradeable base contracts use.
         self.erc7201_pattern = re.compile(
-            r'///\s*@custom:storage-location\s+erc7201:([^\s\n]+)',
+            r'@custom:storage-location\s+erc7201:([^\s\n]+)',
             re.IGNORECASE
         )
         self.found_patterns: Dict[str, List[Tuple[str, int]]] = {}
@@ -52,7 +86,7 @@ class ERC7201Scanner:
                 for line_num, line in enumerate(f, 1):
                     match = self.erc7201_pattern.search(line)
                     if match:
-                        namespace = match.group(1).strip()
+                        namespace = match.group(1).strip().removesuffix('*/')
                         patterns.append((namespace, line_num))
                         if self.verbose:
                             self.log(f"Found ERC-7201 pattern in {file_path}:{line_num} -> {namespace}", "DEBUG")
@@ -94,6 +128,42 @@ class ERC7201Scanner:
                 namespaces.add(namespace)
         return namespaces
     
+    def truncated_namespaces(self) -> Dict[str, List[str]]:
+        """Group the detected namespaces that certora-cli would mis-read.
+
+        Returns:
+            Mapping from what the Prover keeps to the real namespaces that collapse
+            onto it. A group of two or more fails the build outright; a group of one
+            still gets the wrong storage slot.
+        """
+        by_visible: Dict[str, List[str]] = {}
+        for namespace in sorted(self.get_unique_namespaces()):
+            visible = prover_visible_namespace(namespace)
+            if visible != namespace:
+                by_visible.setdefault(visible, []).append(namespace)
+        return by_visible
+
+    def disable_config_files(self, directory: Path) -> None:
+        """Drop storage_extension_annotation from configs that already carry it.
+
+        Withholding the flag is not enough on its own: a config written by an
+        earlier run, or by hand, still carries it into the build.
+        """
+        cleared = 0
+        for conf_file in self._config_files(directory):
+            try:
+                config = json.loads(conf_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            if config.pop('storage_extension_annotation', None) is None:
+                continue
+            with open(conf_file, 'w') as f:
+                json.dump(config, f, indent=2)
+            cleared += 1
+            self.log(f"Removed storage_extension_annotation from {conf_file}", "WARNING")
+        if cleared:
+            self.log(f"Cleared storage_extension_annotation from {cleared} configuration files", "WARNING")
+
     def generate_erc7201_spec(self, output_path: Path) -> bool:
         """Generate erc7201.spec file with namespace comments including source locations."""
         if not self.found_patterns:
@@ -135,17 +205,20 @@ class ERC7201Scanner:
         self.log(f"Generated {output_path} with {len(sorted_namespaces)} ERC-7201 namespaces")
         return True
     
-    def update_config_files(self, directory: Path) -> None:
-        """Update configuration files to enable storage_extension_annotation."""
+    def _config_files(self, directory: Path) -> List[Path]:
+        """Collect the project's .conf files, skipping hidden directories."""
         config_files = []
-
-        # Look for .conf files, excluding hidden directories from traversal
         for root, dirs, files in os.walk(directory):
             dirs[:] = [d for d in dirs if not d.startswith('.')]
             for file in files:
                 if file.endswith('.conf'):
                     config_files.append(Path(root) / file)
-        
+        return config_files
+
+    def update_config_files(self, directory: Path) -> None:
+        """Update configuration files to enable storage_extension_annotation."""
+        config_files = self._config_files(directory)
+
         if not config_files:
             if self.verbose:
                 self.log("No .conf files found to update.", "DEBUG")
@@ -224,7 +297,9 @@ def run(directory=".", spec_output="certora/specs/erc7201.spec", verbose=False,
     Returns:
         Tuple of (exit_code, namespaces_found):
         - exit_code: 0 for success, 1 for error
-        - namespaces_found: True if ERC-7201 namespaces were detected
+        - namespaces_found: True if ERC-7201 namespaces were detected AND certora-cli
+          can read them back correctly. False when the Prover would truncate them,
+          so that callers do not turn storage_extension_annotation on downstream.
     """
     directory = Path(directory).resolve()
     if not directory.exists():
@@ -250,6 +325,25 @@ def run(directory=".", spec_output="certora/specs/erc7201.spec", verbose=False,
     if namespaces:
         spec_path = Path(spec_output)
         scanner.generate_erc7201_spec(spec_path)
+
+        truncated = scanner.truncated_namespaces()
+        if truncated:
+            for visible, group in sorted(truncated.items()):
+                logger.log(
+                    f"ERC-7201 namespaces {group} all read as '{visible}' by certora-cli, "
+                    f"which would put them on one storage slot.",
+                    "WARNING",
+                )
+            logger.log(
+                "Leaving storage_extension_annotation off so the build still runs; "
+                "namespaced storage stays unsplit for this project.",
+                "WARNING",
+            )
+            if not no_config_update:
+                scanner.disable_config_files(directory)
+            # Reported as "none usable" rather than "none found": the caller
+            # propagates this into every config it writes later on.
+            return 0, False
 
         # Update existing config files on disk unless disabled
         if not no_config_update:

--- a/certora_autosetup/setup/setup_erc7201_patch.py
+++ b/certora_autosetup/setup/setup_erc7201_patch.py
@@ -125,7 +125,8 @@ def _find_struct_line(lines: List[str], struct_name: str) -> Optional[int]:
 
 def _already_annotated(lines: List[str], struct_line_idx: int) -> bool:
     """Check if the struct at the given line already has an ERC-7201 annotation."""
-    annotation_pattern = re.compile(r"///\s*@custom:storage-location\s+erc7201:", re.IGNORECASE)
+    # Either comment style counts as annotated; solc strips the delimiters anyway.
+    annotation_pattern = re.compile(r"@custom:storage-location\s+erc7201:", re.IGNORECASE)
     for offset in range(1, 4):
         check_idx = struct_line_idx - offset
         if check_idx < 0:

--- a/tests/test_setup_erc7201_namespace_guard.py
+++ b/tests/test_setup_erc7201_namespace_guard.py
@@ -1,0 +1,104 @@
+"""certora-cli reads namespace ids with a narrower alphabet than ERC-7201 allows.
+
+An id is cut at the first character outside [a-zA-Z.0-9], so every id under a
+prefix like `my_project.` reaches the Prover as `my` and lands on one storage
+slot. Two such structs in one contract make the Prover reject the build outright;
+one on its own just verifies against the wrong slot. Autosetup reads the ids
+correctly, so it is the one place that can tell before it turns the annotation on.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from certora_autosetup.setup.setup_erc7201 import (
+    ERC7201Scanner,
+    prover_visible_namespace,
+    run,
+)
+
+TRUNCATED = [
+    "my_project.storage.Token",
+    "my_project.storage.Vault",
+]
+READ_WHOLE = "openzeppelin.storage.Ownable"
+
+
+def test_an_id_with_an_underscore_reaches_the_prover_cut_short() -> None:
+    assert prover_visible_namespace(TRUNCATED[0]) == "my"
+    assert prover_visible_namespace(TRUNCATED[1]) == "my"
+
+
+def test_an_id_the_prover_can_read_comes_back_whole() -> None:
+    assert prover_visible_namespace(READ_WHOLE) == READ_WHOLE
+
+
+def test_ids_that_collapse_are_grouped_under_what_the_prover_sees() -> None:
+    scanner = ERC7201Scanner()
+    scanner.found_patterns = {
+        "Token.sol": [(TRUNCATED[0], 12)],
+        "Vault.sol": [(TRUNCATED[1], 20)],
+        "Ownable.sol": [(READ_WHOLE, 8)],
+    }
+    assert scanner.truncated_namespaces() == {"my": sorted(TRUNCATED)}
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "/// @custom:storage-location erc7201:{ns}",
+        "/** @custom:storage-location erc7201:{ns} */",
+        "/** @custom:storage-location erc7201:{ns}*/",
+        " * @custom:storage-location erc7201:{ns}",
+    ],
+    ids=["line", "block", "block-closed-tight", "block-continuation"],
+)
+def test_every_comment_style_is_detected(tmp_path: Path, annotation: str) -> None:
+    """OpenZeppelin's upgradeable bases annotate with `/** */`, not `///`."""
+    (tmp_path / "Token.sol").write_text(
+        annotation.format(ns=READ_WHOLE) + "\nstruct S { uint256 x; }\n"
+    )
+    scanner = ERC7201Scanner()
+    scanner.scan_directory(tmp_path)
+    assert scanner.get_unique_namespaces() == {READ_WHOLE}
+
+
+def _project(tmp_path: Path, namespace: str, conf: dict | None = None) -> Path:
+    (tmp_path / "Token.sol").write_text(
+        f"/// @custom:storage-location erc7201:{namespace}\nstruct S {{ uint256 x; }}\n"
+    )
+    conf_path = tmp_path / "run.conf"
+    conf_path.write_text(json.dumps(conf if conf is not None else {"files": ["Token.sol"]}))
+    return conf_path
+
+
+def test_annotation_stays_off_for_an_id_the_prover_would_truncate(tmp_path: Path) -> None:
+    conf = _project(tmp_path, TRUNCATED[0])
+
+    _, usable = run(directory=str(tmp_path), spec_output=str(tmp_path / "erc7201.spec"))
+
+    assert usable is False
+    assert "storage_extension_annotation" not in json.loads(conf.read_text())
+
+
+def test_an_annotation_left_by_an_earlier_run_is_cleared(tmp_path: Path) -> None:
+    """Withholding the flag does not help a config that already carries it."""
+    conf = _project(
+        tmp_path,
+        TRUNCATED[0],
+        conf={"files": ["Token.sol"], "storage_extension_annotation": True},
+    )
+
+    run(directory=str(tmp_path), spec_output=str(tmp_path / "erc7201.spec"))
+
+    assert "storage_extension_annotation" not in json.loads(conf.read_text())
+
+
+def test_annotation_is_still_enabled_for_an_id_the_prover_reads_whole(tmp_path: Path) -> None:
+    conf = _project(tmp_path, READ_WHOLE)
+
+    _, usable = run(directory=str(tmp_path), spec_output=str(tmp_path / "erc7201.spec"))
+
+    assert usable is True
+    assert json.loads(conf.read_text())["storage_extension_annotation"] is True


### PR DESCRIPTION
## Why

certora-cli reads the ERC-7201 namespace back out of the natspec tag with a narrower alphabet than the standard allows, so `my_project.storage.Token` reaches the Prover as `my`. Every id under that prefix lands on one storage slot. Two of them in one contract abort the build; one on its own verifies against the wrong slot and says nothing.

Autosetup is what turns `storage_extension_annotation` on, and it reads the ids correctly, so it is the one place that can tell the difference beforehand. This is a stopgap to keep builds alive until the Prover reads ids in full.

## What it does

Where an id would be truncated, autosetup leaves the annotation off, clears it from configs that already carry it, and reports no usable namespaces so `setup_prover` does not set it again on the configs it writes later in the run. Withholding alone was not enough: a config from an earlier run still carried the flag into the build.

It asks the installed certora-cli what it makes of each id, through the Prover's own parser, instead of restating its alphabet. Once the Prover is fixed this check stops firing by itself, so there is no version gate to remember and no follow-up ticket to file.

Two adjacent fixes came out of the same reading:

- The scanner matched only `///` annotations and never saw the `/** */` form. That is the form OpenZeppelin's upgradeable bases use, so most upgradeable projects had namespaces the scanner could not see, and the guard could not have protected them. solc strips the delimiters either way.
- `_already_annotated` in the patcher carried the same `///` assumption, so it could add a second annotation above a struct that already had one written as a block comment.

## One trade-off

A single truncating namespace disables storage extensions for the whole project, including ids the Prover would have read correctly. That is deliberate, and the warning line is the only signal. Per-namespace suppression is not available, since the flag applies per run.

## Tests

Ten tests: the parse, the grouping, all four comment styles, both config paths, and the clean case where the flag is still set. `pyright` reports 0 errors on the touched files, and the existing ERC-7201 scanner tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

