### PR TITLE
llm: retry an error the server reports mid-stream

### DIFF
--- a/composer/llm/anthropic.py
+++ b/composer/llm/anthropic.py
@@ -8,6 +8,7 @@ import asyncio
 from functools import cache
 
 import anthropic
+import httpx
 
 from composer.input.files import UploaderBase, ContentRenderer
 from composer.input.types import ModelConfiguration
@@ -223,10 +224,17 @@ class AnthropicService(ProviderServiceBase):
     def should_retry(self, exc: Exception) -> bool:
         """Mirrors the SDK's own ``_should_retry`` status roster (408/409/429
         and every 5xx, which covers 529 overloaded) plus connection-level
-        failures (``APITimeoutError`` subclasses ``APIConnectionError``).
-        400-class request errors are deterministic — an over-long prompt fails
-        identically on every attempt — and are deliberately excluded."""
+        failures (``APITimeoutError`` subclasses ``APIConnectionError``), and a
+        connection dropped mid-stream. 400-class request errors are
+        deterministic — an over-long prompt fails identically on every attempt —
+        and are deliberately excluded."""
         if isinstance(exc, anthropic.APIConnectionError):
+            return True
+        # A connection that drops mid-stream surfaces as a raw httpx.RemoteProtocolError
+        # ("peer closed connection without sending complete message body") — the SDK does not
+        # wrap streamed-body failures as APIConnectionError, so match it directly. It is a
+        # transient transport failure, retryable like any connection-level error.
+        if isinstance(exc, httpx.RemoteProtocolError):
             return True
         if isinstance(exc, anthropic.APIStatusError):
             return exc.status_code in (408, 409, 429) or exc.status_code >= 500

--- a/composer/llm/anthropic.py
+++ b/composer/llm/anthropic.py
@@ -2,6 +2,7 @@
 ``ModelProvider`` implementation that mints ``ChatAnthropic`` instances."""
 
 from typing import Literal, TypeGuard, Any, TYPE_CHECKING, override, cast
+from collections.abc import Mapping
 from io import BytesIO
 from dataclasses import dataclass, field
 import asyncio
@@ -197,6 +198,30 @@ class AnthropicFileUploader(UploaderBase):
 
 # --- ModelProvider ---------------------------------------------------------
 
+
+RETRYABLE_ERROR_TYPES = frozenset({
+    "overloaded_error",  # 529
+    "api_error",         # 500
+    "rate_limit_error",  # 429
+    "timeout_error",     # 408
+})
+"""The ``error.type`` values of the statuses ``should_retry`` accepts, for payloads whose
+status code cannot speak for them."""
+
+
+def _payload_error_type(body: object) -> str | None:
+    """The ``error.type`` discriminator of an Anthropic error payload, or ``None``
+    for a body of any other shape (the SDK leaves it as the raw text when the
+    payload does not parse)."""
+    if not isinstance(body, Mapping):
+        return None
+    error = body.get("error")
+    if not isinstance(error, Mapping):
+        return None
+    error_type = error.get("type")
+    return error_type if isinstance(error_type, str) else None
+
+
 class AnthropicService(ProviderServiceBase):
     def __init__(self):
         from graphcore.tools.memory import anthropic_async_memory_tool
@@ -224,10 +249,10 @@ class AnthropicService(ProviderServiceBase):
     def should_retry(self, exc: Exception) -> bool:
         """Mirrors the SDK's own ``_should_retry`` status roster (408/409/429
         and every 5xx, which covers 529 overloaded) plus connection-level
-        failures (``APITimeoutError`` subclasses ``APIConnectionError``), and a
-        connection dropped mid-stream. 400-class request errors are
-        deterministic — an over-long prompt fails identically on every attempt —
-        and are deliberately excluded."""
+        failures (``APITimeoutError`` subclasses ``APIConnectionError``), a
+        connection dropped mid-stream, and an error the server reports inside a
+        stream. 400-class request errors are deterministic — an over-long prompt
+        fails identically on every attempt — and are deliberately excluded."""
         if isinstance(exc, anthropic.APIConnectionError):
             return True
         # A connection that drops mid-stream surfaces as a raw httpx.RemoteProtocolError
@@ -237,7 +262,13 @@ class AnthropicService(ProviderServiceBase):
         if isinstance(exc, httpx.RemoteProtocolError):
             return True
         if isinstance(exc, anthropic.APIStatusError):
-            return exc.status_code in (408, 409, 429) or exc.status_code >= 500
+            if exc.status_code in (408, 409, 429) or exc.status_code >= 500:
+                return True
+            # An error the server reports part-way through a stream rides the already-open
+            # 200 response, and the SDK builds the exception from that response — so the
+            # status code carries none of the meaning and the class stays the base
+            # APIStatusError. The transient/deterministic split lives in the payload.
+            return _payload_error_type(exc.body) in RETRYABLE_ERROR_TYPES
         return False
 
 @dataclass

--- a/tests/test_anthropic_retry.py
+++ b/tests/test_anthropic_retry.py
@@ -1,9 +1,11 @@
-"""AnthropicService.should_retry classifies a mid-stream connection drop as retryable.
+"""AnthropicService.should_retry classifies the two failures a stream can deliver.
 
 A connection that drops while the response body streams surfaces as a raw
 ``httpx.RemoteProtocolError`` (the SDK does not wrap streamed-body failures as
-``anthropic.APIConnectionError``); left unclassified it would crash the run instead of resuming
-from checkpoint. See composer/llm/anthropic.py."""
+``anthropic.APIConnectionError``); an error the server reports part-way through a stream rides
+the already-open 200 response, so the exception's status code says nothing about it. Left
+unclassified either one would crash the run instead of resuming from checkpoint.
+See composer/llm/anthropic.py."""
 
 import anthropic
 import httpx
@@ -27,3 +29,46 @@ def test_connection_error_still_retryable():
 
 def test_deterministic_error_not_retryable():
     assert _svc().should_retry(ValueError("bad prompt")) is False
+
+
+def _stream_error(error_type: str, status_code: int = 200) -> anthropic.APIStatusError:
+    """The exception the SDK raises for an error event inside an open stream:
+    built from the streaming response, so it keeps that response's status."""
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    return anthropic.APIStatusError(
+        f"Error code: {status_code}",
+        response=httpx.Response(status_code, request=request),
+        body={"type": "error", "error": {"type": error_type, "message": "..."}},
+    )
+
+
+def test_mid_stream_overloaded_is_retryable():
+    assert _svc().should_retry(_stream_error("overloaded_error")) is True
+
+
+def test_mid_stream_server_error_is_retryable():
+    assert _svc().should_retry(_stream_error("api_error")) is True
+
+
+def test_mid_stream_request_error_not_retryable():
+    assert _svc().should_retry(_stream_error("invalid_request_error")) is False
+
+
+def test_status_code_still_decides_when_it_can():
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    overloaded = anthropic.APIStatusError(
+        "Error code: 529",
+        response=httpx.Response(529, request=request),
+        body=None,
+    )
+    assert _svc().should_retry(overloaded) is True
+
+
+def test_unparsed_body_not_retryable():
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    exc = anthropic.APIStatusError(
+        "gateway said no",
+        response=httpx.Response(200, request=request),
+        body="gateway said no",
+    )
+    assert _svc().should_retry(exc) is False

--- a/tests/test_anthropic_retry.py
+++ b/tests/test_anthropic_retry.py
@@ -1,0 +1,29 @@
+"""AnthropicService.should_retry classifies a mid-stream connection drop as retryable.
+
+A connection that drops while the response body streams surfaces as a raw
+``httpx.RemoteProtocolError`` (the SDK does not wrap streamed-body failures as
+``anthropic.APIConnectionError``); left unclassified it would crash the run instead of resuming
+from checkpoint. See composer/llm/anthropic.py."""
+
+import anthropic
+import httpx
+
+from composer.llm.anthropic import AnthropicService
+
+
+def _svc() -> AnthropicService:
+    return AnthropicService()
+
+
+def test_mid_stream_drop_is_retryable():
+    exc = httpx.RemoteProtocolError("peer closed connection without sending complete message body")
+    assert _svc().should_retry(exc) is True
+
+
+def test_connection_error_still_retryable():
+    exc = anthropic.APIConnectionError(request=httpx.Request("POST", "https://api.anthropic.com"))
+    assert _svc().should_retry(exc) is True
+
+
+def test_deterministic_error_not_retryable():
+    assert _svc().should_retry(ValueError("bad prompt")) is False


### PR DESCRIPTION
## What

`should_retry` decides whether a provider failure is transient, and the run-wide retry floor
resumes a graph from its checkpoint when it is. For an `APIStatusError` that decision reads the
status code: 408/409/429 and every 5xx are retryable.

An error the server reports part-way through a stream never gets a status code of its own. It
arrives as an SSE `error` event on the already-open 200 response, and the SDK builds the exception
from that response. `_make_status_error` finds no mapping for 200, so it hands back the base
`APIStatusError`, carrying `status_code == 200` and naming the real condition (`overloaded_error`,
`api_error`) only in the body. `should_retry` sees the 200, calls the failure deterministic, and it
propagates on the first attempt.

The damage goes past the one task. The property-extraction fan-out is gathered without
`return_exceptions`, so the first such error ends the run before formalization and discards the
component analysis, harness and autosetup work already done.

## How

When the status code cannot speak for the failure, read the payload's `error.type` and accept the
same conditions the status roster accepts: overloaded, api_error, rate limit, timeout. A body of any
other shape stays non-retryable (the SDK leaves it as raw text when the payload does not parse), and
so does a mid-stream `invalid_request_error`, which is as deterministic as its 400 twin.

Builds on #217, which covers the other half of the same gap: a connection that drops mid-stream.
Merge that one first; this PR targets its branch.

## Testing

`tests/test_anthropic_retry.py` covers both mid-stream conditions, the mid-stream request error, an
unparsed body, and a real 529 to keep the status-code path honest. Local: pytest 1189 passed (the
`test_rag_db.py` errors are a postgres container that will not start on this machine), pyright clean
on the CI target set.
