### PR TITLE
Pin certora-cli 8.19.2 and certora-prover-cli 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "chromadb>=0.4.0",
     "langgraph-prebuilt==1.0.8",
     "langchain_core<1.3.3",
-    "certora-prover-cli",
+    "certora-prover-cli>=0.2.2",
     # certora_autosetup runtime deps (merged in from the AutoSetup repo).
     # einops is provided by the [ml] extra; certora-prover-cli (above) ships the
     # prover_output_utility module AutoSetup imports.
@@ -73,7 +73,7 @@ s3 = ["s3fs>=2023.1.0"]
 # exactly one extra must be selected at install time (enforced via the
 # [tool.uv] conflicts block below). Each extra is named after the package it
 # pulls.
-certora-cli = ["certora-cli>=8.19.1"]
+certora-cli = ["certora-cli>=8.19.2"]
 certora-cli-beta = ["certora-cli-beta>=8.18.0"]
 certora-cli-beta-mirror = ["certora-cli-beta-mirror>=8.18.0"]
 # Back-compat alias: `prover` == stable channel.

--- a/uv.lock
+++ b/uv.lock
@@ -164,10 +164,10 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13" },
     { name = "anthropic", specifier = ">=0.18.0" },
     { name = "attrs", specifier = ">=26.1" },
-    { name = "certora-cli", marker = "extra == 'certora-cli'", specifier = ">=8.19.1" },
+    { name = "certora-cli", marker = "extra == 'certora-cli'", specifier = ">=8.19.2" },
     { name = "certora-cli-beta", marker = "extra == 'certora-cli-beta'", specifier = ">=8.18.0" },
     { name = "certora-cli-beta-mirror", marker = "extra == 'certora-cli-beta-mirror'", specifier = ">=8.18.0" },
-    { name = "certora-prover-cli" },
+    { name = "certora-prover-cli", specifier = ">=0.2.2" },
     { name = "chromadb", specifier = ">=0.4.0" },
     { name = "claude-agent-sdk", specifier = ">=0.1.0" },
     { name = "einops", marker = "extra == 'ml'" },
@@ -651,7 +651,7 @@ wheels = [
 
 [[package]]
 name = "certora-cli"
-version = "8.19.1"
+version = "8.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -667,11 +667,11 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/cd/0bcd2b5ff1b5f2b31ef18e59e6316d194b88cde0e8e7161fc88b345dd84f/certora_cli-8.19.1.tar.gz", hash = "sha256:05a429ebd2463df1b6c5aae6ed65b3585dd13bee668f2160193e797e38d5f4d9", size = 43395773, upload-time = "2026-08-28T20:01:40.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/3f/b8b859ab13cd0f36cbe843450dc2c7893d63513f307bd88197223a6cc537/certora_cli-8.19.2.tar.gz", hash = "sha256:d20f2968f2561c4456ccb41fb8fd55e123664739f3e23db456c11db5767b62f3", size = 43396029, upload-time = "2026-09-07T06:57:22.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/05/4e919576e253c16894e842d08db1e03b62ecfb1b785ea0738c1dea16b73e/certora_cli-8.19.1-py3-none-any.whl", hash = "sha256:2e4b1c9c79fe84bb91eb116f241d8a58923859f2d198d7a7fb0af4843bfcb2ab", size = 43450543, upload-time = "2026-08-28T20:01:31.239Z" },
-    { url = "https://files.pythonhosted.org/packages/47/43/da1321852dbb753d871d07bb152a062b30123f7e276616eab96a11c63d89/certora_cli-8.19.1-py3-none-macosx_10_9_universal2.whl", hash = "sha256:689f59dce81d9b97298b349e50f864740f62740478180c7dc61dd2ed3f02d738", size = 44976667, upload-time = "2026-08-28T20:01:36.925Z" },
-    { url = "https://files.pythonhosted.org/packages/39/f0/b0f2b24be05a7cfc8f6d302ff78d5812e346ab0d374b04aba0776a73630d/certora_cli-8.19.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9ae2c66b0399c4a472f80f62e5f7600ed7528b5deedaa18f6dc257db9ad077a9", size = 44286614, upload-time = "2026-08-28T20:01:33.972Z" },
+    { url = "https://files.pythonhosted.org/packages/da/be/67321e93b52b631598bdc6dcce0f575ec39ccaabd1c185dc72c19e4b01b5/certora_cli-8.19.2-py3-none-any.whl", hash = "sha256:a2a58dffbce01b255e7538f39f9574b6309978b482d92f810361b0851cd10a11", size = 43450897, upload-time = "2026-09-07T06:57:14.22Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/55/a5a65314a6a4ba3bcd9e0d7fef68765c7e830edf75e4dea0ca02cdb09c8d/certora_cli-8.19.2-py3-none-macosx_10_9_universal2.whl", hash = "sha256:0bd11767e0983d85ea63fda744a9a13f05bf569d8ec121e4866bfc56239b1c04", size = 44977020, upload-time = "2026-09-07T06:57:19.736Z" },
+    { url = "https://files.pythonhosted.org/packages/15/10/ca7d5417b9ca6b5590d316aa34e8ac24f24e899018fec70181b0234c6fe1/certora_cli-8.19.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ad862ef09f8b7bc5bb97b14beddda184ed5b46fdd8c9a8bfd4293bef603cfdad", size = 44286967, upload-time = "2026-09-07T06:57:16.946Z" },
 ]
 
 [[package]]
@@ -747,7 +747,7 @@ wheels = [
 
 [[package]]
 name = "certora-prover-cli"
-version = "0.2.1"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -756,9 +756,9 @@ dependencies = [
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/73dc7f810bd4c8b8da92ca1f1074d4dd6d8edbb537cde6f13a9f7c845c34/certora_prover_cli-0.2.1.tar.gz", hash = "sha256:ee6f4d95a440e7be3edfed6d93f7ba07386482e5eb939a41128a48f1198a33de", size = 67439, upload-time = "2026-08-28T10:51:36.83Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a5/0dcabaad2591db1f25b42a481c34c0e0c9563904bc33e6fcad3899a8fa8f/certora_prover_cli-0.2.2.tar.gz", hash = "sha256:18ff1ccd7150fd862757ed1976c98be93082a6c520bdb1673ab85b0e90a63699", size = 68504, upload-time = "2026-09-07T06:54:27.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/d9/fca95f34a9598bdd5c0df9bf8ff5787137786bbb49cca873d6c34bac6bac/certora_prover_cli-0.2.1-py3-none-any.whl", hash = "sha256:72dfdf20d204403c3bb3c353b76d02171fb27a91082b4a41f82d4878f6061782", size = 79828, upload-time = "2026-08-28T10:51:35.455Z" },
+    { url = "https://files.pythonhosted.org/packages/83/08/e2de6664bbe37478a346c89677c02fc218217b063d17ef4750162f4e428a/certora_prover_cli-0.2.2-py3-none-any.whl", hash = "sha256:6954e3e98a94f21276b573da19885957d588673dff6fc4ef20c27ff332ae3c19", size = 80845, upload-time = "2026-09-07T06:54:26.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves the stable-channel CLI extra to `certora-cli>=8.19.2` and gives `certora-prover-cli` a floor of 0.2.2, matching what `uv.lock` already resolves to. Both are the current PyPI releases.