### PR TITLE
autosetup: robust CVL import parsing (fixes prover-cache invalidation)

### DIFF
--- a/certora_autosetup/parsers/spec_imports.py
+++ b/certora_autosetup/parsers/spec_imports.py
@@ -1,9 +1,61 @@
 """Utilities for parsing CVL spec file imports."""
-import re
 from collections import deque
 from pathlib import Path
 
 from certora_autosetup.utils.logger import logger
+
+
+def imports_in_cvl(text: str) -> list[str]:
+    """Every ``import "<target>"`` target in CVL ``text``, in source order.
+
+    A char-level port of the CVL lexer's import rule: a string literal is one whole token and
+    comments are trivia, so an ``import`` written inside a string or a ``//`` / ``/* */`` comment is
+    never a real import — exactly the property that makes the parser AST robust where a line regex is
+    not (the parser's `Ast.importedSpecFiles` is built the same way; see EVMVerifier `cvl.jflex` /
+    `com.certora.certoraprover.cvl.JavaAst`). We reproduce that rule in Python rather than shelling
+    out to the CVL parser because this runs on hot paths (per-job cache keys, per-edit buffer
+    digests) where a JVM subprocess per call is untenable. Not line-limited, so multiple imports on
+    one line and an import after an inline block comment are all found. Soundness matters: callers
+    hash a spec's imports to invalidate caches, so a missed import would let a stale result survive an
+    edit to that import.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':  # string literal — skip it, honoring backslash escapes
+            i += 1
+            while i < n and text[i] != '"':
+                i += 2 if text[i] == '\\' else 1
+            i += 1
+            continue
+        if c == '/' and i + 1 < n and text[i + 1] == '/':  # line comment
+            nl = text.find('\n', i)
+            i = n if nl == -1 else nl + 1
+            continue
+        if c == '/' and i + 1 < n and text[i + 1] == '*':  # block comment
+            end = text.find('*/', i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        if text.startswith('import', i) and (i == 0 or not (text[i - 1].isalnum() or text[i - 1] == '_')):
+            j = i + len('import')
+            # A keyword here, not the prefix of an identifier like `importFoo`.
+            if j < n and not (text[j].isalnum() or text[j] == '_'):
+                k = j
+                while k < n and text[k] in ' \t\r\n':
+                    k += 1
+                if k < n and text[k] == '"':  # import "<target>"
+                    m, buf = k + 1, []
+                    while m < n and text[m] != '"':
+                        if text[m] == '\\' and m + 1 < n:
+                            buf.append(text[m + 1]); m += 2
+                        else:
+                            buf.append(text[m]); m += 1
+                    out.append(''.join(buf))
+                    i = m + 1
+                    continue
+        i += 1
+    return out
 
 
 def parse_imports_from_spec(spec_path: Path, recursive: bool = True) -> list[Path]:
@@ -21,18 +73,12 @@ def parse_imports_from_spec(spec_path: Path, recursive: bool = True) -> list[Pat
     def _parse_direct_imports(path: Path) -> list[Path]:
         """Parse direct imports from a single spec file."""
         imports = []
-        with open(path, "r") as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith("import") and '"' in line:
-                    import_match = re.search(r'import\s+"([^"]+)"', line)
-                    if import_match:
-                        import_path = import_match.group(1)
-                        resolved_path = (path.parent / import_path).resolve()
-                        if resolved_path.exists():
-                            imports.append(resolved_path)
-                        else:
-                            logger.warning(f"Could not resolve import '{import_path}' from {path}")
+        for import_path in imports_in_cvl(path.read_text()):
+            resolved_path = (path.parent / import_path).resolve()
+            if resolved_path.exists():
+                imports.append(resolved_path)
+            else:
+                logger.warning(f"Could not resolve import '{import_path}' from {path}")
         return imports
 
     if not recursive:

--- a/tests/test_spec_imports.py
+++ b/tests/test_spec_imports.py
@@ -1,0 +1,46 @@
+"""Unit tests for the CVL import extractor.
+
+``imports_in_cvl`` feeds prover-cache invalidation (a spec's imports are hashed into the cache key),
+so *missing* a real import is a soundness bug — a changed import
+would not invalidate the cache. These cases pin the char-level scan against
+the line-based regex it replaced, which missed a second import on the same line and any import
+preceded by an inline block comment.
+"""
+
+import pytest
+
+from certora_autosetup.parsers.spec_imports import imports_in_cvl, parse_imports_from_spec
+
+
+@pytest.mark.parametrize("text, expected", [
+    # --- the cases the old line-regex got WRONG (soundness-critical) ---
+    ('import "a.spec"; import "b.spec";\nrule r {}', ["a.spec", "b.spec"]),   # two on one line
+    ('/* header */ import "a.spec";\nrule r {}', ["a.spec"]),                 # inline block comment before
+    # --- comments must NOT yield phantom imports ---
+    ('import "a.spec";\n// import "x.spec";\nrule r {}', ["a.spec"]),          # // commented out
+    ('import "a.spec";\n/* import "x.spec"; */\nrule r {}', ["a.spec"]),       # /* */ commented out
+    ('/* a\n import "x.spec";\n b */\nimport "real.spec";', ["real.spec"]),    # multi-line block comment
+    # --- strings must NOT yield phantom imports, nor swallow real ones ---
+    ('rule r { string s = "import \\"x.spec\\""; }', []),                      # import text inside a string
+    ('methods { function _.u() external => f("a // b"); }\nimport "a.spec";', ["a.spec"]),  # // in a string
+    # --- keyword boundary: importFoo is an identifier, not an import ---
+    ('methods { function importFoo() external; }\nimport "a.spec";', ["a.spec"]),
+    # --- resource (path'd) and sibling (bare) imports both surface ---
+    ('import "shared.spec";\nimport "summaries/o.spec";\nrule r {}', ["shared.spec", "summaries/o.spec"]),
+    ('rule r { assert true; }', []),                                          # none
+])
+def test_imports_in_cvl(text, expected):
+    assert imports_in_cvl(text) == expected
+
+
+def test_parse_imports_from_spec_recursive(tmp_path):
+    # a -> b -> c (transitive); a also imports a missing file (skipped with a warning, not crash)
+    (tmp_path / "c.spec").write_text("rule rc { assert true; }\n")
+    (tmp_path / "b.spec").write_text('import "c.spec";\nrule rb { assert true; }\n')
+    (tmp_path / "a.spec").write_text('import "b.spec"; import "gone.spec";\nrule ra { assert true; }\n')
+
+    recursive = {p.name for p in parse_imports_from_spec(tmp_path / "a.spec", recursive=True)}
+    assert recursive == {"b.spec", "c.spec"}  # transitive closure; unresolvable "gone.spec" dropped
+
+    direct = {p.name for p in parse_imports_from_spec(tmp_path / "a.spec", recursive=False)}
+    assert direct == {"b.spec"}  # only the resolvable direct import


### PR DESCRIPTION
parse_imports_from_spec was a line-based regex that missed a second import on the same line and any import preceded by an inline block comment. Those imports feed the prover cache key (enhanced_config_manager -> cloud_runner), so a missed import let a stale cached result survive an edit to that import.

Replace it with imports_in_cvl(): a char-level port of the CVL lexer's import rule (a string literal is one whole token, comments are trivia), so an import inside a string or a // or /* */ comment is never picked up and a real import is never missed regardless of line structure. Over-including is sound; under-including is not.