### PR TITLE
diagnostics: attribute every billed LLM call to its origin

### DIFF
--- a/composer/diagnostics/timing.py
+++ b/composer/diagnostics/timing.py
@@ -66,6 +66,37 @@ class TokenTotals:
         }
 
 
+@dataclass(frozen=True)
+class CallOrigin:
+    """Where one LLM call came from, independent of which task was billed for it.
+
+    ``thread_id`` / ``node`` are the LangGraph run's, read off the call's metadata;
+    they are ``None`` for a call made outside any graph (a bare
+    ``with_structured_output(...).ainvoke(...)``, a summarizer, a retried attempt
+    that never reached a checkpoint). That distinction is the whole point of the
+    type: a run's *billed* totals and the message history reachable through
+    ``ap-trail`` can only be reconciled if each call says whether it belongs to a
+    recorded thread. Calls with no ``thread_id`` are exactly the ones no
+    transcript will ever account for.
+    """
+    thread_id: str | None = None
+    node: str | None = None
+
+    @property
+    def in_graph(self) -> bool:
+        return self.thread_id is not None
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {"thread_id": self.thread_id, "node": self.node}
+
+
+#: Cap on distinct origins tracked per run. Origins are (thread_id, node) pairs,
+#: so a normal run has a few hundred; the cap only stops a pathological run from
+#: growing the summary without bound. Overflow folds into ``_ORIGIN_OVERFLOW``.
+_MAX_ORIGINS = 2000
+_ORIGIN_OVERFLOW = CallOrigin(thread_id="(origin-overflow)", node=None)
+
+
 @dataclass
 class PhaseRecord:
     task_id: str
@@ -98,6 +129,8 @@ class RunSummary:
     _latest_link_by_task: dict[str, str] = field(default_factory=dict, repr=False)  # Maps task_id -> link for the most recent prover run.
     token_usage_by_model: dict[str, TokenTotals] = field(default_factory=dict)  # Maps model_name -> accumulated raw token counts across the whole run.
     _active_tokens_by_task: dict[str, dict[str, TokenTotals]] = field(default_factory=dict, repr=False)  # Maps task_id -> {model_name -> token counts} accumulated while the task is in flight.
+    token_usage_by_origin: dict[tuple[CallOrigin, str | None], TokenTotals] = field(default_factory=dict)  # Maps (call origin, task_id) -> token counts, run-wide.
+    calls_by_origin: dict[tuple[CallOrigin, str | None], int] = field(default_factory=dict)  # Call count for the same keys.
 
     def record_phase(
         self,
@@ -149,16 +182,33 @@ class RunSummary:
                 self._active_prover_reported_by_task.get(task_id, 0) + ms
             )
 
-    def record_token_usage(self, usage: NormalizedTokenUsage, *, task_id: str | None = None) -> None:
+    def record_token_usage(
+        self,
+        usage: NormalizedTokenUsage,
+        *,
+        task_id: str | None = None,
+        origin: CallOrigin | None = None,
+    ) -> None:
         """Accumulate one LLM call's token counts into the run-wide per-model totals
         and (if a task is active) into that task's in-flight bucket, later folded into
-        its ``PhaseRecord`` by ``record_phase``. Defaults attribution to the active task."""
+        its ``PhaseRecord`` by ``record_phase``. Defaults attribution to the active task.
+
+        ``origin`` additionally records *where the call came from* — see
+        :class:`CallOrigin`. It is kept on a separate axis from the task rather than
+        folded into ``PhaseRecord``, because the question it answers ("is this call in
+        a thread the trail recorded?") cuts across phases and outlives them."""
         model = usage.get("model_name") or "unknown"
         update = TokenTotals.from_normalized(usage)
         self.token_usage_by_model[model] = self.token_usage_by_model.get(model, TokenTotals()) + update
-        if (task_id := task_id or get_current_task_id()) is not None:
+        task_id = task_id or get_current_task_id()
+        if task_id is not None:
             bucket = self._active_tokens_by_task.setdefault(task_id, {})
             bucket[model] = bucket.get(model, TokenTotals()) + update
+        key = (origin or CallOrigin(), task_id)
+        if key not in self.token_usage_by_origin and len(self.token_usage_by_origin) >= _MAX_ORIGINS:
+            key = (_ORIGIN_OVERFLOW, task_id)
+        self.token_usage_by_origin[key] = self.token_usage_by_origin.get(key, TokenTotals()) + update
+        self.calls_by_origin[key] = self.calls_by_origin.get(key, 0) + 1
 
     def total_tokens(self) -> TokenTotals:
         """Run-wide token counts summed across all models."""
@@ -179,6 +229,22 @@ class RunSummary:
                 }
                 for p in self.phases
                 if p.token_usage_by_model
+            ],
+            # Same tokens, sliced by where the call came from rather than which task
+            # paid. Sorted heaviest-first so a truncated read still shows what matters,
+            # and out-of-graph calls (thread_id None) sort in among the rest rather
+            # than being hidden in a footnote — they are the ones worth explaining.
+            "by_origin": [
+                {
+                    **origin.as_dict(),
+                    "task_id": task_id,
+                    "calls": self.calls_by_origin.get((origin, task_id), 0),
+                    **totals.as_dict(),
+                }
+                for (origin, task_id), totals in sorted(
+                    self.token_usage_by_origin.items(),
+                    key=lambda kv: -(kv[1].cache_write + kv[1].cache_read + kv[1].output),
+                )
             ],
         }
 

--- a/composer/diagnostics/usage_callback.py
+++ b/composer/diagnostics/usage_callback.py
@@ -6,26 +6,62 @@ so it fires for *every* ``invoke`` / ``ainvoke`` through the model — including
 analysis, interactive refinement) that never reach the graph's ``StateUpdate`` stream
 and so are invisible to the TUI token bar.
 
+Because it is the one place that sees every billed call, it is also where a call's
+**origin** is captured: the LangGraph ``thread_id`` and node it ran under, or nothing
+at all for a call made outside any graph. Without that, a run's billed totals cannot
+be reconciled against its recorded message history — on one 4h25m run, 92% of the
+cache-write spend belonged to calls that appear in neither the executor log nor any
+``ap-trail`` thread, and there was no way to say which code path produced them. The
+origin travels into :meth:`RunSummary.record_token_usage` and out again through
+``job_info.json``'s ``token_usage.by_origin``.
+
 ``run_inline = True`` keeps dispatch on the event-loop thread (see
 ``langchain_core.callbacks.manager._ahandle_event_for_handler``): the active-task
 context var read by :meth:`RunSummary.record_token_usage` stays visible and the shared
 counters are mutated single-threaded (no race). Compatible across the pinned
 ``langchain_core >=1.2,<1.3.3`` range — uses only the long-stable sync
-``BaseCallbackHandler.on_llm_end`` surface.
+``BaseCallbackHandler`` surface.
 """
 
+import logging
 from typing import Any
+from uuid import UUID
 
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 
 from graphcore.utils import get_normalized_token_usage
-from composer.diagnostics.timing import get_run_summary
+from composer.diagnostics.budget import current_cost_center
+from composer.diagnostics.timing import CallOrigin, get_current_task_id, get_run_summary
+
+logger = logging.getLogger(__name__)
+
+#: Bound on in-flight starts held while waiting for their matching end. A call that
+#: never ends (cancelled, crashed) would otherwise leak its entry; well past any real
+#: concurrency, so hitting it means something is wrong, not that the cap is too small.
+_MAX_INFLIGHT = 4096
+
+
+def _origin_from_metadata(metadata: dict[str, Any] | None) -> CallOrigin:
+    """Read the LangGraph thread/node off a call's run metadata.
+
+    LangGraph stamps ``thread_id`` (from the RunnableConfig's ``configurable``) and
+    ``langgraph_node`` into the metadata of every call it drives. A call with neither
+    was not driven by a graph — that is the signal, so absence is recorded as such
+    rather than being back-filled from ambient context."""
+    if not metadata:
+        return CallOrigin()
+    thread_id = metadata.get("thread_id")
+    return CallOrigin(
+        thread_id=str(thread_id) if thread_id is not None else None,
+        node=metadata.get("langgraph_node"),
+    )
 
 
 class UsageCallback(BaseCallbackHandler):
-    """Records each LLM response's token usage into the active ``RunSummary``."""
+    """Records each LLM response's token usage, and its origin, into the active
+    ``RunSummary``."""
 
     # Run on the calling event-loop thread instead of a thread-pool executor.
     # In async runs LangChain otherwise offloads sync handlers to an executor
@@ -34,7 +70,40 @@ class UsageCallback(BaseCallbackHandler):
     # RunSummary counter mutations single-threaded (no cross-thread race).
     run_inline = True
 
-    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+    def __init__(self) -> None:
+        # Metadata is passed to the *start* hooks only, so the origin is stashed
+        # here and re-joined at end by LangChain's per-call run_id. Single-threaded
+        # by run_inline, so a plain dict is safe.
+        self._origins: dict[UUID, CallOrigin] = {}
+
+    # Chat models dispatch on_chat_model_start; completion models on_llm_start.
+    # Both carry the same metadata, and only one fires per call.
+    def on_chat_model_start(
+        self, serialized: dict[str, Any], messages: Any, *, run_id: UUID,
+        metadata: dict[str, Any] | None = None, **kwargs: Any,
+    ) -> None:
+        self._remember(run_id, metadata)
+
+    def on_llm_start(
+        self, serialized: dict[str, Any], prompts: list[str], *, run_id: UUID,
+        metadata: dict[str, Any] | None = None, **kwargs: Any,
+    ) -> None:
+        self._remember(run_id, metadata)
+
+    def _remember(self, run_id: UUID, metadata: dict[str, Any] | None) -> None:
+        if len(self._origins) >= _MAX_INFLIGHT:
+            # Starts without ends have accumulated; drop the oldest rather than grow.
+            # Losing an origin costs attribution on one call, never a token count.
+            self._origins.pop(next(iter(self._origins)), None)
+        self._origins[run_id] = _origin_from_metadata(metadata)
+
+    def on_llm_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
+        # A failed call is billed by the provider but produces no response here, so
+        # there is nothing to record — just release the stashed origin.
+        self._origins.pop(run_id, None)
+
+    def on_llm_end(self, response: LLMResult, *, run_id: UUID | None = None, **kwargs: Any) -> None:
+        origin = self._origins.pop(run_id, CallOrigin()) if run_id is not None else CallOrigin()
         try:
             generation = response.generations[0][0]
         except IndexError:
@@ -42,10 +111,21 @@ class UsageCallback(BaseCallbackHandler):
         if not isinstance(generation, ChatGeneration):
             return
         msg = generation.message
-        if isinstance(msg, AIMessage):
-            # The normalized usage_metadata is the one source every transport and
-            # provider fills in — the raw response_metadata["usage"] dict exists only
-            # on non-streamed Anthropic responses. get_run_summary() returns an inert
-            # throwaway outside a run, so this is a no-op when no autoprove run is
-            # active (e.g. ad-hoc model use).
-            get_run_summary().record_token_usage(get_normalized_token_usage(msg))
+        if not isinstance(msg, AIMessage):
+            return
+        # The normalized usage_metadata is the one source every transport and
+        # provider fills in — the raw response_metadata["usage"] dict exists only
+        # on non-streamed Anthropic responses. get_run_summary() returns an inert
+        # throwaway outside a run, so this is a no-op when no autoprove run is
+        # active (e.g. ad-hoc model use).
+        usage = get_normalized_token_usage(msg)
+        get_run_summary().record_token_usage(usage, origin=origin)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "LLM call attributed: model=%s task=%s cost_center=%s thread=%s node=%s "
+                "in=%d out=%d cache_read=%d cache_write=%d",
+                usage.get("model_name"), get_current_task_id(), current_cost_center(),
+                origin.thread_id or "-", origin.node or "-",
+                usage["total_input_tokens"], usage["total_output_tokens"],
+                usage["cache_read_tokens"], usage["cache_write_tokens"],
+            )

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -15,10 +15,12 @@ Covers the three layers of the feature:
 
 import json
 from typing import cast
+from uuid import uuid4
 
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.outputs import ChatGeneration, LLMResult
 
 from composer.diagnostics.timing import (
     RunSummary,
@@ -292,3 +294,94 @@ def test_autosetup_usage_fallback_newest_dir(tmp_path):
     usage = read_autosetup_usage(tmp_path)
     assert [u["model_name"] for u in usage] == ["new"]
     assert usage[0]["total_input_tokens"] == 9
+
+
+# ---------------------------------------------------------------------------
+# Call origin: which calls a transcript can account for, and which it cannot
+# ---------------------------------------------------------------------------
+
+def _ai(out: int, cr: int, cw: int, model: str = "claude-opus-5") -> AIMessage:
+    return AIMessage(
+        content="x",
+        response_metadata={"model_name": model},
+        usage_metadata={
+            "input_tokens": 2 + cr + cw,
+            "output_tokens": out,
+            "total_tokens": 2 + cr + cw + out,
+            "input_token_details": {"cache_read": cr, "cache_creation": cw},
+        },
+    )
+
+
+def _result(msg: AIMessage) -> LLMResult:
+    return LLMResult(generations=[[ChatGeneration(message=msg)]])
+
+
+def test_origin_separates_in_graph_from_out_of_graph_calls() -> None:
+    """A call LangGraph drove carries its thread; one made outside any graph does
+    not — and that is the distinction that makes billed totals reconcilable against
+    an ``ap-trail`` export."""
+    summary = RunSummary()
+    install_run_summary(summary)
+    cb = UsageCallback()
+
+    with set_current_task_id("formalize-0"):
+        graphed = uuid4()
+        cb.on_chat_model_start(
+            {}, [], run_id=graphed,
+            metadata={"thread_id": "autoprove_abc-cvl", "langgraph_node": "tools"},
+        )
+        cb.on_llm_end(_result(_ai(100, 5_000, 200)), run_id=graphed)
+
+        bare = uuid4()
+        cb.on_chat_model_start({}, [], run_id=bare, metadata={})
+        cb.on_llm_end(_result(_ai(50, 10, 90_000)), run_id=bare)
+
+    by_origin = cast(list[dict], summary.token_usage_summary()["by_origin"])
+    in_graph = [o for o in by_origin if o["thread_id"] == "autoprove_abc-cvl"]
+    out_of_graph = [o for o in by_origin if o["thread_id"] is None]
+
+    assert len(in_graph) == 1 and in_graph[0]["node"] == "tools"
+    assert in_graph[0]["cache_write"] == 200
+    assert len(out_of_graph) == 1
+    assert out_of_graph[0]["cache_write"] == 90_000
+    # Both are billed to the same task, so by_phase alone cannot tell them apart.
+    assert {o["task_id"] for o in by_origin} == {"formalize-0"}
+
+
+def test_by_origin_sums_to_totals() -> None:
+    """Every billed call lands in exactly one origin bucket — including calls whose
+    start event was never seen, which must not go missing from the accounting."""
+    summary = RunSummary()
+    install_run_summary(summary)
+    cb = UsageCallback()
+
+    started = uuid4()
+    cb.on_chat_model_start({}, [], run_id=started, metadata={"thread_id": "t1"})
+    cb.on_llm_end(_result(_ai(10, 20, 30)), run_id=started)
+    cb.on_llm_end(_result(_ai(7, 1, 2)), run_id=uuid4())        # no matching start
+    cb.on_llm_end(_result(_ai(5, 3, 4)))                        # no run_id at all
+
+    summ = summary.token_usage_summary()
+    totals = cast(dict, summ["totals"])
+    by_origin = cast(list[dict], summ["by_origin"])
+    for bucket in ("input", "output", "cache_read", "cache_write"):
+        assert sum(o[bucket] for o in by_origin) == totals[bucket]
+    assert sum(o["calls"] for o in by_origin) == 3
+
+
+def test_failed_call_releases_its_origin() -> None:
+    """An errored call records nothing, and must not leave its origin behind to be
+    mis-joined onto whichever call reuses the slot."""
+    summary = RunSummary()
+    install_run_summary(summary)
+    cb = UsageCallback()
+
+    run_id = uuid4()
+    cb.on_chat_model_start({}, [], run_id=run_id, metadata={"thread_id": "t1"})
+    cb.on_llm_error(RuntimeError("overloaded"), run_id=run_id)
+    assert summary.token_usage_summary()["by_origin"] == []
+
+    cb.on_llm_end(_result(_ai(1, 2, 3)), run_id=run_id)
+    by_origin = cast(list[dict], summary.token_usage_summary()["by_origin"])
+    assert [o["thread_id"] for o in by_origin] == [None]


### PR DESCRIPTION
## The problem

A run's billed token totals and the message history reachable through `ap-trail`
cannot currently be reconciled, because nothing records *where a call came from*.

On a recent 4h25m dev run (5 components, ~$780), only **$168 of the spend traces
to a recorded LLM call**. The other ~$575 — 91M Opus cache-write tokens, 73% of
the run — is billed to `CVL_GEN` and appears in neither the executor log nor the
run's message history.

This is not a counting error. Per phase, an `ap-trail` export and
`ap_report/job_info.json` agree **to the token**:

| cost_center | billed cache_write | in message history | coverage |
|---|---|---|---|
| `DISCOVER_DESIGN_DOC`, `COMPONENT_ANALYSIS`, `HARNESS`, `BUG_ANALYSIS` | — | — | **100%** |
| `formalization_preparation` | 3,507,156 | 1,545,879 | 44% |
| `formalization` | 96,348,840 | 6,278,951 | **7%** |

`by_phase` sums exactly to `totals`, so nothing is orphaned into a stray task
lane — the calls run inside a real task's scope and are billed to it correctly.
They simply leave no trace of *which code path* made them. `cache_read` is 94%
covered while `cache_write` is 7%, so the missing calls write a large fresh
prefix and read almost nothing: repeated cold starts on a big context.

A second run (9h06m, 2 components, ~$565) shows the same shape — $282 of $565
unattributable, again concentrated in the two formalization cost centers. So it
is not a one-off.

Candidates we currently cannot distinguish:

- `with_structured_output(...).ainvoke(...)` call sites — one-shot calls that
  never enter message state, and at least one sits in the formalization path;
- retried calls — `install_retry_policy` resumes from the last checkpoint, so a
  failed attempt is billed by the provider but never checkpointed.

Already ruled out, so the PR is not chasing these: cache-TTL expiry (4 of 665
Opus calls followed a >300s gap, carrying 1% of writes); server-side context
editing (`context_management: {"applied_edits": []}` on all 625 formalization
calls, i.e. it never fired); and the agentic CEX analyzer in
`composer/prover/agentic_analyzer.py` — its
`run_to_completion(..., within_tool=…)` becomes `ThreadMeta.from_tool_id`, so it
*would* register threads, and there are none.

Rather than keep guessing, make the run say it.

## The change

`UsageCallback` is attached at model construction, so it is the one place that
sees every billed call — which is exactly why `by_phase` sums to `totals`. That
makes it the right place to capture a call's **origin**.

**`composer/diagnostics/timing.py`**

- New `CallOrigin(thread_id, node)` — the LangGraph thread and node a call ran
  under, or `None`/`None` for a call made outside any graph. Absence is the
  signal, so it is recorded as absence rather than back-filled from ambient
  context.
- `RunSummary` gains `token_usage_by_origin` / `calls_by_origin`, keyed by
  `(origin, task_id)`. Deliberately a separate axis from `PhaseRecord`: the
  question it answers ("is this call in a thread the trail recorded?") cuts
  across phases and outlives them.
- `record_token_usage(...)` takes `origin=`.
- `token_usage_summary()` gains **`by_origin`**, sorted heaviest-first, so it
  rides out through `ap_report/job_info.json` next to `by_phase`.
- Bounded at 2000 distinct origins, overflowing into a single
  `(origin-overflow)` bucket, so a pathological run cannot grow the summary
  without bound.

**`composer/diagnostics/usage_callback.py`**

- Metadata reaches the *start* hooks only, so the origin is stashed at
  `on_chat_model_start` / `on_llm_start` and re-joined at `on_llm_end` by
  LangChain's per-call `run_id`. Single-threaded thanks to `run_inline`, so a
  plain dict is safe; capped at 4096 in-flight entries.
- `on_llm_error` releases the stashed origin, so a failed call cannot leave an
  entry behind to be mis-joined onto whichever call reuses the slot.
- A per-call `DEBUG` line (model, task, cost center, thread, node, four token
  buckets) for live triage.

No behaviour change to what is billed or to any existing field: `by_origin` sums
to `totals`, and `totals` / `by_model` / `by_phase` are untouched.

Illustrative output — two calls billed to the same task, one graph-driven and
one not, which `by_phase` cannot tell apart:

```
{'thread_id': None,                 'node': None,    'task_id': 'formalize-0', 'calls': 2, 'cache_write': 90002}
{'thread_id': 'autoprove_abc-cvl',  'node': 'tools', 'task_id': 'formalize-0', 'calls': 1, 'cache_write':   200}
```

## Tests

Three added to `tests/test_token_usage.py` (12 → 15):

- `test_origin_separates_in_graph_from_out_of_graph_calls` — two calls billed to
  the same task land in distinct origin buckets.
- `test_by_origin_sums_to_totals` — including a call whose start event was never
  seen and one with no `run_id` at all; neither may go missing from accounting.
- `test_failed_call_releases_its_origin`.

Full suite: **1293 passed, 10 skipped** on this branch vs **1290 passed, 10
skipped** on `master` — exactly the three new tests. The 27 errors are identical
on both and are environmental (the RAG-DB tests need postgres; one Solana test
needs a real program).

## What this buys

One run answers the question. Tooling that reconciles billed spend against the
trail currently reports only "unattributed cache-write spend: $575" and cannot
say more; with `by_origin` it can name the thread — or state definitively that
the call belonged to no thread, and show which task and node produced it.

## Not in this PR

- Fixing whatever `by_origin` turns out to indict. This only makes it visible.
- Registering additional threads with `thread_logger`. If the spend turns out to
  be out-of-graph structured-output calls, they have no thread to register, and
  `by_origin` is the right permanent home for them regardless.
