### PR TITLE
autoprover: --certora-run-command to select the Certora install for cloud dispatch

### DIFF
--- a/composer/certora_env.py
+++ b/composer/certora_env.py
@@ -28,12 +28,32 @@ class CertoraEnvironmentError(Exception):
     """
 
 
-def certora_home() -> Path | None:
-    """The Certora source checkout pointed to by ``$CERTORA``.
+# Overrides ``$CERTORA`` for AutoProver's own Certora resolution, set by
+# console-autoprove's ``--certora-run-command``. The sentinel ``"pip"`` forces
+# the pip-installed CLI. This lets a session keep ``$CERTORA`` pointed at a local
+# build (for direct local-prover work) while AutoProver dispatches its cloud jobs
+# through the pip ``certora_cli``: a source checkout is not a pip distribution, so
+# ``get_package_and_version`` reports "not installed" and a cloud submission
+# aborts demanding ``prover_version``/``commit_sha1`` — whereas the pip package
+# carries the version that drives the submission.
+CERTORA_HOME_OVERRIDE_ENV = "AUTOPROVER_CERTORA_HOME"
+_FORCE_PIP = "pip"
 
-    Returns ``None`` when ``$CERTORA`` is unset (i.e. we run against the
-    pip-installed ``certora_cli`` / ``certora_jars`` packages).
+
+def certora_home() -> Path | None:
+    """The Certora source checkout to resolve against, or ``None`` to use the
+    pip-installed ``certora_cli`` / ``certora_jars`` packages.
+
+    ``$AUTOPROVER_CERTORA_HOME`` wins over ``$CERTORA`` when set: a filesystem
+    path selects that source checkout; the sentinel ``"pip"`` forces the pip
+    packages (returns ``None``). With the override unset, falls back to
+    ``$CERTORA`` (a checkout), else the pip packages.
     """
+    override = os.environ.get(CERTORA_HOME_OVERRIDE_ENV)
+    if override is not None:
+        if override.strip().lower() == _FORCE_PIP or not override.strip():
+            return None
+        return Path(override)
     path = os.environ.get("CERTORA")
     return Path(path) if path else None
 

--- a/composer/spec/source/autoprove_common.py
+++ b/composer/spec/source/autoprove_common.py
@@ -3,6 +3,7 @@
 import argparse
 import hashlib
 import logging
+import os
 import pathlib
 import uuid
 from contextlib import asynccontextmanager
@@ -24,6 +25,7 @@ from composer.pipeline.ecosystem import EVM
 from composer.spec.source.pipeline import ProverBackend, GeneratedCVL
 from composer.spec.source.cex_capture import CexAnalysisStore
 from composer.prover.core import make_prover_options
+from composer.certora_env import CERTORA_HOME_OVERRIDE_ENV
 from composer.spec.source.source_env import build_source_env
 from composer.spec.source.author import SourceEditing
 from composer.spec.source.live_explorer import setup_live_edits
@@ -61,6 +63,7 @@ class AutoProveArgs(ExtendedModelOptions, RAGDBOptions, Protocol):
     max_bug_rounds: int
     budget: str | None
     budget_total: float | None
+    certora_run_command: str | None
     time_budget: float | None
     run_mode: str | None
 
@@ -105,8 +108,29 @@ async def _entry_point(summary: RunSummary) -> AsyncIterator[Executor]:
              "spends the run on the highest-contribution property and the properties it rests "
              "on. Also settable as AUTOPROVER_RUN_MODE; this flag wins.",
     )
+    parser.add_argument(
+        "--certora-run-command",
+        default=None,
+        help="Which Certora install AutoProver resolves certoraRun / Typechecker.jar from, "
+        "overriding $CERTORA for this run. Pass 'certoraRun' (or 'pip') to use the pip-installed "
+        "certora_cli — required to dispatch cloud jobs while $CERTORA points at a local source "
+        "build (a checkout is not a pip distribution, so a cloud submission cannot infer its "
+        "version). Or pass a path to a source checkout. Omit to honor $CERTORA.",
+    )
 
     args = cast(AutoProveArgs, parser.parse_args())
+    # Translate the flag into the env override certora_env reads. The wrapper
+    # subprocesses (certoraRunWrapper / certoraTypeCheck) inherit this env, so
+    # setting it here covers every certoraRun/jar resolution for the run.
+    if args.certora_run_command is not None:
+        cmd = args.certora_run_command.strip()
+        # A bare command that names the pip CLI selects the pip package; anything
+        # else is treated as a path to a source checkout (its directory).
+        if pathlib.Path(cmd).name in ("certoraRun", "certoraRun.py", "pip"):
+            os.environ[CERTORA_HOME_OVERRIDE_ENV] = "pip"
+        else:
+            p2 = pathlib.Path(cmd)
+            os.environ[CERTORA_HOME_OVERRIDE_ENV] = str(p2.parent if p2.name == "certoraRun.py" else p2)
     async with autoprove_executor(args, summary) as runner:
         yield runner
 


### PR DESCRIPTION
AutoProver resolves certoraRun / Typechecker.jar from `$CERTORA`. When `$CERTORA` points at a local source checkout, a cloud submission cannot infer its version and aborts. `--certora-run-command` (env `AUTOPROVER_CERTORA_HOME`) overrides that resolution per run: 'certoraRun'/'pip' forces the pip-installed `certora_cli` so cloud jobs dispatch, or a path selects a source checkout. Lets one session keep `$CERTORA` on a local build for direct local-prover work while AutoProver dispatches its cloud jobs through the pip package.