### PR TITLE
Let a component lose property extraction without losing the run

### DIFF
--- a/composer/llm/anthropic.py
+++ b/composer/llm/anthropic.py
@@ -2,7 +2,6 @@
 ``ModelProvider`` implementation that mints ``ChatAnthropic`` instances."""
 
 from typing import Literal, TypeGuard, Any, TYPE_CHECKING, override, cast
-from collections.abc import Mapping
 from io import BytesIO
 from dataclasses import dataclass, field
 import asyncio
@@ -14,7 +13,8 @@ import httpx
 from composer.input.files import UploaderBase, ContentRenderer
 from composer.input.types import ModelConfiguration
 from composer.llm.provider import (
-    ProviderServiceBase, ProviderSpec, compaction_threshold, standard_callbacks
+    ProviderServiceBase, ProviderSpec, compaction_threshold, payload_error_type,
+    standard_callbacks
 )
 from composer.llm.pricing import PriceProvider, price_provider_for
 from .types import CacheLevel
@@ -219,19 +219,6 @@ RETRYABLE_ERROR_TYPES = frozenset({
 status code cannot speak for them."""
 
 
-def _payload_error_type(body: object) -> str | None:
-    """The ``error.type`` discriminator of an Anthropic error payload, or ``None``
-    for a body of any other shape (the SDK leaves it as the raw text when the
-    payload does not parse)."""
-    if not isinstance(body, Mapping):
-        return None
-    error = body.get("error")
-    if not isinstance(error, Mapping):
-        return None
-    error_type = error.get("type")
-    return error_type if isinstance(error_type, str) else None
-
-
 class AnthropicService(ProviderServiceBase):
     def __init__(self):
         from graphcore.tools.memory import anthropic_async_memory_tool
@@ -278,7 +265,7 @@ class AnthropicService(ProviderServiceBase):
             # 200 response, and the SDK builds the exception from that response — so the
             # status code carries none of the meaning and the class stays the base
             # APIStatusError. The transient/deterministic split lives in the payload.
-            return _payload_error_type(exc.body) in RETRYABLE_ERROR_TYPES
+            return payload_error_type(exc.body) in RETRYABLE_ERROR_TYPES
         return False
 
 @dataclass

--- a/composer/llm/openai.py
+++ b/composer/llm/openai.py
@@ -22,8 +22,8 @@ import openai
 from composer.input.files import UploaderBase, ContentRenderer
 from composer.input.types import ModelConfiguration
 from .provider import (
-    ProviderServiceBase, ProviderSpec, compaction_threshold, reasoning_effort,
-    standard_callbacks
+    ProviderServiceBase, ProviderSpec, compaction_threshold, payload_error_type,
+    reasoning_effort, standard_callbacks
 )
 from .pricing import PriceProvider, price_provider_for
 from .types import CacheLevel
@@ -149,12 +149,26 @@ class OpenAIService(ProviderServiceBase):
         """Same shape as the Anthropic mapping — the OpenAI SDK shares the
         Stainless exception taxonomy: connection-level failures and
         408/409/429/5xx statuses are transient; 400-class request errors are
-        deterministic and excluded."""
+        deterministic and excluded. When the status cannot speak for the error,
+        because the server reported it inside an already-open stream, the
+        payload's ``error.type`` decides instead."""
         if isinstance(exc, openai.APIConnectionError):
             return True
         if isinstance(exc, openai.APIStatusError):
-            return exc.status_code in (408, 409, 429) or exc.status_code >= 500
+            if exc.status_code in (408, 409, 429) or exc.status_code >= 500:
+                return True
+            return payload_error_type(exc.body) in RETRYABLE_ERROR_TYPES
         return False
+
+RETRYABLE_ERROR_TYPES = frozenset({
+    "server_error",         # 5xx
+    "rate_limit_exceeded",  # 429
+})
+"""The ``error.type`` values ``should_retry`` accepts from a payload whose status code
+cannot speak for it. Deliberately narrower than the Anthropic roster: ``insufficient_quota``
+and the ``invalid_request_error`` family are deterministic, and a type this set does not
+name is treated as deterministic rather than guessed at."""
+
 
 @dataclass
 class OpenAIRenderer:

--- a/composer/llm/openrouter.py
+++ b/composer/llm/openrouter.py
@@ -32,10 +32,10 @@ from composer.input.files import (
 )
 from composer.input.types import ModelConfiguration
 from .provider import (
-    ProviderServiceBase, ProviderSpec, compaction_threshold, reasoning_effort,
-    standard_callbacks
+    ProviderServiceBase, ProviderSpec, compaction_threshold, payload_error_type,
+    reasoning_effort, standard_callbacks
 )
-from .openai import OpenAIRenderer
+from .openai import RETRYABLE_ERROR_TYPES, OpenAIRenderer
 from .pricing import PriceProvider, PriceTier, price_provider_for
 from .types import CacheLevel
 
@@ -464,11 +464,15 @@ class OpenRouterService(ProviderServiceBase):
         Both surface while the SSE body is being read, when the request has already
         succeeded, so the SDK's own ``max_retries`` never sees them: a dropped
         connection (``httpx.TransportError``) and a content stall (langchain's
-        ``StreamChunkTimeoutError``, a ``TimeoutError`` subclass)."""
+        ``StreamChunkTimeoutError``, a ``TimeoutError`` subclass). An error the
+        server reports inside the stream arrives on the already-open 200, so the
+        payload's ``error.type`` decides when the status code cannot."""
         if isinstance(exc, (httpx.TransportError, TimeoutError, openai.APIConnectionError)):
             return True
         if isinstance(exc, openai.APIStatusError):
-            return exc.status_code in (408, 409, 429) or exc.status_code >= 500
+            if exc.status_code in (408, 409, 429) or exc.status_code >= 500:
+                return True
+            return payload_error_type(exc.body) in RETRYABLE_ERROR_TYPES
         return False
 
 

--- a/composer/llm/provider.py
+++ b/composer/llm/provider.py
@@ -10,6 +10,7 @@ the per-provider modules can import it without an import cycle.
 """
 
 from typing import Protocol, TYPE_CHECKING, Callable, Literal
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import cached_property
 from composer.input.files import FileUploader
@@ -45,6 +46,26 @@ class ProviderService(Protocol):
         every time). The harness assembles this into the run-wide retry
         policy (``composer.io.context.install_retry_policy``)."""
         ...
+
+def payload_error_type(body: object) -> str | None:
+    """The ``error.type`` discriminator of a provider error payload, or ``None`` for a
+    body of any other shape (an SDK leaves it as the raw text when the payload does not
+    parse).
+
+    An error the server reports part-way through a stream rides the already-open 200
+    response, and the SDK builds the exception from that response — so the status code
+    carries none of the meaning and the transient/deterministic split lives in the
+    payload. The ``{"error": {"type": ...}}`` shape is common to the Stainless SDKs;
+    which type values count as transient is each provider's own vocabulary.
+    """
+    if not isinstance(body, Mapping):
+        return None
+    error = body.get("error")
+    if not isinstance(error, Mapping):
+        return None
+    error_type = error.get("type")
+    return error_type if isinstance(error_type, str) else None
+
 
 class ProviderServiceBase(ABC):
     def __init__(self,

--- a/composer/pipeline/core.py
+++ b/composer/pipeline/core.py
@@ -73,7 +73,9 @@ from .keys import (
     POST_PROPERTY_KEY, PRE_PROPERTY_KEY, PRIORITIZATION_KEY, PROPERTIES_KEY,
     SYSTEM_ANALYSIS_KEY, PLUGIN_FORMALIZATION_KEY, candidates_digest
 )
-from composer.diagnostics.budget import total_budget, named_budget_or_nop, time_budget
+from composer.diagnostics.budget import (
+    BudgetExceeded, BudgetPressureAbort, total_budget, named_budget_or_nop, time_budget,
+)
 
 from .run_mode import RunMode, run_mode_name
 from .ptypes import (
@@ -532,7 +534,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
             return await prepared.prepare_formalization(run)
     staged_task = asyncio.create_task(_prepare_formalization())
 
-    batches: list[_Batch[U]] = await _extract_all(
+    batches, extraction_failures = await _extract_all(
         backend.analysis_spec.properties_key,
         prepared.main,
         backend.backend_guidance,
@@ -572,6 +574,9 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
 
     staged = await staged_task
     if not batches:
+        if extraction_failures:
+            detail = "; ".join(f"{u.display_name}: {e}" for u, e in extraction_failures)
+            raise ValueError(f"Every component failed property extraction: {detail}")
         raise ValueError("No properties extracted from any component.")
 
     # 4. A backend whose units share an artifact handed back a ``StagedFormalizer`` instead of a
@@ -716,6 +721,11 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
 
     await formalizer.finalize(outcomes, run)
 
+    # A component lost at extraction never reached the formalizer, so it is not in ``outcomes``
+    # and the formalizer is not handed one it never saw. It still belongs in the report and the
+    # verdict: a component that silently vanishes is the failure this reports on.
+    lost_at_extraction = [ComponentOutcome(u, [], e) for u, e in extraction_failures]
+
     # 6. Report (shared, backend-agnostic). The driver assembles the per-component inputs.
     # Best-effort: a failure here never fails the run.
     inputs = [
@@ -724,7 +734,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
             props=o.props,
             formalized=o.result if isinstance(o.result, (Delivered, Curtailed)) else None,
         )
-        for o in outcomes
+        for o in outcomes + lost_at_extraction
     ]
     artifact_records = [
         VerificationArtifactRecord(
@@ -762,7 +772,7 @@ async def run_pipeline_inner[P: enum.Enum, FormT: BackendResult, H, A: ArtifactI
             raise
         _log.warning("report phase failed (continuing)", exc_info=True)
 
-    return _tally(outcomes, run.run_mode, len(deprioritized))
+    return _tally(outcomes + lost_at_extraction, run.run_mode, len(deprioritized))
 
 
 #: The driver-owned task id for the ranking step. Backend-agnostic, like the per-unit
@@ -871,7 +881,7 @@ async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
     # ``Main``/``U`` (matching the caller's), so there's nothing to tie it to.
     ecosystem: Ecosystem[Any, Main, U],
     plugins: PluginPhaseManager[P, U],
-) -> list[_Batch[U]]:
+) -> tuple[list[_Batch[U]], list[tuple[U, BaseException]]]:
     prop_ctx = run.ctx.child(PROPERTIES_KEY(prop_key))
 
     async def _pre_plugin_inputs(feat: U) -> list[AnyPropertyGenerationInput]:
@@ -953,8 +963,41 @@ async def _extract_all[P: enum.Enum, H, Main, U: FeatureUnit](
         with named_budget_or_nop("property_extraction"):
             return await _one(u)
 
-    got = await asyncio.gather(*[budgeted_task(u) for u in ecosystem.units(main)])
-    return [b for b in got if b is not None]
+    units = list(ecosystem.units(main))
+    got = await asyncio.gather(
+        *[budgeted_task(u) for u in units], return_exceptions=True
+    )
+    return _settle_extraction(units, got)
+
+
+def _settle_extraction[U: FeatureUnit](
+    units: list[U], settled: list[_Batch[U] | None | BaseException]
+) -> tuple[list[_Batch[U]], list[tuple[U, BaseException]]]:
+    """Split a finished extraction fan-out into the batches it produced and the components
+    that failed.
+
+    One component's extraction failing is that component's loss, not the run's: the units are
+    independent — inference never sees more than the unit it was given — so a component that
+    raises is reported and the rest carry on, the way formalization settles its own fan-out.
+
+    Cancellation and the budget stops are the exception. They end the whole run, and recording
+    one against a single component would turn a deliberate halt into a quiet partial result.
+    """
+    batches: list[_Batch[U]] = []
+    failed: list[tuple[U, BaseException]] = []
+    for unit, outcome in zip(units, settled):
+        if isinstance(outcome, BaseException):
+            if isinstance(
+                outcome, (asyncio.CancelledError, BudgetExceeded, BudgetPressureAbort)
+            ):
+                raise outcome
+            _log.warning(
+                "property extraction failed for %s", unit.display_name, exc_info=outcome
+            )
+            failed.append((unit, outcome))
+        elif outcome is not None:
+            batches.append(outcome)
+    return batches, failed
 
 
 def _tally[FormT: BackendResult, U: FeatureUnit](

--- a/tests/test_openai_retry.py
+++ b/tests/test_openai_retry.py
@@ -1,0 +1,76 @@
+"""The OpenAI-family services classify an error the server reports inside an open stream.
+
+The OpenAI SDK shares the Stainless taxonomy with Anthropic's, and so shares the blind spot:
+an error event delivered part-way through a stream rides the already-open 200 response, and the
+SDK builds the exception from that response — so the status code says nothing and the payload's
+``error.type`` is the only discriminator. See tests/test_anthropic_retry.py for the twin, and
+composer/llm/openai.py for the roster.
+
+Unlike the Anthropic side, this is not backed by an observed incident: the roster is deliberately
+narrow, and a type it does not name stays deterministic rather than being guessed at.
+"""
+
+import httpx
+import openai
+import pytest
+
+from composer.llm.openai import OpenAIService
+from composer.llm.openrouter import OpenRouterService
+
+
+def _stream_error(error_type: str, status_code: int = 200) -> openai.APIStatusError:
+    """The exception the SDK raises for an error event inside an open stream: built from the
+    streaming response, so it keeps that response's status."""
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    return openai.APIStatusError(
+        f"Error code: {status_code}",
+        response=httpx.Response(status_code, request=request),
+        body={"error": {"type": error_type, "message": "..."}},
+    )
+
+
+def _services():
+    return [OpenAIService(), OpenRouterService()]
+
+
+@pytest.mark.parametrize("svc", _services(), ids=["openai", "openrouter"])
+def test_mid_stream_server_error_is_retryable(svc):
+    assert svc.should_retry(_stream_error("server_error")) is True
+
+
+@pytest.mark.parametrize("svc", _services(), ids=["openai", "openrouter"])
+def test_mid_stream_rate_limit_is_retryable(svc):
+    assert svc.should_retry(_stream_error("rate_limit_exceeded")) is True
+
+
+@pytest.mark.parametrize("svc", _services(), ids=["openai", "openrouter"])
+def test_mid_stream_request_error_not_retryable(svc):
+    assert svc.should_retry(_stream_error("invalid_request_error")) is False
+
+
+@pytest.mark.parametrize("svc", _services(), ids=["openai", "openrouter"])
+def test_quota_exhaustion_not_retryable(svc):
+    # Re-running does not refill the account; this one is deterministic.
+    assert svc.should_retry(_stream_error("insufficient_quota")) is False
+
+
+@pytest.mark.parametrize("svc", _services(), ids=["openai", "openrouter"])
+def test_status_code_still_decides_when_it_can(svc):
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    exc = openai.APIStatusError(
+        "Error code: 503",
+        response=httpx.Response(503, request=request),
+        body=None,
+    )
+    assert svc.should_retry(exc) is True
+
+
+@pytest.mark.parametrize("svc", _services(), ids=["openai", "openrouter"])
+def test_unparsed_body_not_retryable(svc):
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    exc = openai.APIStatusError(
+        "gateway said no",
+        response=httpx.Response(200, request=request),
+        body="gateway said no",
+    )
+    assert svc.should_retry(exc) is False

--- a/tests/test_pipeline_extract_failures.py
+++ b/tests/test_pipeline_extract_failures.py
@@ -1,0 +1,110 @@
+"""What the driver does when property extraction fails for some components but not others.
+
+Extraction fans out one task per component and the units are independent, so a component that
+raises should cost that component and nothing else. The run carries on with the survivors and
+reports the failure the way ``_tally`` reports a formalization failure.
+
+Cancellation and the budget stops are not component failures — they end the run, and swallowing
+one here would turn a deliberate halt into a quiet partial result.
+
+Reference incident: a single mid-stream Anthropic 500 in one of five components discarded two
+finished extractions and two still in flight.
+"""
+
+import asyncio
+
+import pytest
+
+import composer.pipeline.core as core
+from composer.diagnostics.budget import BudgetExceeded, BudgetPressureAbort
+from composer.pipeline.core import _Batch, _settle_extraction, run_pipeline
+
+# The driver stubs live with the overlap tests; reuse them rather than restating a whole backend.
+from tests.test_pipeline_overlap import ECOSYSTEM, _Backend, _Prepared, _Run, _Step
+
+
+class _Unit:
+    """Only the field the failure rollup reads."""
+
+    def __init__(self, name: str):
+        self.display_name = name
+
+
+def _batch(unit: _Unit) -> _Batch:
+    # _settle_extraction only partitions; it never looks inside a batch.
+    return _Batch(unit, [], None)  # type: ignore[arg-type]
+
+
+def test_a_failed_component_does_not_cost_the_others():
+    good, bad, also_good = _Unit("good"), _Unit("bad"), _Unit("also-good")
+    boom = RuntimeError("Internal server error")
+
+    batches, failed = _settle_extraction(
+        [good, bad, also_good],
+        [_batch(good), boom, _batch(also_good)],  # type: ignore[list-item]
+    )
+
+    assert [b.feat for b in batches] == [good, also_good]
+    assert failed == [(bad, boom)]
+
+
+def test_a_component_with_no_properties_is_not_a_failure():
+    # `_one` returns None for a component that yielded nothing to formalize. That is an empty
+    # result, not an error, and it is dropped exactly as it was before.
+    quiet = _Unit("quiet")
+    batches, failed = _settle_extraction([quiet], [None])
+    assert batches == []
+    assert failed == []
+
+
+def test_every_component_failing_is_reported_not_hidden():
+    one, two = _Unit("one"), _Unit("two")
+    batches, failed = _settle_extraction(
+        [one, two], [RuntimeError("a"), RuntimeError("b")]  # type: ignore[list-item]
+    )
+    assert batches == []
+    assert [u for u, _ in failed] == [one, two]
+
+
+@pytest.mark.parametrize(
+    "signal",
+    [asyncio.CancelledError(), BudgetExceeded("out of budget"), BudgetPressureAbort()],
+    ids=["cancelled", "budget-exceeded", "budget-pressure"],
+)
+def test_run_wide_stops_still_propagate(signal: BaseException):
+    unit = _Unit("unit")
+    with pytest.raises(type(signal)):
+        _settle_extraction([unit], [signal])
+
+
+def test_a_run_wide_stop_wins_over_a_component_failure():
+    # The stop ends the run whichever order the tasks settled in.
+    first, second = _Unit("first"), _Unit("second")
+    with pytest.raises(BudgetExceeded):
+        _settle_extraction(
+            [first, second],
+            [RuntimeError("component"), BudgetExceeded("out of budget")],  # type: ignore[list-item]
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_total_extraction_wipeout_names_the_failures(monkeypatch):
+    """"Nothing was extracted" on its own hides the reason. When every component raised, the
+    error the operator sees should say so and name them."""
+    lost = _Unit("Signature Verification")
+
+    async def fake_extract_all(*_a, **_kw):
+        return [], [(lost, RuntimeError("Internal server error"))]
+
+    async def fake_analysis(*_a, **_kw):
+        return "analyzed"
+
+    monkeypatch.setattr(core, "run_component_analysis", fake_analysis)
+    monkeypatch.setattr(core, "_extract_all", fake_extract_all)
+    backend = _Backend(_Prepared(_Step(0, None, "formalizer")))
+    with pytest.raises(ValueError) as caught:
+        await run_pipeline(backend, _Run(), max_bug_rounds=1, ecosystem=ECOSYSTEM)  # type: ignore[arg-type]
+
+    message = str(caught.value)
+    assert "Signature Verification" in message
+    assert "Internal server error" in message

--- a/tests/test_pipeline_overlap.py
+++ b/tests/test_pipeline_overlap.py
@@ -151,7 +151,9 @@ async def _drive(
 
     async def fake_extract_all(*_a, **_kw):
         await extract.run()
-        return []  # no batches — the driver's own "nothing extracted" error, if it gets that far
+        # no batches and nothing failed — the driver's own "nothing extracted" error,
+        # if it gets that far
+        return [], []
 
     monkeypatch.setattr(core, "run_component_analysis", fake_analysis)
     monkeypatch.setattr(core, "_extract_all", fake_extract_all)

--- a/tests/test_pipeline_staged_formalizer.py
+++ b/tests/test_pipeline_staged_formalizer.py
@@ -181,7 +181,7 @@ async def _drive[F: (_Staged, _Formalizer)](
         return [
             core._Batch(_Unit(name, i), [_prop(t) for t in titles], _FeatCtx())  # type: ignore[arg-type]
             for i, (name, titles) in enumerate(units.items())
-        ]
+        ], []  # nothing failed extraction
 
     async def fake_report(*_a, **_kw): return object()
 
@@ -346,7 +346,7 @@ async def test_ranking_does_not_wait_for_pre_formalization(monkeypatch):
 
     async def fake_extract_all(*_a, **_kw):
         await started.wait()  # the setup is in flight, exactly as in a real run
-        return [core._Batch(_Unit("deposits", 0), [_prop("a")], _FeatCtx())]  # type: ignore[arg-type]
+        return [core._Batch(_Unit("deposits", 0), [_prop("a")], _FeatCtx())], []  # type: ignore[arg-type]
 
     async def fake_rank(**_kw):
         order.append("rank")


### PR DESCRIPTION
## What happened

When one of five components hit an Anthropic 500, a dev run died 35 minutes in:

```
19:37:33 task failed: phase=BUG_ANALYSIS task_id=extract-3 wall=1393.66s error=APIStatusError
APIStatusError: {'type': 'error', 'error': {'type': 'api_error', 'message': 'Internal server error'}}
```

`extract-0` and `extract-1` had finished (844s and 1271s) and never became CVL. `extract-2` and
`extract-4` were 15 and 9 minutes in and were destroyed mid-flight. System analysis, the `HARNESS`
phase, the prover setup phase and structural invariants had all succeeded. No report, no spec, no prover runs.

This is a recurring class, not a one-off. Two earlier runs went the same way, one of them after
about eight hours of prover time.

## Why the retry did not fire

The run-wide retry did not fail. It was not in the image. The dev AutoProver image that ran this
job pinned `f1f62a55`, which is older than #217 and #220. At that commit `should_retry` looked
only at the status code. An error the server reports mid-stream arrives on the open 200 response
of the stream. The predicate returned False and the task died on its first attempt. The log has no
"(Retry 1)" line. #220 reached that image four days later, with the next pin bump.

Two cloud images pin AutoProver separately. An earlier version of this description said the
shipped pin already had #217 and #220. That was true of the other image only.

## The fan-out

`core.py` gathered the per-component extraction tasks with no `return_exceptions`, so the first
exception propagated out of `run_pipeline` and killed the process. The sibling tasks were orphaned
at loop teardown. Formalization, twelve lines up the file, does the opposite: it gathers
tolerantly, wraps each settled value in a `ComponentOutcome`, and lets `_tally` turn a
`BaseException` into a failure string. That asymmetry was the bug.

`_settle_extraction` splits a finished fan-out into an `ExtractionResult`: the batches it produced
and the components that failed, each an `ExtractionFailure` of the unit and its error. It is a
module-level helper rather than inline so the partition is testable without standing up a backend.

A component lost at extraction never reached the formalizer. It stays out of `outcomes`, and the
formalizer is never handed one it did not see. It goes into the report inputs and into `_tally`
instead, so a lost component is visible in both the report and the run verdict.

If every component fails, the run still fails, but the error now names them rather than only
saying that nothing was extracted.

## The retry predicate

Not what killed this run, but the same family. An error the server reports mid-stream arrives on
the already-open 200, so the status code cannot speak for the error. For that case, #220 taught
`AnthropicService.should_retry` to fall through to the payload's `error.type`. `openai.py`
and `openrouter.py` were still status-only and fail identically on the same payload.

The extractor moves to `provider.py` as `payload_error_type`: the `{"error": {"type": ...}}` shape
is common to the Stainless SDKs. The roster is not. Which type values count as transient is each
provider's own vocabulary, so the OpenAI-family set is separate and deliberately narrow
(`server_error`, `rate_limit_exceeded`). `insufficient_quota` and the `invalid_request_error`
family are deterministic, and a type the set does not name stays deterministic rather than being
guessed at.

Worth flagging: unlike the Anthropic side, this half is not backed by an observed incident. I have
not seen an OpenAI mid-stream error payload in a real run. The roster is reasoned from the
documented taxonomy rather than from a trace.

## Tests

`tests/test_pipeline_extract_failures.py` covers the partition. One component failing leaves the
others. A component with no properties is still not a failure. Every component failing is
reported. `CancelledError`, `BudgetExceeded` and `BudgetPressureAbort` still propagate. A
component failure that settled first does not change that. The wipeout message naming the failures is driven through
`run_pipeline`.

`tests/test_openai_retry.py` is the twin of `test_anthropic_retry.py`, parametrized over both
OpenAI-family services.

Two existing fakes of `_extract_all` now return an `ExtractionResult`: `test_pipeline_overlap.py`
and `test_pipeline_staged_formalizer.py`.

1314 pass, and pyright is clean over the CI scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
